### PR TITLE
Add support for datetimeoffset date type in MS SQL Server

### DIFF
--- a/wheels/model/adapters/SQLServer.cfc
+++ b/wheels/model/adapters/SQLServer.cfc
@@ -37,7 +37,7 @@
 				case "date":
 					loc.rv = "cf_sql_date";
 					break;
-				case "datetime": case "datetime2": case "smalldatetime":
+				case "datetime": case "datetime2": case "smalldatetime": case "datetimeoffset":
 					loc.rv = "cf_sql_timestamp";
 					break;
 				case "decimal": case "money": case "smallmoney":


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/bb630289.aspx

This is a valid MS SQL data type that is currently not supported