### PR TITLE
Add CFFileServlet to the pattern list of the web.config

### DIFF
--- a/web.config
+++ b/web.config
@@ -13,7 +13,7 @@
 				<rule name="ColdFusion on Wheels URL Rewriting" enabled="false">
 					<match url="^(.*)$" ignoreCase="true" />
 					<conditions logicalGrouping="MatchAll">
-						<add input="{SCRIPT_NAME}" negate="true" pattern="^/(flex2gateway|jrunscripts|cfide|cfformgateway|railo-context|files|images|javascripts|miscellaneous|stylesheets|robots.txt|sitemap.xml|rewrite.cfm)($|/.*$)" />
+						<add input="{SCRIPT_NAME}" negate="true" pattern="^/(flex2gateway|jrunscripts|cfide|CFFileServlet|cfformgateway|railo-context|files|images|javascripts|miscellaneous|stylesheets|robots.txt|sitemap.xml|rewrite.cfm)($|/.*$)" />
 					</conditions>
 					<action type="Rewrite" url="/rewrite.cfm/{R:1}" />
 				</rule>


### PR DESCRIPTION
Add CFFileServlet to the pattern list of the web.config file to be able to display an image when using <cfimage action='writeToBrowser'>.
