### PR TITLE
Adding support for JSON type in Mysql and also seperating the long types so that length validation isn't an issue

### DIFF
--- a/wheels/model/adapters/Base.cfc
+++ b/wheels/model/adapters/Base.cfc
@@ -215,6 +215,8 @@ component output=false {
 				return "array";
 			case "CF_SQL_STRUCT":
 				return "struct";
+			case "CF_SQL_LONGVARCHAR": case "CF_SQL_LONGNVARCHAR":
+                return "text";
 			default:
 				return "string";
 		}

--- a/wheels/model/adapters/MySQL.cfc
+++ b/wheels/model/adapters/MySQL.cfc
@@ -54,7 +54,7 @@ component extends="Base" output=false {
 				local.rv = "cf_sql_varchar";
 				break;
 			case "json": case "text": case "mediumtext": case "longtext": case "tinytext": 
-                loc.rv = "cf_sql_longvarchar";
+                local.rv = "cf_sql_longvarchar";
                 break;
 		}
 		return local.rv;

--- a/wheels/model/adapters/MySQL.cfc
+++ b/wheels/model/adapters/MySQL.cfc
@@ -50,9 +50,12 @@ component extends="Base" output=false {
 			case "varbinary":
 				local.rv = "cf_sql_varbinary";
 				break;
-			case "varchar": case "text": case "mediumtext": case "longtext": case "tinytext": case "enum": case "set":
+			case "varchar": case "enum": case "set":
 				local.rv = "cf_sql_varchar";
 				break;
+			case "json": case "text": case "mediumtext": case "longtext": case "tinytext": 
+                loc.rv = "cf_sql_longvarchar";
+                break;
 		}
 		return local.rv;
 	}


### PR DESCRIPTION
Add JSON mysql type and also set the rv for text to cf_sql_longvarchar
Add the cf_SQL_LONGVARCHAR and CF_SQL_LONGNVARCHAR to return "text" rather than string