### PR TITLE
Fixed bug in $findRoute() that causes blow up on unmatched named route

### DIFF
--- a/wheels/global/internal.cfm
+++ b/wheels/global/internal.cfm
@@ -310,7 +310,7 @@
 			loc.foundRoute = false;
 			while (!loc.foundRoute) // need to use a while loop here so we don't loop through all of the routes
 			{
-				if (application.wheels.showErrorInformation && !ArrayLen(loc.routePos))
+				if (application.wheels.showErrorInformation && !ArrayLen(loc.routeArray))
 					$throw(type="Wheels.RouteMatchNotFound", message="Could not find a match for the `#arguments.route#` route.");
 
 				// we always try to find the route on the first position because we are cleaning the array everytime we don't find a match


### PR DESCRIPTION
The bug is only present when **more than one** route is defined with the same
name, and $findRoute() is called without the variables required for the
route path to be generated.

The proper condition is not triggered to show the Wheels.RouteMatchNotFound error message. Here is the test case for this bug:

Enter these routes in routes.cfm

``` coldfusion
<cfscript>
addRoute(name="testFail", pattern="testFail/[bob1]", controller="test", action="fail");
addRoute(name="testFail", pattern="testFail/[bob2]", controller="test", action="fail");
</cfscript>
```

See that the route identification works fine with the variables present:

``` coldfusion
<cfscript>
$findRoute(route="testFail", bob1=1);
$findRoute(route="testFail", bob2=2);
</cfscript>
```

Make it blow up from a controller, instead of showing a nice error:

``` coldfusion
<cfscript>
$findRoute(route="testFail");
</cfscript>
```

This should cause an error like `The element at position 1 cannot be found.` on the line `loc.returnValue = loc.routeArray[1];`

You should get the same results with linkTo() and urlFor(), since they call $findRoute().
