### PR TITLE
#879: If the application variable doesn't exist don't call the injection

### DIFF
--- a/wheels/Model.cfc
+++ b/wheels/Model.cfc
@@ -1,5 +1,7 @@
 component output="false" displayName="Model" {
 	include "model/functions.cfm";
 	include "global/functions.cfm";
-	include "plugins/standalone/injection.cfm";
+	if (isDefined("application")){
+		include "plugins/standalone/injection.cfm";
+	}
 }


### PR DESCRIPTION
My logic here is that the call for injection is made to modify the **application** scope.  At session's end, if that scope is not available (or required as the session is over), then there is no reason to call the injection.

This fixes #879 and ensures no more errors are logged to the application/exception logs.