### PR TITLE
repair populate.cfm trying to drop USERS system table on H2 database

### DIFF
--- a/wheels/tests/populate.cfm
+++ b/wheels/tests/populate.cfm
@@ -42,7 +42,10 @@
 
 <!--- get a listing of all the tables and view in the database --->
 <cfdbinfo name="loc.dbinfo" datasource="#application.wheels.dataSourceName#" type="tables">
-<cfset loc.tableList = ValueList(loc.dbinfo.table_name, chr(7))>
+<cfquery dbtype="query" name="loc.wheelstestdbinfo">
+	select * from loc.dbinfo where table_type <> 'SYSTEM TABLE'
+</cfquery>
+<cfset loc.tableList = ValueList(loc.wheelstestdbinfo.table_name, chr(7))>
 
 
 <!--- list of views to delete --->


### PR DESCRIPTION
Fix for #227. I filter the system tables out, so populate.cfm will not try to drop USERS system table. 
