### PR TITLE
flashMessage() builds the wrong CSS class name on Railo 3.2.3

### DIFF
--- a/wheels/controller/flash.cfm
+++ b/wheels/controller/flash.cfm
@@ -237,7 +237,7 @@
 		for (loc.i=1; loc.i <= loc.iEnd; loc.i++)
 		{
 			loc.item = ListGetAt(loc.flashKeys, loc.i);
-			loc.class = loc.item & "Message";
+			loc.class = lCase( loc.item ) & "Message";
 			if (arguments.lowerCaseDynamicClassValues)
 				loc.class = LCase(loc.class);
 			loc.attributes = {class=loc.class};


### PR DESCRIPTION
Very minor railo bug fix.

flashMessage() builds the wrong CSS class name on Railo 3.2.3 because it uses the structure key + "Message". On ACF9 this returns the proper lower case values "errorMessage" / "infoMessage" / "successMessage" / etc, but on Railo this returns "ERRORMessage", "INFOMessage", "SUCCESSMessage". I stuck in a lCase() and that fixed it.

Sorry I didn't know how to make a branch on github web interface.
