### PR TITLE
Adds `flashAppend` as a configurable flash behaviour option

### DIFF
--- a/wheels/controller/flash.cfm
+++ b/wheels/controller/flash.cfm
@@ -69,8 +69,26 @@ public any function flashDelete(required string key) {
  */
 public void function flashInsert() {
 	local.flash = $readFlash();
+
 	for (local.key in arguments) {
-		StructInsert(local.flash, local.key, arguments[local.key], true);
+
+		// Does the user want us to append new messages or just replace?
+		if($getFlashAppend() && structKeyExists(local.flash, local.key)){
+
+			// Are we dealing with just an existing string or an array?
+			if(isArray(local.flash[local.key])){
+				arrayAppend(local.flash[local.key], arguments[local.key]);
+			} else {
+				// Capture previous value, make it an array and append new value
+				local.tempArr=[];
+				arrayAppend(local.tempArr, local.flash[local.key]);
+				arrayAppend(local.tempArr, arguments[local.key]);
+				StructInsert(local.flash, local.key, local.tempArr, true);
+			}
+
+		} else {
+			StructInsert(local.flash, local.key, arguments[local.key], true);
+		}
 	}
 	$writeFlash(local.flash);
 }
@@ -191,6 +209,20 @@ public void function $setFlashStorage(required string storage) {
  */
 public string function $getFlashStorage() {
 	return variables.$class.flashStorage;
+}
+
+/**
+ * Internal function.
+ */
+public void function $setFlashAppend(required boolean append) {
+	variables.$class.flashAppend = arguments.append;
+}
+
+/**
+ * Internal function.
+ */
+public string function $getFlashAppend() {
+	return variables.$class.flashAppend;
 }
 
 </cfscript>

--- a/wheels/controller/initialization.cfm
+++ b/wheels/controller/initialization.cfm
@@ -46,6 +46,7 @@ public any function $initControllerClass(string name="") {
 	variables.$class.formats.nonExistingTemplates = "";
 
 	$setFlashStorage($get("flashStorage"));
+	$setFlashAppend($get("flashAppend"));
 
 	// Call the developer's "config" function if it exists.
 	if (StructKeyExists(variables, "config")) {

--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -271,6 +271,9 @@ public void function onApplicationStart() {
 		application.$wheels.flashStorage = "cookie";
 	}
 
+	// Additional configurable flash options
+	application.$wheels.flashAppend = false;
+
 	// Possible formats for provides functionality.
 	application.$wheels.formats = {};
 	application.$wheels.formats.html = "text/html";

--- a/wheels/tests/controller/flash/flashmessages.cfc
+++ b/wheels/tests/controller/flash/flashmessages.cfc
@@ -40,10 +40,16 @@ component extends="wheels.tests.Test" {
 		run_empty_flash_includeEmptyContainer();
 	}
 
-	function test_skipping_complex_values() {
-		run_skipping_complex_values();
+	function test_allow_complex_values() {
+		run_allow_complex_values();
 		_controller.$setFlashStorage("cookie");
-		run_skipping_complex_values();
+		run_allow_complex_values();
+	}
+
+	function test_appends_if_allowed(){
+		run_appends_if_allowed();
+		_controller.$setFlashStorage("cookie");
+		run_appends_if_allowed();
 	}
 
 	function test_control_order_via_keys_argument() {
@@ -110,13 +116,22 @@ component extends="wheels.tests.Test" {
 		assert("actual IS '<div class=""flash-messages""></div>'");
 	}
 
-	function run_skipping_complex_values() {
+	function run_appends_if_allowed() {
+		_controller.$setFlashAppend(true);
 		_controller.flashInsert(success="Congrats!");
-		arr = [];
-		arr[1] = "test";
-		_controller.flashInsert(alert=arr);
+		_controller.flashInsert(success="Congrats Again!");
 		actual = _controller.flashMessages();
-		assert("actual IS '<div class=""flash-messages""><p class=""success-message"">Congrats!</p></div>'");
+		assert("actual IS '<div class=""flash-messages""><p class=""success-message"">Congrats!</p><p class=""success-message"">Congrats Again!</p></div>'");
+		_controller.$setFlashAppend(false);
+	}
+
+	function run_allow_complex_values() {
+		arr = [];
+		arr[1] = "Congrats!";
+		arr[2] = "Congrats Again!";
+		_controller.flashInsert(success=arr);
+		actual = _controller.flashMessages();
+		assert("actual IS '<div class=""flash-messages""><p class=""success-message"">Congrats!</p><p class=""success-message"">Congrats Again!</p></div>'");
 	}
 
 	function run_control_order_via_keys_argument() {

--- a/wheels/view/miscellaneous.cfm
+++ b/wheels/view/miscellaneous.cfm
@@ -131,7 +131,12 @@ public string function flashMessages(
 		local.attributes = {class=local.class};
 		if (!StructKeyExists(arguments, "key") || arguments.key == local.item) {
 			local.content = local.flash[local.item];
-			if (IsSimpleValue(local.content)) {
+			// Do we have an array of values or a simple value?
+			if (isArray(local.content)) {
+				for(local.contentItem in local.content){
+					local.listItems &= $element(name="p", content=local.contentItem, attributes=local.attributes, encode=arguments.encode);
+				}
+			} else if(IsSimpleValue(local.content)){
 				local.listItems &= $element(name="p", content=local.content, attributes=local.attributes, encode=arguments.encode);
 			}
 		}


### PR DESCRIPTION
Add new configuration option: `set(flashAppend=true)` which then allows appending a flash value by default instead of replacing. Set to `false` by default; could make this true in future version maybe.

Stored in an array of strings, `flashMessages()` now checks to see if it's an array of strings or just a string and outputs appropriately.

Also means `flashInsert()` can be handed a simple one dimensional array. 

I don't think this is a major breaking behaviour, as the functionality is hidden behind a flag and can be turned off; the only major difference is that you can now pass an array in as you couldn't before.

So useage if `set(flashAppend=true)`  now can be:

```
flashInsert(success="One");
flashInsert(success="Two");
```
Or 
```
msg=[
   "One", "Two"
];
flashInsert(success=msg);
```
Both of which would give you:
```
<div class=""flash-messages""><p class=""success-message"">One</p><p class=""success-message"">Two</p></div>
```

Note, doesn't currently support directly passing in an array when a key already exists.

