### PR TITLE
Pass through "includeSoftDeletes" in exists()

### DIFF
--- a/wheels/model/miscellaneous.cfm
+++ b/wheels/model/miscellaneous.cfm
@@ -51,6 +51,7 @@
 	<cfargument name="where" type="string" required="false">
 	<cfargument name="reload" type="boolean" required="false">
 	<cfargument name="parameterize" type="any" required="false">
+	<cfargument name="includeSoftDeletes" type="boolean" required="false">
 	<cfscript>
 		var loc = {};
 		$args(name="exists", args=arguments);


### PR DESCRIPTION
Added "includeSoftDeletes" argument to exists(), so it can be used to see if soft deleted records exist. Due to the last change that allows "parameterize" through, this just needed to be added in name only (this could have been functionally done even without the cfargument thanks to the new use of argumentcollection=arguments for the findByKey and findOne function calls).