### PR TITLE
Workaround for #623: Inject CORS headers, stop request on OPTIONS

### DIFF
--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -185,7 +185,10 @@ public void function onApplicationStart() {
 	application.$wheels.csrfCookiePath = "/";
 	application.$wheels.csrfCookiePreserveCase = "";
 	application.$wheels.csrfCookieSecure = "";
-
+	
+	// CORS (Cross-Origin Resource Sharing) settings.
+	application.$wheels.allowCorsRequests = false;
+	
 	// Debugging and error settings.
 	application.$wheels.showDebugInformation = true;
 	application.$wheels.showErrorInformation = true;

--- a/wheels/events/onrequeststart.cfm
+++ b/wheels/events/onrequeststart.cfm
@@ -104,16 +104,18 @@ public void function $runOnRequestStart(required targetPage) {
 	}
 
 	// For CORS compliance, we must set these 3 headers in every request 
-	cfheader(name="Access-Control-Allow-Origin", value="*");
-	cfheader(name="Access-Control-Allow-Methods", value="GET, POST, PATCH, PUT, DELETE, OPTIONS");
-	cfheader(name="Access-Control-Allow-Headers", value="Origin, Content-Type, X-Auth-Token, X-Requested-By, X-Requested-With");
+	if($get("allowCorsRequests")){
 
-	// Also for CORS compliance, an OPTIONS request must return 200 and the above headers. No data is required.
-	// This will be remove when OPTIONS is implemented in the mapper (issue #623)
-	if(structKeyExists(request,"CGI") && structKeyExists(request.CGI,"request_method") && request.CGI.request_method eq "OPTIONS" ){
-		abort;
+		$header(name="Access-Control-Allow-Origin", value="*");
+		$header(name="Access-Control-Allow-Methods", value="GET, POST, PATCH, PUT, DELETE, OPTIONS");
+		$header(name="Access-Control-Allow-Headers", value="Origin, Content-Type, X-Auth-Token, X-Requested-By, X-Requested-With");
+
+		// Also for CORS compliance, an OPTIONS request must return 200 and the above headers. No data is required.
+		// This will be remove when OPTIONS is implemented in the mapper (issue #623)
+		if(structKeyExists(request,"CGI") && structKeyExists(request.CGI,"request_method") && request.CGI.request_method eq "OPTIONS" ){
+			abort;
+		}
 	}
-
 }
 
 </cfscript>

--- a/wheels/events/onrequeststart.cfm
+++ b/wheels/events/onrequeststart.cfm
@@ -102,6 +102,18 @@ public void function $runOnRequestStart(required targetPage) {
 	if (application.wheels.showDebugInformation) {
 		$debugPoint("requestStart");
 	}
+
+	// For CORS compliance, we must set these 3 headers in every request 
+	cfheader(name="Access-Control-Allow-Origin", value="*");
+	cfheader(name="Access-Control-Allow-Methods", value="GET, POST, PATCH, PUT, DELETE, OPTIONS");
+	cfheader(name="Access-Control-Allow-Headers", value="Origin, Content-Type, X-Auth-Token, X-Requested-By, X-Requested-With");
+
+	// Also for CORS compliance, an OPTIONS request must return 200 and the above headers. No data is required.
+	// This will be remove when OPTIONS is implemented in the mapper (issue #623)
+	if(structKeyExists(request,"CGI") && structKeyExists(request.CGI,"request_method") && request.CGI.request_method eq "OPTIONS" ){
+		abort;
+	}
+
 }
 
 </cfscript>


### PR DESCRIPTION
As a temporary workaround for [#623](https://github.com/cfwheels/cfwheels/issues/623), we're setting the Allow-Method headers on every request header to comply with CORS.

Until we add the OPTIONS method into the mapper properly, we need to check for it and abort the request before wheels has a chance to process it.  This will effectively return a 200 and the appropriate headers in order to comply with CORS.

WARNING - This will enable CORS requests for everyone even if the developer doesn't want to allow these requests.