### PR TITLE
Updated the oracle adapter to account for the table's owner

### DIFF
--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -119,6 +119,7 @@ public void function onApplicationStart() {
 	{
 		application.$wheels.dataSourceName = LCase(ListLast(GetDirectoryFromPath(GetBaseTemplatePath()), Right(GetDirectoryFromPath(GetBaseTemplatePath()), 1)));
 	}
+	application.$wheels.schemaOwner = "";
 	application.$wheels.dataSourceUserName = "";
 	application.$wheels.dataSourcePassword = "";
 	application.$wheels.transactionMode = "commit";
@@ -451,4 +452,4 @@ public void function onApplicationStart() {
 		$location(url=local.url, addToken=false);
 	}
 }
-</cfscript> 
+</cfscript>

--- a/wheels/model/adapters/Base.cfc
+++ b/wheels/model/adapters/Base.cfc
@@ -4,10 +4,12 @@
 
 		public any function init(
 		  required string dataSource,
+			string schemaOwner,
 		  required string username,
 		  required string password
 		) {
 			variables.dataSource = arguments.dataSource;
+			variables.schemaOwner = arguments.schemaOwner;
 			variables.username = arguments.username;
 			variables.password = arguments.password;
 			return this;
@@ -112,6 +114,7 @@
 		public query function $getColumns(required string tableName) {
 			local.args = {};
 			local.args.dataSource = variables.dataSource;
+			local.args.schemaOwner = variables.schemaOwner;
 			local.args.username = variables.username;
 			local.args.password = variables.password;
 			local.args.table = arguments.tableName;

--- a/wheels/model/adapters/Oracle.cfc
+++ b/wheels/model/adapters/Oracle.cfc
@@ -184,6 +184,7 @@ component extends="Base" output="false" {
 	public query function $getColumnInfo(
 	  required string table,
 	  required string datasource,
+		string schemaOwner,
 	  required string username,
 	  required string password
 	) {
@@ -197,37 +198,44 @@ component extends="Base" output="false" {
 		{
 			StructDelete(local.args, "password");
 		}
+
+		sql="
+			SELECT
+			TC.COLUMN_NAME
+			,TC.DATA_TYPE AS TYPE_NAME
+			,TC.NULLABLE AS IS_NULLABLE
+			,CASE WHEN PKC.COLUMN_NAME IS NULL THEN 0 ELSE 1 END AS IS_PRIMARYKEY
+			,0 AS IS_FOREIGNKEY
+			,'' AS REFERENCED_PRIMARYKEY
+			,'' AS REFERENCED_PRIMARYKEY_TABLE
+			,NVL(TC.DATA_PRECISION, TC.DATA_LENGTH) AS COLUMN_SIZE
+			,TC.DATA_SCALE AS DECIMAL_DIGITS
+			,TC.DATA_DEFAULT AS COLUMN_DEFAULT_VALUE
+			,TC.DATA_LENGTH AS CHAR_OCTET_LENGTH
+			,TC.COLUMN_ID AS ORDINAL_POSITION
+			,'' AS REMARKS
+		FROM
+			ALL_TAB_COLUMNS TC
+			LEFT JOIN ALL_CONSTRAINTS PK
+				ON (PK.CONSTRAINT_TYPE = 'P'
+				AND PK.TABLE_NAME = TC.TABLE_NAME
+				AND TC.OWNER = PK.OWNER)
+			LEFT JOIN ALL_CONS_COLUMNS PKC
+				ON (PK.CONSTRAINT_NAME = PKC.CONSTRAINT_NAME
+				AND TC.COLUMN_NAME = PKC.COLUMN_NAME
+				AND TC.OWNER = PKC.OWNER)
+		WHERE
+			TC.TABLE_NAME = '#UCase(arguments.table)#'";
+
+		/* filter by the current schema owner if defined */
+		if (isdefined("local.args.schemaOwner") and local.args.schemaOwner  neq ""){
+			sql=sql & " AND TC.OWNER = '#UCase(arguments.schemaOwner)#'";
+		}
+
+		sql = sql & " ORDER BY TC.COLUMN_ID";
+
 		local.rv = $query(
-			sql="
-				SELECT
-					TC.COLUMN_NAME
-					,TC.DATA_TYPE AS TYPE_NAME
-					,TC.NULLABLE AS IS_NULLABLE
-					,CASE WHEN PKC.COLUMN_NAME IS NULL THEN 0 ELSE 1 END AS IS_PRIMARYKEY
-					,0 AS IS_FOREIGNKEY
-					,'' AS REFERENCED_PRIMARYKEY
-					,'' AS REFERENCED_PRIMARYKEY_TABLE
-					,NVL(TC.DATA_PRECISION, TC.DATA_LENGTH) AS COLUMN_SIZE
-					,TC.DATA_SCALE AS DECIMAL_DIGITS
-					,TC.DATA_DEFAULT AS COLUMN_DEFAULT_VALUE
-					,TC.DATA_LENGTH AS CHAR_OCTET_LENGTH
-					,TC.COLUMN_ID AS ORDINAL_POSITION
-					,'' AS REMARKS
-				FROM
-					ALL_TAB_COLUMNS TC
-					LEFT JOIN ALL_CONSTRAINTS PK
-						ON (PK.CONSTRAINT_TYPE = 'P'
-						AND PK.TABLE_NAME = TC.TABLE_NAME
-						AND TC.OWNER = PK.OWNER)
-					LEFT JOIN ALL_CONS_COLUMNS PKC
-						ON (PK.CONSTRAINT_NAME = PKC.CONSTRAINT_NAME
-						AND TC.COLUMN_NAME = PKC.COLUMN_NAME
-						AND TC.OWNER = PKC.OWNER)
-				WHERE
-					TC.TABLE_NAME = '#UCase(arguments.table)#'
-				ORDER BY
-					TC.COLUMN_ID
-			",
+			sql=sql,
 			argumentCollection=local.args
 		);
 		/*

--- a/wheels/model/initialization.cfm
+++ b/wheels/model/initialization.cfm
@@ -30,6 +30,7 @@
 		variables.wheels.class.callbacks = {};
 		variables.wheels.class.keys = "";
 		variables.wheels.class.dataSource = application.wheels.dataSourceName;
+		variables.wheels.class.schemaOwner = application.wheels.schemaOwner;
 		variables.wheels.class.username = application.wheels.dataSourceUserName;
 		variables.wheels.class.password = application.wheels.dataSourcePassword;
 		variables.wheels.class.automaticValidations = application.wheels.automaticValidations;
@@ -263,7 +264,7 @@
 		{
 			$throw(type="Wheels.DatabaseNotSupported", message="#loc.info.database_productname# is not supported by CFWheels.", extendedInfo="Use SQL Server, MySQL, MariaDB, Oracle, PostgreSQL or H2.");
 		}
-		loc.rv = CreateObject("component", "adapters.#loc.adapterName#").init(dataSource=variables.wheels.class.dataSource, username=variables.wheels.class.username, password=variables.wheels.class.password);
+		loc.rv = CreateObject("component", "adapters.#loc.adapterName#").init(dataSource=variables.wheels.class.dataSource, schemaOwner=variables.wheels.class.schemaOwner, username=variables.wheels.class.username, password=variables.wheels.class.password);
 		application.wheels.adapterName = loc.adapterName;
 	</cfscript>
 	<cfreturn loc.rv>


### PR DESCRIPTION
Previously the same table name could be pulled from multiple schema's in oracle and you wouldn't know which table you are getting.

I added a new application variable called schemaOwner.  I tried to find all the places dataSource was setup and just follow that path.  I didn't make schemaOwner mandatory either.  Figure if it's working for them don't make someone explicitly set it.  But if you do set it under config/settings.cfm it will carry through and filter by it in the oracle.cfc file.

Not sure if I missed anything obvious, or messed up other db adapter, but this update was working for me in Oracle.
