### PR TITLE
Added the cfheader status code message so Search Engines know the site is

### DIFF
--- a/events/onmaintenance.cfm
+++ b/events/onmaintenance.cfm
@@ -1,3 +1,4 @@
+<cfheader statuscode="503" statustext="Service Temporarily Unavailable" >
 <!--- Place HTML here that should be displayed when the application is running in "maintenance" mode. --->
 <h1>Maintenance!</h1>
 <p>


### PR DESCRIPTION
Added the cfheader status code message so Search Engines know the site is in maintenance mode should they try to crawl the site while in maintenance mode.
