### PR TITLE
added scoped variable

### DIFF
--- a/wheels/model/callbacks.cfm
+++ b/wheels/model/callbacks.cfm
@@ -140,6 +140,7 @@
 <cffunction name="$callbacks" returntype="any" access="public" output="false">
 	<cfargument name="type" type="string" required="false" default="">
 	<cfscript>
+		var loc = {};
 		if (Len(arguments.type))
 		{
 			if (StructKeyExists(variables.wheels.class.callbacks, arguments.type))


### PR DESCRIPTION
fixes error “You have attempted to dereference a scalar variable of
type class java.lang.String as a structure with members.”