### PR TITLE
Incorrect keys passed into $query

### DIFF
--- a/wheels/model/crud.cfm
+++ b/wheels/model/crud.cfm
@@ -973,7 +973,14 @@
 		loc.iEnd = ArrayLen(loc.sql);
 		for (loc.i=1; loc.i <= loc.iEnd; loc.i++)
 			ArrayAppend(loc.sql, loc.sql2[loc.i]);
-		loc.ins = variables.wheels.class.adapter.$query(sql=loc.sql, parameterize=arguments.parameterize, $primaryKey=primaryKeys());
+
+		// map the primary keys down to the SQL columns before calling
+		loc.primaryKeys = ListToArray(primaryKeys());
+		loc.iEnd = ArrayLen(loc.primaryKeys);
+		for(loc.i = 1; loc.i LTE loc.iEnd; loc.i++)
+			loc.primaryKeys[loc.i] = variables.wheels.class.properties[loc.primaryKeys[loc.i]].column;
+
+		loc.ins = variables.wheels.class.adapter.$query(sql=loc.sql, parameterize=arguments.parameterize, $primaryKey=ArrayToList(loc.primaryKeys));
 		loc.generatedKey = variables.wheels.class.adapter.$generatedKey();
 		if (StructKeyExists(loc.ins.result, loc.generatedKey))
 			this[primaryKeys(1)] = loc.ins.result[loc.generatedKey];


### PR DESCRIPTION
See commit log for initial details.

Originally, the return from primaryKeys() was passed down beginning in the $create function of crud.cfm and eventually getting to the adapter-specific $identitySelect() functions. This value represents the model property names, but is being used to compare against the DB column names. For example, in line 156 of MicrosoftSqlServer.cfc:

&lt;cfif NOT ListFindNoCase(loc.columnList, ListFirst(arguments.primaryKey))&gt;

It's complicated, but this bug results in primary key properties that are not auto-increment (i.e. varchar or char columns) being set as empty strings in the model instance that has just had .save() called on it. This is because the above CFIF incorrectly assumes that the primary key was not explicitly set in the INSERT statement, and tries to load it as if it were an auto-increment integer field.

My fix simply maps the return from primaryKeys() down to the correct database columns before passing the value into the $query function.

This may not be the only solution for this bug, but it seems to keep our varchar primary keys from being emptied on INSERT.
