### PR TITLE
Add ability to turn off incompatible plugin warnings from showing

### DIFF
--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -217,6 +217,7 @@
 		application.$wheels.setUpdatedAtOnCreate = true;
 		application.$wheels.useExpandedColumnAliases = false;
 		application.$wheels.modelRequireInit = false;
+		application.$wheels.showIncompatiblePlugins = (application.$wheels.version < 2.0);
 		application.$wheels.booleanAttributes = "allowfullscreen,async,autofocus,autoplay,checked,compact,controls,declare,default,defaultchecked,defaultmuted,defaultselected,defer,disabled,draggable,enabled,formnovalidate,hidden,indeterminate,inert,ismap,itemscope,loop,multiple,muted,nohref,noresize,noshade,novalidate,nowrap,open,pauseonexit,readonly,required,reversed,scoped,seamless,selected,sortable,spellcheck,translate,truespeed,typemustmatch,visible";
 
 		// if session management is enabled in the application we default to storing flash data in the session scope, if not we use a cookie

--- a/wheels/events/onrequestend/debug.cfm
+++ b/wheels/events/onrequestend/debug.cfm
@@ -76,12 +76,12 @@
 
 <div id="wheels-debug-area">
 	<table>
-		<cfif (get("version") LT 2.0 AND Len(application.wheels.incompatiblePlugins)) OR Len(application.wheels.dependantPlugins)>
+		<cfif (get('showIncompatiblePlugins') AND Len(application.wheels.incompatiblePlugins)) OR Len(application.wheels.dependantPlugins)>
 			<tr>
 				<td><strong><span style="color:red;">Warnings:</span></strong></td>
 				<td>
 					<span style="color:red;">
-						<cfif get("version") LT 2.0 AND Len(application.wheels.incompatiblePlugins)>
+						<cfif get('showIncompatiblePlugins') AND Len(application.wheels.incompatiblePlugins)>
 							<cfloop list="#application.wheels.incompatiblePlugins#" index="loc.i">The #loc.i# plugin may be incompatible with this version of Wheels, please look for a compatible version of the plugin<br /></cfloop>
 						</cfif>
 						<cfif Len(application.wheels.dependantPlugins)>


### PR DESCRIPTION
We are recently upgrading an older wheels project, and the incompatible plugins warning can be a little too much. This keeps the existing behavior, but allows for it be turned off as a setting.