### PR TITLE
#623: Add allowCorsRequests & CORS headers, abort processing on OPTIONS

### DIFF
--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -186,6 +186,9 @@ public void function onApplicationStart() {
 	application.$wheels.csrfCookiePreserveCase = "";
 	application.$wheels.csrfCookieSecure = "";
 
+	// CORS (Cross-Origin Resource Sharing) settings.
+	application.$wheels.allowCorsRequests = false;
+	
 	// Debugging and error settings.
 	application.$wheels.showDebugInformation = true;
 	application.$wheels.showErrorInformation = true;

--- a/wheels/events/onrequeststart.cfm
+++ b/wheels/events/onrequeststart.cfm
@@ -102,6 +102,20 @@ public void function $runOnRequestStart(required targetPage) {
 	if (application.wheels.showDebugInformation) {
 		$debugPoint("requestStart");
 	}
+
+	// For CORS compliance, we must set these 3 headers in every request 
+	if($get("allowCorsRequests")){
+
+		$header(name="Access-Control-Allow-Origin", value="*");
+		$header(name="Access-Control-Allow-Methods", value="GET, POST, PATCH, PUT, DELETE, OPTIONS");
+		$header(name="Access-Control-Allow-Headers", value="Origin, Content-Type, X-Auth-Token, X-Requested-By, X-Requested-With");
+
+		// Also for CORS compliance, an OPTIONS request must return 200 and the above headers. No data is required.
+		// This will be remove when OPTIONS is implemented in the mapper (issue #623)
+		if(structKeyExists(request,"CGI") && structKeyExists(request.CGI,"request_method") && request.CGI.request_method eq "OPTIONS" ){
+			abort;
+		}
+	}
 }
 
 </cfscript>


### PR DESCRIPTION
I deleted the other pull request because once again Git decided to rewrite the whole file on my second commit.

I've added the global flag as requested.

@neokoenig , I've also suggested an update to the 2.0 docs (Configuration and Defaults) so the user is aware of this change.  By default, I've opted to turn this feature off to maintain a secure framework.