### PR TITLE
Add geometry and geography datatypes

### DIFF
--- a/wheels/model/adapters/MicrosoftSQLServer.cfc
+++ b/wheels/model/adapters/MicrosoftSQLServer.cfc
@@ -15,7 +15,7 @@
 			switch(arguments.type)
 			{
 				case "bigint": {loc.returnValue = "cf_sql_bigint"; break;}
-				case "binary": case "timestamp": {loc.returnValue = "cf_sql_binary"; break;}
+				case "binary": case "geography": case "geometry": case "timestamp": {loc.returnValue = "cf_sql_binary"; break;}
 				case "bit": {loc.returnValue = "cf_sql_bit"; break;}
 				case "char": case "nchar": case "uniqueidentifier": {loc.returnValue = "cf_sql_char"; break;}
 				case "date": {loc.returnValue = "cf_sql_date"; break;}


### PR DESCRIPTION
Add support for geometry and geography datatypes to MicrosoftSQLServer
adapter (Solution provided by aaron@graphicaldata.com via
googlegroups.com)
