### PR TITLE
- Changed to use mapping instead of folder name so test suite works from...

### DIFF
--- a/wheels/global/internal.cfm
+++ b/wheels/global/internal.cfm
@@ -10,7 +10,7 @@
 			application.wheels.vendor.stringEscapeUtils = loc.javaLoader.create("org.apache.commons.lang.StringEscapeUtils");
 		}
 	</cfscript>
-	<cfreturn application.wheels.vendor.stringEscapeUtils.escapeHtml(arguments.string) />
+	<cfreturn application.wheels.vendor.stringEscapeUtils.escapeHtml(ToString(arguments.string)) />
 </cffunction>
 
 <cffunction name="$initializeRequestScope" returntype="void" access="public" output="false">

--- a/wheels/tests/_assets/controllers/nested/Test.cfc
+++ b/wheels/tests/_assets/controllers/nested/Test.cfc
@@ -1,2 +1,2 @@
-<cfcomponent extends="wheels.tests._assets.controllers.Controller">
+<cfcomponent extends="wheelsMapping.tests._assets.controllers.Controller">
 </cfcomponent>

--- a/wheels/tests/cache/Add.cfc
+++ b/wheels/tests/cache/Add.cfc
@@ -1,6 +1,6 @@
 <cfcomponent extends="wheelsMapping.Test">
 
-	<cfset cache = CreateObject("component", "wheels.Cache").init(storage="memory", strategy="age")>
+	<cfset cache = CreateObject("component", "wheelsMapping.Cache").init(storage="memory", strategy="age")>
 
 	<cffunction name="setup">
 		<cfset StructDelete(variables, "result")>

--- a/wheels/tests/cache/Clear.cfc
+++ b/wheels/tests/cache/Clear.cfc
@@ -1,6 +1,6 @@
 <cfcomponent extends="wheelsMapping.Test">
 
-	<cfset cache = CreateObject("component", "wheels.Cache").init(storage="memory", strategy="age")>
+	<cfset cache = CreateObject("component", "wheelsMapping.Cache").init(storage="memory", strategy="age")>
 
 	<cffunction name="setup">
 		<cfset StructDelete(variables, "result")>

--- a/wheels/tests/cache/Count.cfc
+++ b/wheels/tests/cache/Count.cfc
@@ -1,6 +1,6 @@
 <cfcomponent extends="wheelsMapping.Test">
 
-	<cfset cache = CreateObject("component", "wheels.Cache").init(storage="memory", strategy="age")>
+	<cfset cache = CreateObject("component", "wheelsMapping.Cache").init(storage="memory", strategy="age")>
 
 	<cffunction name="setup">
 		<cfset cache.clear()>

--- a/wheels/tests/cache/Get.cfc
+++ b/wheels/tests/cache/Get.cfc
@@ -1,6 +1,6 @@
 <cfcomponent extends="wheelsMapping.Test">
 
-	<cfset pkg.cache = CreateObject("component", "wheels.Cache").init(storage="memory", strategy="age")>
+	<cfset pkg.cache = CreateObject("component", "wheelsMapping.Cache").init(storage="memory", strategy="age")>
 
 	<cffunction name="setup">
 		<cfset StructDelete(variables, "result")>

--- a/wheels/tests/cache/Remove.cfc
+++ b/wheels/tests/cache/Remove.cfc
@@ -1,6 +1,6 @@
 <cfcomponent extends="wheelsMapping.Test">
 
-	<cfset cache = CreateObject("component", "wheels.Cache").init(storage="memory", strategy="age")>
+	<cfset cache = CreateObject("component", "wheelsMapping.Cache").init(storage="memory", strategy="age")>
 
 	<cffunction name="setup">
 		<cfset StructDelete(variables, "result")>

--- a/wheels/tests/model/validations/standard_validations.cfc
+++ b/wheels/tests/model/validations/standard_validations.cfc
@@ -320,7 +320,7 @@
 		<cfset assert('!loc.user.valid()')>
 	</cffunction>
 	
-	<cffunction name="test_validatesNumericalityOf_greaterThanOrEqualTo_invalid">
+	<cffunction name="test_validatesNumericalityOf_greaterThanOrEqualTo_invalid_float">
 		<cfset loc.user.birthdaymonth = "11.25">
 		<cfset loc.user.validatesNumericalityOf(property="birthdaymonth", greaterThanOrEqualTo="11.30")>
 		<cfset assert('!loc.user.valid()')>


### PR DESCRIPTION
... sub folder.
- Renamed a test to avoid duplicate function name error thrown.
- Converted string before passing to escapeHTML to get around error in ACF 8.
