### PR TITLE
fix to change text field to NVARCHAR(MAX)

### DIFF
--- a/wheels/migrator/adapters/MicrosoftSQLServer.cfc
+++ b/wheels/migrator/adapters/MicrosoftSQLServer.cfc
@@ -10,7 +10,7 @@ component extends="Abstract" {
 	variables.sqlTypes['float'] = {name='FLOAT'};
 	variables.sqlTypes['integer'] = {name='INT'};
 	variables.sqlTypes['string'] = {name='VARCHAR',limit=255};
-	variables.sqlTypes['text'] = {name='TEXT'};
+	variables.sqlTypes['text'] = {name='NVARCHAR',limit="max"};
 	variables.sqlTypes['time'] = {name='DATETIME'};
 	variables.sqlTypes['timestamp'] = {name='DATETIME'};
 	variables.sqlTypes['uniqueidentifier'] = {name='UNIQUEIDENTIFIER'} ;


### PR DESCRIPTION
This is recommended for all versions of MS SQL that support NVARCHAR(max) especially since TEXT is being deprecated in future versions.  I also found this change to be required to get the Settings table migration to work that was included with the example app.