### PR TITLE
Fix titleize view helper function to titleize text strings that are all i

### DIFF
--- a/wheels/view/text.cfm
+++ b/wheels/view/text.cfm
@@ -257,6 +257,7 @@
 	'
 	categories="view-helper,text" functions="autoLink,excerpt,highlight,simpleFormat,truncate">
 	<cfargument name="word" type="string" required="true" hint="The text to turn into a title.">
+	<cfset arguments.word = LCase(arguments.word)>
 	<cfscript>
 		var loc = {};
 		loc.returnValue = "";


### PR DESCRIPTION
If I use the titleize function on a string value that's in all UPPERCASE then the function returns all UPPERCASE.  This change makes the string value passed into this function all lowercase, then performs the loop to capitalize the string correctly.
