### PR TITLE
Issue 141. Added setting 'modelRequireInit'

### DIFF
--- a/wheels/docs/02 Working with Wheels/02 Configuration and Defaults.md
+++ b/wheels/docs/02 Working with Wheels/02 Configuration and Defaults.md
@@ -481,6 +481,12 @@ reload URL argument without also providing a password URL argument of somepasswo
 			<td>[empty string]</td>
 			<td>Password to require when reloading the Wheels application from the URL. Leave empty to require no password.</td>
 		</tr>
+		<tr>
+			<td>modelRequireInit</td>
+			<td>boolean</td>
+			<td>false</td>
+			<td>Set to true to require an init function in each of your models.</td>
+		</tr>
 	</tbody>
 </table>
 

--- a/wheels/events/onapplicationstart/settings.cfm
+++ b/wheels/events/onapplicationstart/settings.cfm
@@ -92,6 +92,7 @@
 	application.wheels.automaticValidations = true;
 	application.wheels.setUpdatedAtOnCreate = true;
 	application.wheels.useExpandedColumnAliases = false;
+	application.wheels.modelRequireInit = false;
 	
 	// are we allowed to switch environments through the url?
 	application.wheels.allowedEnvironmentSwitchThroughURL = false;

--- a/wheels/model/initialization.cfm
+++ b/wheels/model/initialization.cfm
@@ -55,6 +55,9 @@
 		{
 			init();
 		}
+		else if (get("modelRequireInit")){
+			$throw(type="Wheels.ModelInitMissing", message="An init function is required for Model: #variables.wheels.class.modelName#", extendedInfo="Create an init function in /models/#variables.wheels.class.modelName#");	
+		}
 		
 		// make sure that the tablename has the respected prefix
 		table(getTableNamePrefix() & tableName());


### PR DESCRIPTION
Set this config setting to true to require an init function in each of
your models. Super helpful for the initial wire-up of your wheels app to
the database.
