### PR TITLE
Made changes to urlFor() to improve formatting of generated URLs

### DIFF
--- a/wheels/global/public.cfm
+++ b/wheels/global/public.cfm
@@ -595,7 +595,8 @@
 		if (arguments.$URLRewriting == "On")
 		{
 			loc.returnValue = Replace(loc.returnValue, application.wheels.rewriteFile, "");
-			loc.returnValue = Replace(loc.returnValue, "//", "/");
+			loc.returnValue = REReplace(loc.returnValue, "/{2,}", "/", "ALL");
+			loc.returnValue = REReplace(loc.returnValue, "(?!^/)/$", "");
 		}
 
 		if (Len(arguments.params))


### PR DESCRIPTION
We had this change in our work code base. It more reliably cleans up generated URLs by replacing any number of consecutive slashes with a single slash. It also strips off the final slash in the URL, while making sure not to destroy the root route "/".
