### PR TITLE
report node hostname

### DIFF
--- a/wheels/events/onerror/cfmlerror.cfm
+++ b/wheels/events/onerror/cfmlerror.cfm
@@ -34,6 +34,9 @@
 	</cfif>
 	<p><strong>Method:</strong><br />#cgi.request_method#</p>
 	<p><strong>IP Address:</strong><br />#cgi.remote_addr#</p>
+	<cfset inet = CreateObject("java", "java.net.InetAddress")>
+	<cfset inetHostName = inet.getLocalHost().getHostName()>
+	<p><strong>Server hostname:</strong>#inetHostName#</p>
 	<p><strong>User Agent:</strong><br />#cgi.http_user_agent#</p>
 	<p><strong>Date & Time:</strong><br />#DateFormat(now(), "MMMM D, YYYY")# at #TimeFormat(now(), "h:MM TT")#</p>
 	<cfset loc.scopes = "CGI,Form,URL,Application,Session,Request,Cookie,Arguments.Exception">


### PR DESCRIPTION
Hi, here's the change I proposed on the cfwheels Google Group:

Report on the hostname of the server in the cfmlerror page. This is especially useful when running Wheels on a cluster of nodes.

Let me know what you think.

Colin
