### PR TITLE
Pagination links always show no results on the last page.

### DIFF
--- a/wheels/global/public.cfm
+++ b/wheels/global/public.cfm
@@ -158,7 +158,7 @@
 		arguments.totalPages = fix(arguments.totalRecords/arguments.perPage);
 
 		// currentPage shouldn't be less then 1 or greater then the number of pages
-		if (arguments.currentPage gte arguments.totalPages)
+		if (arguments.currentPage gt arguments.totalPages)
 		{
 			arguments.currentPage = arguments.totalPages;
 		}


### PR DESCRIPTION
When you set the pagination links for a query, the number of total pages is always too high by one.  When you click on the last anchor link, you always get no results.

Changing the variable to be set with fix() instead of ceiling() seems to solve the problem.

I am doing this with a non-ORM query, so I'm not sure if that makes any difference, but I don't see why it would.  Using ceiling just makes the totalPages value too high by one, so it should apply no matter how you are getting the data.

If I did this wrong, don't yell at me.  I'm new to the githubs. :)  (But helpful tips are always appreciated.)
