### PR TITLE
Aliases HEAD requests to GET requests

### DIFF
--- a/wheels/dispatch/functions.cfm
+++ b/wheels/dispatch/functions.cfm
@@ -84,6 +84,12 @@ public struct function $createNestedParamStruct(required struct params) {
  */
 public struct function $findMatchingRoute(required string path, string requestMethod=$getRequestMethod()) {
 
+	// If this is a HEAD request, look for the corresponding GET route
+	if (arguments.requestMethod == 'HEAD'){
+		arguments.requestMethod = 'GET';
+		local.isHeadRequest = true;
+	}
+
 	// Loop over Wheels routes.
 	for (local.route in application.wheels.routes) {
 

--- a/wheels/tests/dispatch/$findMatchingRoute.cfc
+++ b/wheels/tests/dispatch/$findMatchingRoute.cfc
@@ -224,5 +224,12 @@ component extends="wheels.tests.Test" {
     route = d.$findMatchingRoute(path="admin/users/1");
     assert('route.name eq "adminUser" and route.methods eq "delete"');
   }
+ 
+  function test_head_request_aliases_get() {
+    request.cgi["request_method"] = "HEAD";
+    route = d.$findMatchingRoute(path="users"); 
+    assert('route.name eq "Users" and route.methods eq "GET"');
+  }
+
 
 }


### PR DESCRIPTION
Looks like we might be able to do something as simple as this. Basically, if it's a head request, we set the requestmethod the router matches to GET, but only for the matching process.

In my experiments with postman:

```
component extends="Controller" {
	function config(){
		filters(Through="checkHeadReq");
	}
	function index(){ 
		if(isHead()){
			cfheader (name="SetInAction", value="pong");
		}
	}
	function checkHeadReq(){
		if(isHead()){
			cfheader (name="YesIAmAHEADRequest", value="Howdy");
		}
	}
}
```

These headers get set appropriately. Interestingly, there's no body returned by default it seems - I'm not sure if this a CFML engine specific or not, or whether this is just Postman ignoring the body?

