### PR TITLE
Made change to allow models to update primary key values

### DIFF
--- a/wheels/model/crud.cfm
+++ b/wheels/model/crud.cfm
@@ -1082,7 +1082,7 @@
 		for (loc.key in variables.wheels.class.properties)
 		{
 			// include all changed non-key values in the update
-			if (StructKeyExists(this, loc.key) && !ListFindNoCase(primaryKeys(), loc.key) && hasChanged(loc.key))
+			if (StructKeyExists(this, loc.key) && hasChanged(loc.key))
 			{
 				ArrayAppend(loc.sql, "#variables.wheels.class.properties[loc.key].column# = ");
 				loc.param = $buildQueryParamValues(loc.key);


### PR DESCRIPTION
This was a problem in some places where numeric or character IDs needed to be changed, but Wheels was not putting the properties in the SET for the UPDATE to run.

Based on my findings, the hasChanged() call should be a sufficient check to decide whether or not to update any property value. The $addKeyWhereClause() function called from within $update() even considers that primary key values may have been changed. It doesn't make sense to not allow the model to send these changed values to the SQL server if the application required it.

This is reopening pull request #9, which I accidentally closed.
