### PR TITLE
Singularize double camel-cases already singular strings

### DIFF
--- a/wheels/global/string.cfm
+++ b/wheels/global/string.cfm
@@ -156,6 +156,9 @@
 			// default to returning the same string when nothing can be converted
 			loc.returnValue = arguments.text;
 			
+			// keep track of the success of any rule matches
+			loc.ruleMatched = false;
+			
 			// only pluralize/singularize the last part of a camelCased variable (e.g. in "websiteStatusUpdate" we only change the "update" part)
 			// also set a variable with the unchanged part of the string (to be prepended before returning final result)
 			if (REFind("[A-Z]", arguments.text))
@@ -171,6 +174,9 @@
 			{
 				// this word is the same in both plural and singular so it can just be returned as is
 				loc.returnValue = arguments.text;
+				
+				// note that we successfully matched a rule
+				loc.ruleMatched = true;
 			}
 			else if (ListFindNoCase(loc.irregulars, arguments.text))
 			{
@@ -182,6 +188,9 @@
 					loc.returnValue = ListGetAt(loc.irregulars, loc.pos+1);
 				else
 					loc.returnValue = arguments.text;
+				
+				// note that we successfully matched a rule
+				loc.ruleMatched = true;
 			}
 			else
 			{
@@ -208,6 +217,7 @@
 					if (REFindNoCase(loc.rules[loc.i][1], arguments.text))
 					{
 						loc.returnValue = REReplaceNoCase(arguments.text, loc.rules[loc.i][1], loc.rules[loc.i][2]);
+						loc.ruleMatched = true;
 						break;
 					}
 				}
@@ -217,7 +227,7 @@
 			}
 	
 			// if this is a camel cased string we need to prepend the unchanged part to the result
-			if (StructKeyExists(loc, "prepend"))
+			if (StructKeyExists(loc, "prepend") && loc.ruleMatched)
 				loc.returnValue = loc.prepend & loc.returnValue;
 		}
 		return loc.returnValue;

--- a/wheels/tests/global/strings.cfc
+++ b/wheels/tests/global/strings.cfc
@@ -89,4 +89,9 @@
 		<cfset assert("NOT Compare(loc.result, 'address')")>
 	</cffunction>
 
+	<cffunction name="test_singularize_already_singularized_camel_case">
+		<cfset loc.result = singularize("camelCasedFailure")>
+		<cfset assert("NOT Compare(loc.result, 'camelCasedFailure')")>
+	</cffunction>
+
 </cfcomponent>


### PR DESCRIPTION
For example, `singularize('myFavoriteMatrix')` results in the string
"myFavoriteMyFavoriteMatrix". The reason is that if no rule is matched,
the original string is returned, with its camel cased prefix prepended
again. This fix only prepends the the prefix if a rule was matched.

Just give me a +1 and I'll pull this in.
