### PR TITLE
#879 - Test for the application variable directly in the calling cfm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ server.json
 cfwheels.*.zip
 settings.json
 .vscode
+setting.xml

--- a/wheels/Model.cfc
+++ b/wheels/Model.cfc
@@ -1,7 +1,5 @@
 component output="false" displayName="Model" {
 	include "model/functions.cfm";
 	include "global/functions.cfm";
-	if (isDefined("application")){
-		include "plugins/standalone/injection.cfm";
-	}
+	include "plugins/standalone/injection.cfm";
 }

--- a/wheels/plugins/standalone/injection.cfm
+++ b/wheels/plugins/standalone/injection.cfm
@@ -2,13 +2,13 @@
 
 // We use $wheels here since these variables get placed in the variables scope of all objects.
 // This way we sure they don't clash with other Wheels variables or any variables the developer may set.
-if (StructKeyExists(application, "$wheels")) {
+if (isDefined("application") && StructKeyExists(application, "$wheels")) {
 	$wheels.appKey = "$wheels";
 } else {
 	$wheels.appKey = "wheels";
 }
 
-if (!StructIsEmpty(application[$wheels.appKey].mixins)) {
+if (isDefined("application") && !StructIsEmpty(application[$wheels.appKey].mixins)) {
 	$wheels.metaData = GetMetaData(this);
 	if (StructKeyExists($wheels.metaData, "displayName")) {
 		$wheels.className = $wheels.metaData.displayName;


### PR DESCRIPTION
It looks like the injection.cfm file is still being called (this time by the wheels\Controller.cfc) and that's causing the same errors (Application not defined).  This still occurs  onSessionEnd, so it's the same error as before.

In this hotfix, I've moved isDefined to the place where the variable is actually being used (which I should have done in the first place).