### PR TITLE
Migrator Default Timestamps

### DIFF
--- a/wheels/global/internal.cfm
+++ b/wheels/global/internal.cfm
@@ -230,6 +230,26 @@ public any function $timeSpanForCache(
 /**
  * Internal function.
  */
+public string function $timestamp(string timeStampMode=application.wheels.timeStampMode) {
+	switch (arguments.timeStampMode) {
+		case "utc":
+			local.rv = DateConvert("local2Utc", Now());
+			break;
+		case "local":
+			local.rv = Now();
+			break;
+		case "epoch":
+			local.rv = Now().getTime();
+			break;
+		default:
+			Throw(type="Wheels.InvalidTimeStampMode", message="Timestamp mode #arguments.timeStampMode# is invalid");
+	}
+	return local.rv;
+}
+
+/**
+ * Internal function.
+ */
 public void function $combineArguments(
 	required struct args,
 	required string combine,

--- a/wheels/migrator/Migration.cfc
+++ b/wheels/migrator/Migration.cfc
@@ -227,6 +227,14 @@ component extends="Base" {
 	public void function addRecord(required string table) {
 		local.columnNames = "";
 		local.columnValues = "";
+		if(!StructKeyExists(arguments, application.wheels.timeStampOnCreateProperty) && ListFindNoCase($getColumns(arguments.table), application.wheels.timeStampOnCreateProperty)) {
+			arguments[application.wheels.timeStampOnCreateProperty] = $timestamp();
+		}
+		if(application.wheels.setUpdatedAtOnCreate && !StructKeyExists(arguments, application.wheels.timeStampOnUpdateProperty) && ListFindNoCase($getColumns(arguments.table), application.wheels.timeStampOnUpdateProperty)) {
+			announce(application.wheels.setUpdatedAtOnCreate);
+			arguments[application.wheels.timeStampOnUpdateProperty] = $timestamp();
+		}
+
 		for (local.key in arguments) {
 			if(local.key neq "table") {
 				local.columnNames = ListAppend(local.columnNames,this.adapter.quoteColumnName(local.key));
@@ -258,6 +266,9 @@ component extends="Base" {
     */
 	public void function updateRecord(required string table, string where="") {
 		local.columnUpdates = "";
+		if (!StructKeyExists(arguments, application.wheels.timeStampOnUpdateProperty) && ListFindNoCase($getColumns(arguments.table), application.wheels.timeStampOnUpdateProperty)) {
+			arguments[application.wheels.timeStampOnUpdateProperty] = $timestamp();
+		}
 		for (local.key in arguments) {
 			if(local.key neq "table" && local.key neq "where") {
 				local.update = "#this.adapter.quoteColumnName(local.key)# = ";

--- a/wheels/migrator/TableDefinition.cfc
+++ b/wheels/migrator/TableDefinition.cfc
@@ -321,7 +321,12 @@ component extends="Base" {
     * adds CFWheels convention automatic timestamp and soft delete columns to table definition
     */
 	public any function timestamps() {
-		timestamp(columnNames="createdat,updatedat,deletedat",null=true);
+		local.columnNames = ArrayToList([
+			application.wheels.timeStampOnCreateProperty,
+			application.wheels.timeStampOnUpdateProperty,
+			application.wheels.softDeleteProperty
+		]);
+		timestamp(columnNames=local.columnNames,null=true);
 		return this;
 	}
 

--- a/wheels/model/miscellaneous.cfm
+++ b/wheels/model/miscellaneous.cfm
@@ -274,15 +274,7 @@ public void function $keyLengthCheck(required any key) {
  * Internal function.
  */
 public void function $timestampProperty(required string property) {
-	if (variables.wheels.class.timeStampMode eq "utc") {
-		this[arguments.property] = DateConvert("local2Utc", Now());
-	} else if (variables.wheels.class.timeStampMode eq "local") {
-		this[arguments.property] = Now();
-	} else if (variables.wheels.class.timeStampMode eq "epoch") {
-		this[arguments.property] = Now().getTime();
-	} else {
-		Throw(type="Wheels.InvalidTimeStampMode", message="Timestamp mode #variables.wheels.class.timeStampMode# is invalid");
-	}
+	this[arguments.property] = $timestamp(variables.wheels.class.timeStampMode);
 }
 
 </cfscript>


### PR DESCRIPTION
* Migrator now automatically manages the timestamp columns on addRecord() and updateRecord() calls.
* Migrator correctly honors CFWheels Timestamp configuration settings (setUpdatedAtOnCreate, softDeleteProperty, timeStampMode, timeStampOnCreateProperty, timeStampOnUpdateProperty) .