### PR TITLE
Modify JSON content-type search to exclude charset if present

### DIFF
--- a/wheels/dispatch/functions.cfm
+++ b/wheels/dispatch/functions.cfm
@@ -202,7 +202,8 @@ public struct function $parseJsonBody(required struct params) {
 	local.headers = request.wheels.httpRequestData.headers;
 	local.content = request.wheels.httpRequestData.content;
 	if (StructKeyExists(local.headers, "Content-Type")) {
-		local.type = local.headers["Content-Type"];
+		// Content-Type may also include charset so we need only check the first item in the list
+		local.type = spanExcluding(local.headers["Content-Type"],";");
 
 		// Only proceed if the content type is JSON.
 		// Allow multiple JSON content types by checking the start and end of the string.


### PR DESCRIPTION
The premise behind this change is that we've created an API for exclusive use with a mobile app that runs Vue.js . The "Put" requests from this (and apparently from Laravel as well for our PHP friends) add more information to "Content-Type" than just application/json. In our case, this is the content-type provided with each "Put" request:

application/json; charset=UTF-8

And that's a valid Content-Type. The charset is especially important for any country that doesn't use UTF-8. 

Anyhow, because the original wheels/dispatch/function/$parseJsonBody test uses **right** and **left** functions to test for the presence of JSON content, that presupposes only the 1 option being listed. 

We're assuming that the type always comes first and the charset follows second.  In the event there is no second option, SpanExcluding will still return the full option.