### PR TITLE
Fix misspelled method name

### DIFF
--- a/wheels/Plugins.cfc
+++ b/wheels/Plugins.cfc
@@ -33,7 +33,7 @@
 		<!--- incompatibility --->
 		<cfset $determineIncompatible()>
 		<!--- dependancies --->
-		<cfset $determinDependancy()>
+		<cfset $determineDependancy()>
 
 		<cfreturn this>
 	</cffunction>
@@ -154,7 +154,7 @@
 	</cffunction>
 	
 	
-	<cffunction name="$determinDependancy">
+	<cffunction name="$determineDependancy">
 		<cfset var loc = {}>
 
 		<cfloop collection="#variables.$class.plugins#" item="loc.iPlugins">


### PR DESCRIPTION
Changed method determinDependancy to determineDependancy in wheels/Plugins.cfc - issue #66.
