### PR TITLE
adds simple argument to properties function

### DIFF
--- a/wheels/model/properties.cfm
+++ b/wheels/model/properties.cfm
@@ -236,7 +236,8 @@
 			if (!IsCustomFunction(this[loc.key]))
 			{
 				// try to get the property name from the list set on the object, this is just to avoid returning everything in ugly upper case which Adobe ColdFusion does by default
-				if (ListFindNoCase(propertyNames(), loc.key)) {
+				if (ListFindNoCase(propertyNames(), loc.key))
+				{
 					loc.key = ListGetAt(propertyNames(), ListFindNoCase(propertyNames(), loc.key));
 				}
 				// if it's a nested property, apply this function recursively

--- a/wheels/model/properties.cfm
+++ b/wheels/model/properties.cfm
@@ -227,39 +227,39 @@
 <cffunction name="properties" returntype="struct" access="public" output="false">
 	<cfargument name="simple" type="boolean" required="false" default="false">
 	<cfscript>
-	var loc = {};
-	loc.rv = {};
-	// loop through all properties and functions in the this scope
-	for (loc.key in this)
-	{
-		// we return anything that is not a function
-		if (!IsCustomFunction(this[loc.key]))
+		var loc = {};
+		loc.rv = {};
+		// loop through all properties and functions in the this scope
+		for (loc.key in this)
 		{
-			// try to get the property name from the list set on the object, this is just to avoid returning everything in ugly upper case which Adobe ColdFusion does by default
-			if (ListFindNoCase(propertyNames(), loc.key)) {
-				loc.key = ListGetAt(propertyNames(), ListFindNoCase(propertyNames(), loc.key));
-			}
-			// if it's a nested property, apply this function recursively
-			if (IsObject(this[loc.key]) && arguments.simple)
+			// we return anything that is not a function
+			if (!IsCustomFunction(this[loc.key]))
 			{
-				loc.rv[loc.key] = this[loc.key].properties(argumentCollection=arguments);
-			}
-			// loop thru the array and apply this function to each item
-			else if (IsArray(this[loc.key]) && arguments.simple)
-			{
-				loc.rv[loc.key] = [];
-				for (loc.i=1; loc.i <= ArrayLen(this[loc.key]); loc.i++)
+				// try to get the property name from the list set on the object, this is just to avoid returning everything in ugly upper case which Adobe ColdFusion does by default
+				if (ListFindNoCase(propertyNames(), loc.key)) {
+					loc.key = ListGetAt(propertyNames(), ListFindNoCase(propertyNames(), loc.key));
+				}
+				// if it's a nested property, apply this function recursively
+				if (IsObject(this[loc.key]) && arguments.simple)
 				{
-					loc.rv[loc.key][loc.i] = this[loc.key][loc.i].properties(argumentCollection=arguments);
+					loc.rv[loc.key] = this[loc.key].properties(argumentCollection=arguments);
+				}
+				// loop thru the array and apply this function to each item
+				else if (IsArray(this[loc.key]) && arguments.simple)
+				{
+					loc.rv[loc.key] = [];
+					for (loc.i=1; loc.i <= ArrayLen(this[loc.key]); loc.i++)
+					{
+						loc.rv[loc.key][loc.i] = this[loc.key][loc.i].properties(argumentCollection=arguments);
+					}
+				}
+				// set property from the this scope in the struct that we will return
+				else
+				{
+					loc.rv[loc.key] = this[loc.key];
 				}
 			}
-			// set property from the this scope in the struct that we will return
-			else
-			{
-				loc.rv[loc.key] = this[loc.key];
-			}
 		}
-	}
 	</cfscript>
 	<cfreturn loc.rv>
 </cffunction>

--- a/wheels/tests/model/miscellaneous/properties.cfc
+++ b/wheels/tests/model/miscellaneous/properties.cfc
@@ -74,4 +74,26 @@
 		<cfset assert('loc.result.lastName eq "b"')>
 	</cffunction>
 
+	<cffunction name="test_getting_nested_objects_with_simple_argument">
+		<cfset loc.adam = {firstName="adam", lastName="chapman"}>
+		<cfset loc.postOne = {views="1000", averageRating=1.0, body="This is the single body", title="this is the single title"}>
+		<cfset loc.postTwo = {views="2000", averageRating=2.0, body="This is the arrays first body", title="this is the arrays first title"}>
+		<cfset loc.postThree = {views="3000", averageRating=3.0, body="This is the arrays second body", title="this is the arrays second title"}>
+
+		<cfset loc.author = model("author").new(loc.adam)>
+		<cfset loc.author.post = model("post").new(loc.postOne)>
+		<cfset loc.author.posts = [model("post").new(loc.postTwo), model("post").new(loc.postThree)]>
+
+		<cfset loc.simpleAuthor = loc.author.properties(simple=true)>
+		<cfset loc.complexAuthor = loc.author.properties()>
+
+		<cfset loc.in = loc.simpleAuthor>
+		<cfset loc.want = loc.adam>
+		<cfset loc.want.post = loc.postOne>
+		<cfset loc.want.posts = [loc.postTwo, loc.postThree]>
+
+		<cfset assert('SerializeJSON(loc.in) eq SerializeJSON(loc.want)')>
+		<cfset assert("IsObject(loc.complexAuthor.post)")>
+	</cffunction>
+
 </cfcomponent>


### PR DESCRIPTION
when used `myobject.properties(simple=true)` will recurse through an object, it's nested properties and return a structure of simple values. It is most useful when using `dump` to visually render an object.