### PR TITLE
imageTag edit: if height and/or width values are set to false, the attrib

### DIFF
--- a/wheels/view/assets.cfm
+++ b/wheels/view/assets.cfm
@@ -194,6 +194,14 @@
 					arguments.width = loc.image.width;
 				if (!StructKeyExists(arguments, "height") and loc.image.height gt 0)
 					arguments.height = loc.image.height;
+			} else {
+				// remove height and width attributes if false
+				if (arguments.width EQ false) {
+					StructDelete(arguments, "width");
+				}
+				if (arguments.height EQ false) {
+					StructDelete(arguments,"height");
+				}
 			}
 			// only append a query string if the file is local
 			arguments.src = $assetDomain(arguments.src) & $appendQueryString();


### PR DESCRIPTION
imageTag edit: if height and/or width values are set to false, the attribute will be left out of html tag.
