### PR TITLE
Allow lowercase desc to order a query. The output is still uppercase,…

### DIFF
--- a/wheels/model/sql.cfm
+++ b/wheels/model/sql.cfm
@@ -87,7 +87,7 @@ public string function $orderByClause(required string order, required string inc
 			local.iEnd = ListLen(arguments.order);
 			for (local.i = 1; local.i <= local.iEnd; local.i++) {
 				local.iItem = Trim(ListGetAt(arguments.order, local.i));
-				if (!Find(" ASC", local.iItem) && !Find(" DESC", local.iItem)) {
+				if (!FindNoCase(" ASC", local.iItem) && !FindNoCase(" DESC", local.iItem)) {
 					local.iItem &= " ASC";
 				}
 				if (Find(".", local.iItem)) {


### PR DESCRIPTION
… so the resulting SQL statement is still the same.

Testcase:

```
        var qKunde1 = model("kunde").findAll(
            select="kunde.knd_id,kunde.ort,kunde.extern_id",
            order="ort desc",
            returnAs="query",
            returnIncluded=false
        );

        var qKunde2 = model("kunde").findAll(
            select="kunde.knd_id,kunde.ort,kunde.extern_id",
            order="ort DESC",
            returnAs="query",
            returnIncluded=false
        );

       writeDump(var=qKunde1);
       writeDump(var=qKunde2,abort=true);

```

The first query resulted in "ORDER BY ort ASC" and the second to "ORDER BY ort DESC". After the patch, both queries "ORDER BY ort DESC". The SQL-Statement doesn't change, it is just the find of any order clause. 

It is not very intuitive, if you write order="ort desc" and it is not sorted properly.