### PR TITLE
#844 Don't run controller config() for internal wheels controller

### DIFF
--- a/wheels/controller/initialization.cfm
+++ b/wheels/controller/initialization.cfm
@@ -49,7 +49,8 @@ public any function $initControllerClass(string name="") {
 	$setFlashAppend($get("flashAppend"));
 
 	// Call the developer's "config" function if it exists.
-	if (StructKeyExists(variables, "config")) {
+	// Don't run this for internal wheels pages
+	if (variables.$class.path NEQ "wheels" && StructKeyExists(variables, "config")) {
 		config();
 	}
 


### PR DESCRIPTION
Simple temp fix for #844 
This at least stops a filter from aborting an internal wheels request. Need to consider how plugin injection or other overrides can still affect this. It's hardly a complete solution.