### PR TITLE
Shared app name fix #359

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,11 +12,13 @@ usage:
   - "mvn verify -P jetty,railo,oracle-emu" runs all CFWheels tests on Oracle emulation via embedded H2 database
   - "mvn verify -P jetty,railo,mysql" runs all CFWheels tests on Travis-CI MySQL database
   - "mvn verify -P jetty,railo,postgresal" runs all CFWheels tests on Travis-CI postgreSQL database
-  - "mvn verify -P jetty,railo,plugins" donwload plugins and run all tests with it
+  - "mvn verify -P jetty,railo,plugins" download plugins and run all tests with it
   - "mvn clean verify -P mssql" upload and runs all CFWheels tests on ACF11 and Microsoft SQLServer on VivioTech test server
   - "mvn clean verify -P mssql,acf9oracle" upload and deploy CFWheels on test server and run all tests also on ACF9 Oracle database 
   - "mvn clean verify -P oracle" copy and runs all CFWheels tests on local ColdFusion8 and Oracle (or whatever database configured locally)
   - "mvn clean verify -P jetty,openbd" download OpenBD and run all tests on it (preliminary support)
+  - "mvn verify -DtestParallelStart=true" start with parallel request and then run all tests 
+  - "mvn verify -DtestSharedAppName=true" start with shared application name test and then run all tests 
 
 Benefits of embedded-container-test versus full-integration-test
   #1 clean test data (data is not shared with nor contaminated by other processes)
@@ -43,6 +45,7 @@ Benefits of embedded-container-test versus full-integration-test
 		<testServer>http://localhost:8080</testServer>
 		<testSecondPort></testSecondPort>
 		<deployUrl></deployUrl>
+		<testSharedAppName>false</testSharedAppName>
 		<testSubfolder>false</testSubfolder>
 		<testParallelStart>false</testParallelStart>
 		<!-- settings for Oracle emulation -->
@@ -102,6 +105,7 @@ Benefits of embedded-container-test versus full-integration-test
 						<testSecondPort>${testSecondPort}</testSecondPort>
 						<deployUrl>${deployUrl}</deployUrl>
 						<testOracleEmulation>${testOracleEmulation}</testOracleEmulation>
+						<testSharedAppName>${testSharedAppName}</testSharedAppName>
 						<testSubfolder>${testSubfolder}</testSubfolder>
 						<testParallelStart>${testParallelStart}</testParallelStart>
 					</systemPropertyVariables>

--- a/src/test/java/org/cfwheels/cfwheels/CFWheelsCoreIT.java
+++ b/src/test/java/org/cfwheels/cfwheels/CFWheelsCoreIT.java
@@ -139,6 +139,15 @@ public class CFWheelsCoreIT {
 					"ALTER TABLE #loc.i# MODIFY COLUMN <cfif loc.i IS \"photogalleries\">photogalleryid<cfelseif loc.i IS \"photogalleryphotos\">photogalleryphotoid<cfelse>id</cfif> #loc.identityColumnType# DEFAULT #loc.seq#.nextval");
 			Files.write(Paths.get("wheels/tests/populate.cfm"), content.getBytes());
 		}
+		if ("true".equals(System.getProperty("testSharedAppName"))) {
+			driver.get(baseUrl + "/wheels/tests/_assets/sharedappname/test.cfm");
+			driver.get(baseUrl);
+	        String pageSource = driver.getPageSource();
+	        if (pageSource.contains("Error")) {
+	        	fail("Shared App Name test failed");
+	    		Files.write(Paths.get("target/failsafe-reports/_databaseRecreateERROR.html"), pageSource.getBytes());
+	        }
+		}
 		if ("true".equals(System.getProperty("testParallelStart"))) {
 			hitHomepageWithParallelRequest();
 		}

--- a/wheels/events/onrequeststart.cfm
+++ b/wheels/events/onrequeststart.cfm
@@ -4,6 +4,12 @@
 		// abort if called from incorrect file
 		$abortInvalidRequest();
 
+		//fix for shared application name issue 359
+		if(!StructKeyExists(application, "wheels") || !StructKeyExists(application.wheels, "eventpath"))
+		{
+			$simpleLock(execute="onApplicationStart", name="wheelsReloadLock", type="exclusive", timeout=180);
+		}
+
 		// need to setup the wheels struct up here since it's used to store debugging info below if this is a reload request
 		$initializeRequestScope();
 
@@ -42,7 +48,7 @@
 		{
 			request.cgi = $cgiScope();
 		}
-		
+
 		// reload the plugins on each request if cachePlugins is set to false
 		if (!application.wheels.cachePlugins)
 		{

--- a/wheels/events/onsessionstart.cfm
+++ b/wheels/events/onsessionstart.cfm
@@ -1,5 +1,11 @@
 <cffunction name="onSessionStart" returntype="void" access="public" output="false">
 	<cfscript>
+		//fix for shared application name issue 359
+		if(!StructKeyExists(application, "wheels") || !StructKeyExists(application.wheels, "eventpath"))
+		{
+			$simpleLock(execute="onApplicationStart", name="wheelsReloadLock", type="exclusive", timeout=180);
+		}
+
 		$simpleLock(execute="$runOnSessionStart", name="wheelsReloadLock", type="readOnly", timeout=180);
 	</cfscript>
 </cffunction>

--- a/wheels/tests/_assets/sharedappname/Application.cfc
+++ b/wheels/tests/_assets/sharedappname/Application.cfc
@@ -1,0 +1,7 @@
+<!---
+	You can place ".cfm" files in this folder and run them independently from Wheels.
+	This empty "Application.cfc" file makes sure that Wheels does not interfere with the request.
+--->
+<cfcomponent>
+	<cfset this.name=Hash(GetDirectoryFromPath(Left(GetBaseTemplatePath(),Len(GetBaseTemplatePath())-Len("wheels/tests/_assets/sharedappname/test.cfm"))))>
+</cfcomponent>

--- a/wheels/tests/_assets/sharedappname/test.cfm
+++ b/wheels/tests/_assets/sharedappname/test.cfm
@@ -1,0 +1,2 @@
+Visit this page first after restarting Windows/Linux CF service,
+then click <a href="../../../../index.cfm">here</a> to test shared app name bug.


### PR DESCRIPTION
This fix for #359 is tested on Railo and ACF with included test case.
The test case is not RockeUnit unit test, but can be executed via "mvn verify -DtestSharedAppName=true" or by visiting http://127.0.0.1:8500/wheels/tests/_assets/sharedappname/test.cfm.
