### PR TITLE
Fixes blank cgi.path_info issue

### DIFF
--- a/wheels/global/internal.cfm
+++ b/wheels/global/internal.cfm
@@ -314,21 +314,19 @@
 		   Bug: https://bugbase.adobe.com/index.cfm?event=bug&id=3209090 
 		*/
 		if (structKeyExists(cgi,"http_x_rewrite_url") && len(cgi.http_x_rewrite_url)) // iis6 1/ IIRF (Ionics Isapi Rewrite Filter)
-			request.path_info = listFirst(cgi.http_x_rewrite_url,'?');
+			loc.returnValue.path_info = listFirst(cgi.http_x_rewrite_url,'?');
 			else if (structKeyExists(cgi,"http_x_original_url") && len(cgi.http_x_original_url)) // iis7 rewrite default
-			request.path_info = listFirst(cgi.http_x_original_url,"?");
+			loc.returnValue.path_info = listFirst(cgi.http_x_original_url,"?");
 			else if (structKeyExists(cgi,"request_uri") && len(cgi.request_uri)) // apache default
-			request.path_info = listFirst(cgi.request_uri,'?');
+			loc.returnValue.path_info = listFirst(cgi.request_uri,'?');
 			else if (structKeyExists(cgi,"redirect_url") && len(cgi.redirect_url)) // apache fallback
-			request.path_info = listFirst(cgi.redirect_url,'?');
+			loc.returnValue.path_info = listFirst(cgi.redirect_url,'?');
 			else // fallback to cgi.path_info
-			request.path_info = cgi.path_info;
+			loc.returnValue.path_info = cgi.path_info;
 			
 			// finally lets remove the index.cfm because some of the custom cgi variables don't bring it back
 			// like this it means at the root we are working with / instead of /index.cfm
-			request.path_info = replace(request.path_info,'index.cfm',''); 
-			request.cgi.path_info = request.path_info;
-			loc.returnValue.path_info = request.cgi.path_info;
+			loc.returnValue.path_info = replace(loc.returnValue.path_info,'index.cfm',''); 	
 	</cfscript>
 	<cfreturn loc.returnValue>
 </cffunction>


### PR DESCRIPTION
Fixes IIS issue that returns a blank cgi.path_info when rewriting is on.
Description/Solution:
http://www.giancarlogomez.com/2012/06/you-are-not-going-crazy-cgipathinfo-is.html
Bug: https://bugbase.adobe.com/index.cfm?event=bug&id=3209090
Group Thread: https://groups.google.com/forum/?fromgroups#!topic/cfwheels/MNHrcPciWZs
