### PR TITLE
Travis parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,29 @@
 sudo: false #upgrade to faster docker-based CI
-language: java #all CFML engine runs on JVM
+language: java
 
 cache: bundler #works only for private repo http://docs.travis-ci.com/user/caching/
 
 env:
   global: #ftp credential for remote test server, encrypted with repo specific key 
     - secure: "QZdX3M+wYTejkwHLseV/LwhPOCvkbONJcElHjdsrwb4xiuzZSdHiRYmTc+9hzyIOTb1hrylKZ8udMzIuZZTUCa0Ze30sQmcC83vGIteM+uzQr0RV9asf/4hL83cBye50f1OWIJlyq5FLvD0KMkhP+BnTA7jTI5UD8a4FX+F2UUU="
-  matrix: #parallel test combination: Windows+ACF11/SQLServer+ACF10/Oracle, Lucee/H2, Lucee/MySQL, Lucee/PostgreSQL, Lucee/OracleEmulation
+  matrix:
     - PROFILE=mssql,acf10oracle PARAM=onlysecure
     - PROFILE=jetty,lucee,subfolder PARAM=testParallelStart=true
     - PROFILE=jetty,lucee,mysql PARAM=none
     - PROFILE=jetty,lucee,postgresql PARAM=none
     - PROFILE=jetty,lucee,oracle-emu PARAM=none
 
-before_script: #prepare MySQL and PostgresSQL databases
+before_script:
   - mysql -e 'create database test;'
   - psql -c 'create database test;' -U postgres
 
 script: "
- if [ $TRAVIS_SECURE_ENV_VARS == 'true' || $PARAM != 'onlysecure' ];
+ if [ $TRAVIS_SECURE_ENV_VARS == 'true' ] || [ $PARAM != 'onlysecure' ]; 
  then
   mvn verify -P$PROFILE -D$PARAM;
  else
   mvn clean;
- fi" #only run ACF/MSSQL/Oracle test on when secure enviroment parameter exists (e.g.: only in cfwheels/cfwheels commits)
+ fi"
  
 #see pom.xml for the explanation of the mvn commands above
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,21 @@ language: java
 
 cache: bundler #works only for private repo http://docs.travis-ci.com/user/caching/
 
-env: #ftp credential for remote test server, encrypted with repo specific key 
-  - secure: "QZdX3M+wYTejkwHLseV/LwhPOCvkbONJcElHjdsrwb4xiuzZSdHiRYmTc+9hzyIOTb1hrylKZ8udMzIuZZTUCa0Ze30sQmcC83vGIteM+uzQr0RV9asf/4hL83cBye50f1OWIJlyq5FLvD0KMkhP+BnTA7jTI5UD8a4FX+F2UUU="
+env:
+  global: #ftp credential for remote test server, encrypted with repo specific key 
+    - secure: "QZdX3M+wYTejkwHLseV/LwhPOCvkbONJcElHjdsrwb4xiuzZSdHiRYmTc+9hzyIOTb1hrylKZ8udMzIuZZTUCa0Ze30sQmcC83vGIteM+uzQr0RV9asf/4hL83cBye50f1OWIJlyq5FLvD0KMkhP+BnTA7jTI5UD8a4FX+F2UUU="
+  matrix:
+    - PROFILE=mssql,acf10oracle
+    - PROFILE=jetty,lucee,subfolder PARAM=testParallelStart=true
+    - PROFILE=jetty,lucee,mysql
+    - PROFILE=jetty,lucee,postgresql
+    - PROFILE=jetty,lucee,oracle-emu
 
 before_script:
   - mysql -e 'create database test;'
   - psql -c 'create database test;' -U postgres
 
-script: "
-if [ $TRAVIS_SECURE_ENV_VARS == 'true' ];
-then 
-    mvn verify -Pjetty,lucee,subfolder -DtestParallelStart=true && mvn verify -Pjetty,lucee,mysql && mvn verify -Pjetty,lucee,postgresql && mvn verify -Pjetty,lucee,oracle-emu && mvn clean verify -Pmssql,acf10oracle; 
-else 
-    mvn verify -Pjetty,lucee,subfolder -DtestParallelStart=true && mvn verify -Pjetty,lucee,mysql && mvn verify -Pjetty,lucee,postgresql && mvn verify -Pjetty,lucee,oracle-emu;
-fi"
+script: "mvn verify -P$PROFILE -D$PARAM"
 
 #see pom.xml for the explanation of the mvn commands above
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,30 @@
 sudo: false #upgrade to faster docker-based CI
-language: java
+language: java #all CFML engine runs on JVM
 
 cache: bundler #works only for private repo http://docs.travis-ci.com/user/caching/
 
 env:
   global: #ftp credential for remote test server, encrypted with repo specific key 
     - secure: "QZdX3M+wYTejkwHLseV/LwhPOCvkbONJcElHjdsrwb4xiuzZSdHiRYmTc+9hzyIOTb1hrylKZ8udMzIuZZTUCa0Ze30sQmcC83vGIteM+uzQr0RV9asf/4hL83cBye50f1OWIJlyq5FLvD0KMkhP+BnTA7jTI5UD8a4FX+F2UUU="
-  matrix:
-    - PROFILE=mssql,acf10oracle PARAM=none
+  matrix: #parallel test combination: Windows+ACF11/SQLServer+ACF10/Oracle, Lucee/H2, Lucee/MySQL, Lucee/PostgreSQL, Lucee/OracleEmulation
+    - PROFILE=mssql,acf10oracle PARAM=onlysecure
     - PROFILE=jetty,lucee,subfolder PARAM=testParallelStart=true
     - PROFILE=jetty,lucee,mysql PARAM=none
     - PROFILE=jetty,lucee,postgresql PARAM=none
     - PROFILE=jetty,lucee,oracle-emu PARAM=none
 
-before_script:
+before_script: #prepare MySQL and PostgresSQL databases
   - mysql -e 'create database test;'
   - psql -c 'create database test;' -U postgres
 
-script: "mvn verify -P$PROFILE -D$PARAM"
-
+script: "
+ if [ $TRAVIS_SECURE_ENV_VARS == 'true' || $PARAM != 'onlysecure' ];
+ then
+  mvn verify -P$PROFILE -D$PARAM;
+ else
+  mvn clean;
+ fi" #only run ACF/MSSQL/Oracle test on when secure enviroment parameter exists (e.g.: only in cfwheels/cfwheels commits)
+ 
 #see pom.xml for the explanation of the mvn commands above
  
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ env:
   global: #ftp credential for remote test server, encrypted with repo specific key 
     - secure: "QZdX3M+wYTejkwHLseV/LwhPOCvkbONJcElHjdsrwb4xiuzZSdHiRYmTc+9hzyIOTb1hrylKZ8udMzIuZZTUCa0Ze30sQmcC83vGIteM+uzQr0RV9asf/4hL83cBye50f1OWIJlyq5FLvD0KMkhP+BnTA7jTI5UD8a4FX+F2UUU="
   matrix:
-    - PROFILE=mssql,acf10oracle
+    - PROFILE=mssql,acf10oracle PARAM=none
     - PROFILE=jetty,lucee,subfolder PARAM=testParallelStart=true
-    - PROFILE=jetty,lucee,mysql
-    - PROFILE=jetty,lucee,postgresql
-    - PROFILE=jetty,lucee,oracle-emu
+    - PROFILE=jetty,lucee,mysql PARAM=none
+    - PROFILE=jetty,lucee,postgresql PARAM=none
+    - PROFILE=jetty,lucee,oracle-emu PARAM=none
 
 before_script:
   - mysql -e 'create database test;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 sudo: false #upgrade to faster docker-based CI
-language: java
+language: java #all CFML engine runs on JVM
 
 cache: bundler #works only for private repo http://docs.travis-ci.com/user/caching/
 
 env:
   global: #ftp credential for remote test server, encrypted with repo specific key 
     - secure: "QZdX3M+wYTejkwHLseV/LwhPOCvkbONJcElHjdsrwb4xiuzZSdHiRYmTc+9hzyIOTb1hrylKZ8udMzIuZZTUCa0Ze30sQmcC83vGIteM+uzQr0RV9asf/4hL83cBye50f1OWIJlyq5FLvD0KMkhP+BnTA7jTI5UD8a4FX+F2UUU="
-  matrix:
+  matrix: #parallel test combination: Windows+ACF11/SQLServer+ACF10/Oracle, Lucee/H2, Lucee/MySQL, Lucee/PostgreSQL, Lucee/OracleEmulation
     - PROFILE=mssql,acf10oracle PARAM=onlysecure
     - PROFILE=jetty,lucee,subfolder PARAM=testParallelStart=true
     - PROFILE=jetty,lucee,mysql PARAM=none
     - PROFILE=jetty,lucee,postgresql PARAM=none
     - PROFILE=jetty,lucee,oracle-emu PARAM=none
 
-before_script:
+before_script: #prepare MySQL and PostgresSQL databases
   - mysql -e 'create database test;'
   - psql -c 'create database test;' -U postgres
 
@@ -23,7 +23,7 @@ script: "
   mvn verify -P$PROFILE -D$PARAM;
  else
   mvn clean;
- fi"
+ fi" #only run ACF/MSSQL/Oracle test on when secure enviroment parameter exists (e.g.: only in cfwheels/cfwheels commits)
  
 #see pom.xml for the explanation of the mvn commands above
  


### PR DESCRIPTION
Travis tests now run in parallel, cutting the total test time to half (from 5 minutes to 2,5 minutes).
The longest test is the ACF11/MSQL + ACF10/Oracle, because we cannot run them in parallel.
In the future, if we can upload the wheels package on to separate FTP directories, then these tests can run in parallel too.