### PR TITLE
Add basic redirects in mapper for GET/PUT/PATCH/POST/DELETE

### DIFF
--- a/wheels/dispatch/functions.cfm
+++ b/wheels/dispatch/functions.cfm
@@ -105,6 +105,11 @@ public struct function $findMatchingRoute(required string path, string requestMe
 
 	}
 
+	// If returned route contains a redirect, execute that asap
+	if(structKeyExists(local, "rv") && structKeyExists(local.rv, "redirect")){
+		$location(url=local.rv.redirect, addToken=false);
+	}
+
 	// Throw error if no route was found.
 	if (!StructKeyExists(local, "rv")) {
 

--- a/wheels/mapper/matching.cfm
+++ b/wheels/mapper/matching.cfm
@@ -13,6 +13,7 @@
  * @action Map the route to a given action within the `controller`. This must be passed along with the `controller` argument.
  * @package Indicates a subfolder that the controller will be referenced from (but not added to the URL pattern). For example, if you set this to `admin`, the controller will be located at `admin/YourController.cfc`, but the URL path will not contain `admin/`.
  * @on If this route is within a nested resource, you can set this argument to `member` or `collection`. A `member` route contains a reference to the resource's `key`, while a `collection` route does not.
+ * @redirect Redirect via 302 to this URL when this route is matched. Has precedence over controller/action. Use either an absolute link like `/about/`, or a full canonical link.
  */
 public struct function get(
 	string name,
@@ -21,7 +22,8 @@ public struct function get(
 	string controller,
 	string action,
 	string package,
-	string on
+	string on,
+	string redirect
 ) {
 	return $match(argumentCollection=arguments, method="get");
 }
@@ -39,6 +41,7 @@ public struct function get(
  * @action Map the route to a given action within the `controller`. This must be passed along with the `controller` argument.
  * @package Indicates a subfolder that the controller will be referenced from (but not added to the URL pattern). For example, if you set this to `admin`, the controller will be located at `admin/YourController.cfc`, but the URL path will not contain `admin/`.
  * @on If this route is within a nested resource, you can set this argument to `member` or `collection`. A `member` route contains a reference to the resource's `key`, while a `collection` route does not.
+ * @redirect Redirect via 302 to this URL when this route is matched. Has precedence over controller/action. Use either an absolute link like `/about/`, or a full canonical link.
  */
 public struct function post(
 	string name,
@@ -47,7 +50,8 @@ public struct function post(
 	string controller,
 	string action,
 	string package,
-	string on
+	string on,
+	string redirect
 ) {
 	return $match(argumentCollection=arguments, method="post");
 }
@@ -65,6 +69,7 @@ public struct function post(
  * @action Map the route to a given action within the `controller`. This must be passed along with the `controller` argument.
  * @package Indicates a subfolder that the controller will be referenced from (but not added to the URL pattern). For example, if you set this to `admin`, the controller will be located at `admin/YourController.cfc`, but the URL path will not contain `admin/`.
  * @on If this route is within a nested resource, you can set this argument to `member` or `collection`. A `member` route contains a reference to the resource's `key`, while a `collection` route does not.
+ * @redirect Redirect via 302 to this URL when this route is matched. Has precedence over controller/action. Use either an absolute link like `/about/`, or a full canonical link.
  */
 public struct function patch(
 	string name,
@@ -73,7 +78,8 @@ public struct function patch(
 	string controller,
 	string action,
 	string package,
-	string on
+	string on,
+	string redirect
 ) {
 	return $match(argumentCollection=arguments, method="patch");
 }
@@ -91,6 +97,7 @@ public struct function patch(
  * @action Map the route to a given action within the `controller`. This must be passed along with the `controller` argument.
  * @package Indicates a subfolder that the controller will be referenced from (but not added to the URL pattern). For example, if you set this to `admin`, the controller will be located at `admin/YourController.cfc`, but the URL path will not contain `admin/`.
  * @on If this route is within a nested resource, you can set this argument to `member` or `collection`. A `member` route contains a reference to the resource's `key`, while a `collection` route does not.
+ * @redirect Redirect via 302 to this URL when this route is matched. Has precedence over controller/action. Use either an absolute link like `/about/`, or a full canonical link.
  */
 public struct function put(
 	string name,
@@ -99,7 +106,8 @@ public struct function put(
 	string controller,
 	string action,
 	string package,
-	string on
+	string on,
+	string redirect
 ) {
 	return $match(argumentCollection=arguments, method="put");
 }
@@ -117,6 +125,7 @@ public struct function put(
  * @action Map the route to a given action within the `controller`. This must be passed along with the `controller` argument.
  * @package Indicates a subfolder that the controller will be referenced from (but not added to the URL pattern). For example, if you set this to `admin`, the controller will be located at `admin/YourController.cfc`, but the URL path will not contain `admin/`.
  * @on If this route is within a nested resource, you can set this argument to `member` or `collection`. A `member` route contains a reference to the resource's `key`, while a `collection` route does not.
+ * @redirect Redirect via 302 to this URL when this route is matched. Has precedence over controller/action. Use either an absolute link like `/about/`, or a full canonical link.
  */
 public struct function delete(
 	string name,
@@ -125,7 +134,8 @@ public struct function delete(
 	string controller,
 	string action,
 	string package,
-	string on
+	string on,
+	string redirect
 ) {
 	return $match(argumentCollection=arguments, method="delete");
 }

--- a/wheels/public/routes.cfm
+++ b/wheels/public/routes.cfm
@@ -33,6 +33,11 @@
       <td>
         <code>#EncodeForHtml(route.pattern)#</td>
       </code>
+      <cfif StructKeyExists(route, "redirect")>
+      <td colspan="2"> 
+          <i class="fa fa-chevron-right"></i> <code>#truncate(EncodeForHtml(route.redirect), 70)#</code>
+      </td>
+      <cfelse>
       <td>
         <cfif StructKeyExists(route, "controller")>
           <code>#EncodeForHtml(route.controller)#</code>
@@ -43,6 +48,7 @@
           <code>#EncodeForHtml(route.action)#</code>
         </cfif>
       </td>
+    </cfif>
     </tr>
   </cfloop>
   </tbody>

--- a/wheels/tests/mapper/redirect.cfc
+++ b/wheels/tests/mapper/redirect.cfc
@@ -1,0 +1,44 @@
+component extends="wheels.tests.Test" {
+  function setup() {
+    config = {
+      path="wheels",
+      fileName="Mapper",
+      method="$init"
+    };
+
+    _params = { controller="test", action="index" };
+    _originalRoutes = application[$appKey()].routes;
+
+    $clearRoutes();
+  }
+
+  function teardown() {
+    application[$appKey()].routes = _originalRoutes;
+  }
+
+  function test_redirect_argument_is_passed_through() {
+    $mapper().$draw()
+      .get(name="testredirect1", redirect="https://www.google.com")
+      .post(name="testredirect2", redirect="https://www.google.com")
+      .put(name="testredirect3", redirect="https://www.google.com")
+      .patch(name="testredirect4", redirect="https://www.google.com")
+      .delete(name="testredirect5", redirect="https://www.google.com")
+    .end(); 
+ 	assert("structKeyExists(application.wheels.routes[1], 'redirect')");
+ 	assert("structKeyExists(application.wheels.routes[2], 'redirect')");
+ 	assert("structKeyExists(application.wheels.routes[3], 'redirect')");
+ 	assert("structKeyExists(application.wheels.routes[4], 'redirect')");
+ 	assert("structKeyExists(application.wheels.routes[5], 'redirect')");
+  }
+ 
+
+  private function $clearRoutes() {
+    application[$appKey()].routes = [];
+  }
+
+  private struct function $mapper() {
+    local.args = Duplicate(config);
+    StructAppend(local.args, arguments, true);
+    return $createObjectFromRoot(argumentCollection=local.args);
+  }
+}


### PR DESCRIPTION
See https://github.com/cfwheels/cfwheels/issues/847

You can do the following now:

```
mapper()
  .get(name="foo", redirect="https://www.google.com")
  .post(name="foo", redirect="https://www.google.com")
  .put(name="foo", redirect="https://www.google.com")
  .patch(name="foo", redirect="https://www.google.com")
  .delete(name="foo", redirect="https://www.google.com")
.end()
```

This then executes cflocation with a 302 redirect fairly early on in the request (just after matching the route) so it doesn't need to do it in the controller etc.