### PR TITLE
Change structKey check to match len check on resources "except"

### DIFF
--- a/wheels/mapper/resources.cfm
+++ b/wheels/mapper/resources.cfm
@@ -96,7 +96,7 @@
       local.args.actions = LCase(arguments.only);
 
     // remove unwanted routes from local.args.only
-    if (structKeyExists(arguments, "only") && ListLen(arguments.except) > 0) {
+    if (structKeyExists(arguments, "except") && ListLen(arguments.except) > 0) {
       local.except = ListToArray(arguments.except);
       local.iEnd = ArrayLen(local.except);
       for (local.i=1; local.i LTE local.iEnd; local.i++)


### PR DESCRIPTION
I was testing/learning the new way of routing and when I went to use "only" restriction in the resources() route, I came across an non existent key error.  The error will not occur when using except, just "only" on resources.