### PR TITLE
BUGFIX: `wheels.dispatch` component not found in Linux during test run

### DIFF
--- a/wheels/tests/plugins/injection.cfc
+++ b/wheels/tests/plugins/injection.cfc
@@ -15,7 +15,7 @@
 		<cfset loc.m = model("authors").new()>
 		<cfset loc.params = {controller="test", action="index"}>	
 		<cfset loc.c = controller("test", loc.params)>
-		<cfset loc.d = $createObjectFromRoot(path="wheels", fileName="dispatch", method="$init")>
+		<cfset loc.d = $createObjectFromRoot(path="wheels", fileName="Dispatch", method="$init")>
 	</cffunction>
 	
 	<cffunction name="teardown">


### PR DESCRIPTION
The test suite should be looking for `wheels.Dispatch` in case sensitive
environments.
