### PR TITLE
Enable more attributes for stylesheets

### DIFF
--- a/wheels/controller/filters.cfm
+++ b/wheels/controller/filters.cfm
@@ -126,7 +126,7 @@ public void function $runFilters(required string type, required string action) {
 			local.result = $invoke(method=local.filter.through, invokeArgs=local.filter.arguments);
 
 			// If the filter returned false, rendered content or made a delayed redirect we skip the remaining filters.
-			if ((StructKeyExists(local, "result") && !local.result) || $performedRenderOrRedirect()) {
+			if ((StructKeyExists(local, "result") && !isNull(local.result) && !local.result) || $performedRenderOrRedirect()) {
 				break;
 			}
 

--- a/wheels/model/adapters/cfquery.cfm
+++ b/wheels/model/adapters/cfquery.cfm
@@ -27,7 +27,7 @@
 			queryAttributes=arguments.queryAttributes,
 			result=local.$wheels.result
 		);
-		if (StructKeyExists(local.$wheels, "id")) {
+		if (StructKeyExists(local.$wheels, "id") && Len(local.$wheels.id)) {
 			StructAppend(local.$wheels.result, local.$wheels.id);
 		}
 

--- a/wheels/public/docs/reference/controller/stylesheetlinktag.txt
+++ b/wheels/public/docs/reference/controller/stylesheetlinktag.txt
@@ -5,12 +5,12 @@
     <!--- Includes `stylesheets/blog.css` and `stylesheets/comments.css` --->
     #styleSheetLinkTag("blog,comments")#
     <!--- Includes printer style sheet --->
-    #styleSheetLinkTag(source="print", media="print")#
+    #styleSheetLinkTag(sources="print", media="print")#
     <!--- Includes external style sheet --->
     #styleSheetLinkTag("http://ajax.googleapis.com/ajax/libs/jqueryui/1.7.0/themes/cupertino/jquery-ui.css")#
 </head>
 
 <body>
     <!--- This will still appear in the `head` --->
-    #styleSheetLinkTag(source="tabs", head=true)#
+    #styleSheetLinkTag(sources="tabs", head=true)#
 </body>

--- a/wheels/view/assets.cfm
+++ b/wheels/view/assets.cfm
@@ -9,6 +9,7 @@
  * @sources The name of one or many CSS files in the stylesheets folder, minus the `.css` extension. Pass a full URL to generate a tag for an external style sheet. Can also be called with the `source` argument.
  * @type The `type` attribute for the `link` tag.
  * @media The `media` attribute for the `link` tag.
+ * @rel  The `rel` attribute for the relation between the tag and href.
  * @head Set to `true` to place the output in the `head` area of the HTML page instead of the default behavior (which is to place the output where the function is called from).
  * @delim The delimiter to use for the list of CSS files.
  * @encode When set to `true`, encodes tag content, attribute values, and URLs so that Cross Site Scripting (XSS) attacks can be prevented. Set to `attributes` to only encode attribute values and not tag content.
@@ -17,18 +18,22 @@ public string function styleSheetLinkTag(
 	string sources="",
 	string type,
 	string media,
+	string rel,
 	boolean head,
 	string delim=",",
 	boolean encode
 ) {
-	$args(name="styleSheetLinkTag", args=arguments, combine="sources/source/!", reserved="href,rel");
+	$args(name="styleSheetLinkTag", args=arguments, combine="sources/source/!", reserved="href");
 	if (!Len(arguments.type)) {
 		StructDelete(arguments, "type");
 	}
 	if (!Len(arguments.media)) {
 		StructDelete(arguments, "media");
 	}
-	arguments.rel = "stylesheet";
+	if (!structKeyExists(arguments, "rel") || !Len(arguments.rel)) {
+		arguments.rel = "stylesheet";
+	}
+
 	local.rv = "";
 	arguments.sources = $listClean(list=arguments.sources, returnAs="array", delim=arguments.delim);
 	local.iEnd = ArrayLen(arguments.sources);


### PR DESCRIPTION
Enable the rel attribute for stylesheets.
Update the documentation as sources is the main attribute and source looks deprecated.
As I see, I can use data_theme and it will be modified to data-theme, but I need to overwrite the rel-attribute, too.