### PR TITLE
Potential fix for https://github.com/cfwheels/cfwheels/issues/873

### DIFF
--- a/wheels/controller/miscellaneous.cfm
+++ b/wheels/controller/miscellaneous.cfm
@@ -188,7 +188,9 @@ public any function sendFile(
 		}
 		local.fullPath = Replace(local.folder, "\", "/", "all");
 		local.fullPath = ListAppend(local.fullPath, arguments.file, "/");
-		local.fullPath = ExpandPath(local.fullPath);
+		// https://github.com/cfwheels/cfwheels/issues/873 Don't expand path if already contains root
+		if(local.fullPath DOES NOT CONTAIN Replace(local.root, "\", "/", "all"))
+			local.fullPath = ExpandPath(local.fullPath);
 		local.fullPath = Replace(local.fullPath, "\", "/", "all");
 		local.file = ListLast(local.fullPath, "/");
 		local.directory = Reverse(ListRest(Reverse(local.fullPath), "/"));


### PR DESCRIPTION
Slightly different solution for fix in https://github.com/cfwheels/cfwheels/issues/873 as that breaks Lucee.
This appears to work on both ACF / Lucee - essentially all we're doing is checking for the existence of the duplicate string in the path and not expanding it if it's there. 