### PR TITLE
Fixes debugging duplicate output in the test suite

### DIFF
--- a/wheels/public/tests/html.cfm
+++ b/wheels/public/tests/html.cfm
@@ -92,11 +92,12 @@
   			<cfif result.status neq "Success">
   				<tr class="errRow"><td colspan="4" class="failed">#replace(result.message, chr(10), "<br/>", "ALL")#</td></tr>
   			</cfif>
-  			<cfif StructKeyExists(request, "TESTING_FRAMEWORK_DEBUGGING") && StructKeyExists(request["TESTING_FRAMEWORK_DEBUGGING"], result.testName)>
-  				<cfloop array="#request['TESTING_FRAMEWORK_DEBUGGING'][result.testName]#" index="i">
-  				<tr class="<cfif result.status neq 'Success'>errRow<cfelse>sRow</cfif>"><td colspan="4">#i#</tr>
-  				</cfloop>
-  			</cfif>
+  			<cfset distinctKey= replace(replace(result.packageName, ".", "_", "all"), "tests_", "", "one") & '_' & result.testName>
+        <cfif StructKeyExists(request, "TESTING_FRAMEWORK_DEBUGGING") && StructKeyExists(request["TESTING_FRAMEWORK_DEBUGGING"], distinctKey)>
+          <cfloop array="#request['TESTING_FRAMEWORK_DEBUGGING'][distinctKey]#" index="i">
+          <tr class="<cfif result.status neq 'Success'>errRow<cfelse>sRow</cfif>"><td colspan="4">#i#</tr>
+          </cfloop>
+        </cfif>
   		</cfloop>
   	</table>
   </cfif>

--- a/wheels/test/functions.cfm
+++ b/wheels/test/functions.cfm
@@ -277,8 +277,10 @@ public boolean function $runTest(string resultKey="test", string testname="") {
 
 	for (key in listToArray(keyList)) {
 
+		/* Include test name and make distinct so debugging doesn't duplicate output */
+		var distinctKey= replace(replace(testCase, ".", "_", "all"), "tests_", "", "one") & '_' & key;
 		/* keep track of the test name so we can display debug information */
-		TESTING_FRAMEWORK_VARS.RUNNING_TEST = key;
+		TESTING_FRAMEWORK_VARS.RUNNING_TEST = distinctkey;
 
 		if ((left(key, 4) eq "test" and isCustomFunction(this[key])) and (!len(arguments.testname) or (len(arguments.testname) and arguments.testname eq key))) {
 


### PR DESCRIPTION
A smidge hacky, but basically prepends the package name to the debug key (replacing `.` with `_`) to make sure it's unique. See https://github.com/cfwheels/cfwheels/issues/176