### PR TITLE
adds includeFilters argument to processRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * Added the ability to pass `&lock=false` in the URL for when reload requests won't work due to locking - [Per Djurner]
 * Basic 302 redirects now available in mapper via `redirect` argument for `GET/PUT/PATCH/POST/DELETE` [#847](https://github.com/cfwheels/cfwheels/issues/847) - [Tom King]
+* Added the `includeFilters` argument to the `processRequest` function for skipping execution of filters during controller unit tests - [Adam Chapman]
 <a name="2.0.1"></a>
 
 # [2.0.1](https://github.com/cfwheels/cfwheels/releases/tag/v2.0.1) (01/31/2018)

--- a/wheels/controller/processing.cfm
+++ b/wheels/controller/processing.cfm
@@ -6,8 +6,10 @@
  *
  * [section: Controller]
  * [category: Miscellaneous Functions]
+ *
+ * @includeFilters Set to `before` to only execute "before" filters, `after` to only execute "after" filters or `false` to skip all filters. This argument is generally inherited from the `processRequest` function during unit test execution.
  */
-public boolean function processAction() {
+public boolean function processAction(string includeFilters = true) {
 	$runCsrfProtection(action=params.action);
 
 	// Check if action should be cached, and if so, cache statically or set the time to use later when caching just the action.
@@ -42,7 +44,9 @@ public boolean function processAction() {
 	if (!$abortIssued()) {
 
 		// Run before filters if they exist on the controller.
-		$runFilters(type="before", action=params.action);
+		if (ListFindNoCase("true,before", arguments.includeFilters)) {
+			$runFilters(type="before", action=params.action);
+		}
 
 		if ($get("showDebugInformation")) {
 			$debugPoint("beforeFilters,action");
@@ -98,8 +102,8 @@ public boolean function processAction() {
 			$debugPoint("action,afterFilters");
 		}
 
-		if (!$performedRedirect()) {
-			$runFilters(type="after", action=params.action);
+		if (!$performedRedirect() && ListFindNoCase("true,after", arguments.includeFilters)) {
+				$runFilters(type="after", action=params.action);
 		}
 
 		if ($get("showDebugInformation")) {

--- a/wheels/global/misc.cfm
+++ b/wheels/global/misc.cfm
@@ -263,8 +263,15 @@ public struct function mapper(boolean restful=true, boolean methods=arguments.re
  * @method The HTTP method to use in the request (`get`, `post` etc).
  * @returnAs Pass in `struct` to return all information about the request instead of just the final output (`body`).
  * @rollback Pass in `true` to roll back all database transactions made during the request.
+ * @includeFilters Set to `before` to only execute "before" filters, `after` to only execute "after" filters or `false` to skip all filters.
  */
-public any function processRequest(required struct params, string method, string returnAs, string rollback) {
+public any function processRequest(
+	required struct params,
+	string method,
+	string returnAs,
+	string rollback,
+	string includeFilters = true
+) {;
 	$args(name="processRequest", args=arguments);
 
 	// Set the global transaction mode to rollback when specified.
@@ -291,7 +298,7 @@ public any function processRequest(required struct params, string method, string
 	// Set to ignore CSRF errors during testing.
 	local.controller.protectsFromForgery(with="ignore");
 
-	local.controller.processAction();
+	local.controller.processAction(includeFilters=arguments.includeFilters);
 	local.response = local.controller.response();
 
 	// Get redirect info.

--- a/wheels/tests/_assets/controllers/Filtering.cfc
+++ b/wheels/tests/_assets/controllers/Filtering.cfc
@@ -7,6 +7,19 @@ component extends="Controller" {
 		filters(through="str", strArguments=Duplicate(aStr));
 		filters(through="both", bothArguments=Duplicate(aStr), testArg=1);
 		filters(through="pub,priv", only="index,actOne,actTwo");
+		filters(through="typeBefore", only="noView", type="before");
+		filters(through="typeAfter", only="noView", type="after");
+	}
+
+	function typeBefore() {
+		request.filterTestTypes = ["before"];
+	}
+
+	function typeAfter() {
+		if (NOT IsDefined("request.filterTestTypes")) {
+			request.filterTestTypes = [];
+		}
+		ArrayAppend(request.filterTestTypes, "after");
 	}
 
 	function dir() {
@@ -40,6 +53,10 @@ component extends="Controller" {
 			request.filterTests.test = "";
 		}
 		request.filterTests.test = request.filterTests.test & "priv";
+	}
+
+	function noView() {
+		renderText(text="#params.controller####params.action#");
 	}
 
 }

--- a/wheels/tests/global/public/processrequest.cfc
+++ b/wheels/tests/global/public/processrequest.cfc
@@ -1,5 +1,9 @@
 component extends="wheels.tests.Test" {
 
+	function setup() {
+		StructDelete(request, "filterTestTypes");
+	}
+
 	function test_process_request() {
 		local.params = {
 			action = "show",
@@ -38,6 +42,52 @@ component extends="wheels.tests.Test" {
 		result = processRequest(method="post", params=local.params);
 		expected = "actionPost";
 		assert("Find(expected, result)");
+	}
+
+	function test_processRequest_executes_filters() {
+		local.params = {
+			controller = "Filtering",
+			action = "noView"
+		};
+		response = processRequest(params=local.params);
+		actual = ArrayLen(request.filterTestTypes);
+		expected = 2;
+		assert("actual == expected");
+	}
+
+	function test_processRequest_skips_all_filters() {
+		local.params = {
+			controller = "Filtering",
+			action = "noView"
+		};
+		response = processRequest(params=local.params, includeFilters=false);
+		actual = StructKeyExists(request, "filterTestTypes");
+		expected = false;
+		assert("actual == expected", "request.filterTestTypes");
+	}
+
+	function test_processRequest_only_runs_before_filters() {
+		local.params = {
+			controller = "Filtering",
+			action = "noView"
+		};
+		response = processRequest(params=local.params, includeFilters="before");
+		actual = request.filterTestTypes;
+		expected = "before";
+		assert("ArrayLen(actual) == 1");
+		assert("actual[1] == expected", "request.filterTestTypes");
+	}
+
+	function test_processRequest_only_runs_after_filters() {
+		local.params = {
+			controller = "Filtering",
+			action = "noView"
+		};
+		response = processRequest(params=local.params, includeFilters="after");
+		actual = request.filterTestTypes;
+		expected = "after";
+		assert("ArrayLen(actual) == 1");
+		assert("actual[1] == expected", "request.filterTestTypes");
 	}
 
 }


### PR DESCRIPTION
Set to `before` to only execute "before" filters, `after` to only execute "after" filters or `false` to skip all filters.