### PR TITLE
Clarified that no extra fields should be in the join table

### DIFF
--- a/wheels/docs/04 Database Interaction Through Models/10 Nested Properties.md
+++ b/wheels/docs/04 Database Interaction Through Models/10 Nested Properties.md
@@ -346,7 +346,7 @@ association.
 The `keys` argument accepts the foreign keys that should be associated together in the `subscriptions` 
 join table. Note that these keys should be listed in the order that they appear in the database table. 
 In this example, the `subscriptions` table in the database contains a composite primary key with columns 
-called `customerid` and `publicationid`, in that order.
+called `customerid` and `publicationid`, in that order and without any other fields in the table.
 
 ## How the Form Submission Works
 


### PR DESCRIPTION
Added a line to clarify that a many-to-many join table should only contain the composite primary key and should not contain any extra fields.
