### PR TITLE
Feature/891

### DIFF
--- a/wheels/controller/initialization.cfm
+++ b/wheels/controller/initialization.cfm
@@ -35,7 +35,7 @@ public any function $initControllerClass(string name="") {
 	variables.$class.verifications = [];
 	variables.$class.filters = [];
 	variables.$class.cachableActions = [];
-	variables.$class.layout = {};
+	variables.$class.layouts = [];
 
 	// Setup format info for providing content.
 	// Default the controller to only respond to HTML.

--- a/wheels/controller/layouts.cfm
+++ b/wheels/controller/layouts.cfm
@@ -49,9 +49,9 @@ public any function $useLayout(required string $action) {
  
 	for (local.layout in variables.$class.layouts){
 
+		local.rv = local.layout.useDefault;
+		
 		if ((!StructKeyExists(local.layout, "except") || !ListFindNoCase(local.layout.except, arguments.$action)) && (!StructKeyExists(local.layout, "only") || ListFindNoCase(local.layout.only, arguments.$action))) {
-
-			local.rv = local.layout.useDefault;
 
 			if (isAjax() && StructKeyExists(local.layout, "ajax") && Len(local.layout.ajax)) {
 				local.layoutType = "ajax";

--- a/wheels/controller/layouts.cfm
+++ b/wheels/controller/layouts.cfm
@@ -41,8 +41,8 @@ public void function usesLayout(
 	// Check to see if the layout struct is already present in the array
 	local.layoutInArray = false;
 	if (arrayLen(variables.$class.layouts)){
-		for (i=1; i<=arrayLen(variables.$class.layouts); i++){
-			local.layout = variables.$class.layouts[i];
+		for (local.i=1; local.i<=arrayLen(variables.$class.layouts); local.i++){
+			local.layout = variables.$class.layouts[local.i];
 			if (structCount(local.layout) eq structCount(arguments)){
 				local.oneKeyIsDifferent = false;
 				for (local.key in arguments){
@@ -52,7 +52,7 @@ public void function usesLayout(
 				}
 				if (!local.oneKeyIsDifferent){
 					local.layoutInArray = true;
-					local.layoutPostionInArray = i;
+					local.layoutPostionInArray = local.i;
 				}
 			}
 		}

--- a/wheels/controller/layouts.cfm
+++ b/wheels/controller/layouts.cfm
@@ -37,7 +37,33 @@ public void function usesLayout(
 	if (StructKeyExists(arguments, "only")) {
 		arguments.only = $listClean(arguments.only);
 	}
+
+	// Check to see if the layout struct is already present in the array
+	local.layoutInArray = false;
+	if (arrayLen(variables.$class.layouts)){
+		for (i=1; i<=arrayLen(variables.$class.layouts); i++){
+			local.layout = variables.$class.layouts[i];
+			if (structCount(local.layout) eq structCount(arguments)){
+				local.oneKeyIsDifferent = false;
+				for (local.key in arguments){
+					if (local.layout[local.key] neq arguments[key]){
+						local.oneKeyIsDifferent = true;
+					}
+				}
+				if (!local.oneKeyIsDifferent){
+					local.layoutInArray = true;
+					local.layoutPostionInArray = i;
+				}
+			}
+		}
+	}
+
 	variables.$class.layouts.append(arguments);
+
+	// If this layout was is in the array, we need to delete it to respect the order of declaration
+	if (local.layoutInArray){
+		arrayDeleteAt(variables.$class.layouts, local.layoutPostionInArray);
+	}	
 }
 
 /**

--- a/wheels/tests/controller/rendering/specified_layouts.cfc
+++ b/wheels/tests/controller/rendering/specified_layouts.cfc
@@ -2,28 +2,44 @@ component extends="wheels.tests.Test" {
 
 	function setup() {
 		request.cgi.http_x_requested_with = "";
+		params = {controller="dummy", action="index"};
+		_controller = controller("dummy",params);  
 	}
 
-	function test_using_method() {
+
+	function test_using_method_match() {
 		args = {template="controller_layout_test"};
-		params = {controller="dummy", action="index"};
-		_controller = controller("dummy", params);
 		_controller.controller_layout_test = controller_layout_test;
 		_controller.usesLayout(argumentCollection=args);
 
 		e = "index_layout";
 		r = _controller.$useLayout("index");
 		assert('e eq r');
+	}
+
+	function test_using_method_match2() {
+		args = {template="controller_layout_test"};
+		_controller.controller_layout_test = controller_layout_test;
+		_controller.usesLayout(argumentCollection=args);
 
 		e = "show_layout";
 		r = _controller.$useLayout("show");
 		assert('e eq r');
+	}
+
+	function test_using_method_no_match() {
+		args = {template="controller_layout_test"};
+		_controller.controller_layout_test = controller_layout_test;
+		_controller.usesLayout(argumentCollection=args);
 
 		e = "true";
 		r = _controller.$useLayout("list");
 		assert('e eq r');
+	}
 
-		args.usedefault = false;
+	function test_using_method_no_match_no_default() {
+		args = {template="controller_layout_test", usedefault = false};
+		_controller.controller_layout_test = controller_layout_test;
 		_controller.usesLayout(argumentCollection=args);
 
 		e = "false";
@@ -34,8 +50,6 @@ component extends="wheels.tests.Test" {
 	function test_ajax_request_with_no_layout_specified_should_fallback_to_template() {
 		request.cgi.http_x_requested_with = "XMLHTTPRequest";
 		args = {template="controller_layout_test"};
-		params = {controller="dummy", action="index"};
-		_controller = controller("dummy", params);
 		_controller.controller_layout_test = controller_layout_test;
 		_controller.usesLayout(argumentCollection=args);
 
@@ -44,11 +58,9 @@ component extends="wheels.tests.Test" {
 		assert('e eq r');
 	}
 
-	function test_using_method_ajax() {
+	function test_using_method_ajax_match() {
 		request.cgi.http_x_requested_with = "XMLHTTPRequest";
 		args = {template="controller_layout_test", ajax="controller_layout_test_ajax"};
-		params = {controller="dummy", action="index"};
-		_controller = controller("dummy", params);
 		_controller.controller_layout_test = controller_layout_test;
 		_controller.controller_layout_test_ajax = controller_layout_test_ajax;
 		_controller.usesLayout(argumentCollection=args);
@@ -56,16 +68,37 @@ component extends="wheels.tests.Test" {
 		e = "index_layout_ajax";
 		r = _controller.$useLayout("index");
 		assert('e eq r');
+	}
+	
+	function test_using_method_ajax_match2() {
+		request.cgi.http_x_requested_with = "XMLHTTPRequest";
+		args = {template="controller_layout_test", ajax="controller_layout_test_ajax"};
+		_controller.controller_layout_test = controller_layout_test;
+		_controller.controller_layout_test_ajax = controller_layout_test_ajax;
+		_controller.usesLayout(argumentCollection=args);
 
 		e = "show_layout_ajax";
 		r = _controller.$useLayout("show");
 		assert('e eq r');
+	}
+	
+	function test_using_method_ajax_no_match() {
+		request.cgi.http_x_requested_with = "XMLHTTPRequest";
+		args = {template="controller_layout_test", ajax="controller_layout_test_ajax"};
+		_controller.controller_layout_test = controller_layout_test;
+		_controller.controller_layout_test_ajax = controller_layout_test_ajax;
+		_controller.usesLayout(argumentCollection=args);
 
 		e = "true";
 		r = _controller.$useLayout("list");
 		assert('e eq r');
+	}
 
-		args.usedefault = false;
+	function test_using_method_ajax_no_match_no_default() {
+		request.cgi.http_x_requested_with = "XMLHTTPRequest";
+		args = {template="controller_layout_test", ajax="controller_layout_test_ajax", usedefault = false};
+		_controller.controller_layout_test = controller_layout_test;
+		_controller.controller_layout_test_ajax = controller_layout_test_ajax;
 		_controller.usesLayout(argumentCollection=args);
 
 		e = "false";
@@ -73,21 +106,26 @@ component extends="wheels.tests.Test" {
 		assert('e eq r');
 	}
 
-	function test_should_respect_exceptions() {
+	function test_should_respect_exceptions_no_match() {
 		args = {template="mylayout", except="index"};
-		params = {controller="dummy", action="index"};
-		_controller = controller("dummy", params);
 		_controller.usesLayout(argumentCollection=args);
 
 		e = "mylayout";
 		r = _controller.$useLayout("show");
 		assert('e eq r');
+	}
+
+	function test_should_respect_exceptions_match() {
+		args = {template="mylayout", except="index"};
+		_controller.usesLayout(argumentCollection=args);
 
 		e = "true";
 		r = _controller.$useLayout("index");
 		assert('e eq r');
+	}
 
-		args.usedefault = false;
+	function test_should_respect_exceptions_match_no_default() {
+		args = {template="mylayout", except="index", usedefault = false};
 		_controller.usesLayout(argumentCollection=args);
 
 		e = "false";
@@ -95,22 +133,29 @@ component extends="wheels.tests.Test" {
 		assert('e eq r');
 	}
 
-	function test_should_respect_exceptions_ajax() {
+	function test_should_respect_exceptions_ajax_no_match() {
 		request.cgi.http_x_requested_with = "XMLHTTPRequest";
 		args = {template="mylayout", ajax="mylayout_ajax", except="index"};
-		params = {controller="dummy", action="index"};
-		_controller = controller("dummy", params);
 		_controller.usesLayout(argumentCollection=args);
 
 		e = "mylayout_ajax";
 		r = _controller.$useLayout("show");
 		assert('e eq r');
+	}
+	
+	function test_should_respect_exceptions_ajax_match() {
+		request.cgi.http_x_requested_with = "XMLHTTPRequest";
+		args = {template="mylayout", ajax="mylayout_ajax", except="index"};
+		_controller.usesLayout(argumentCollection=args);
 
 		e = "true";
 		r = _controller.$useLayout("index");
 		assert('e eq r');
-
-		args.usedefault = false;
+	}
+	
+	function test_should_respect_exceptions_ajax_match_no_default() {
+		request.cgi.http_x_requested_with = "XMLHTTPRequest";
+		args = {template="mylayout", ajax="mylayout_ajax", except="index", usedefault = false};
 		_controller.usesLayout(argumentCollection=args);
 
 		e = "false";
@@ -118,21 +163,26 @@ component extends="wheels.tests.Test" {
 		assert('e eq r');
 	}
 
-	function test_should_respect_only() {
+	function test_should_respect_only_no_match() {
 		args = {template="mylayout", only="index"};
-		params = {controller="dummy", action="index"};
-		_controller = controller("dummy", params);
 		_controller.usesLayout(argumentCollection=args);
 
 		e = "true";
 		r = _controller.$useLayout("show");
 		assert('e eq r');
+	}
+	
+	function test_should_respect_only_match() {
+		args = {template="mylayout", only="index"};
+		_controller.usesLayout(argumentCollection=args);
 
 		e = "mylayout";
 		r = _controller.$useLayout("index");
 		assert('e eq r');
-
-		args.usedefault = false;
+	}
+	
+	function test_should_respect_only_no_match_no_default() {
+		args = {template="mylayout", only="index", usedefault = false};
 		_controller.usesLayout(argumentCollection=args);
 
 		e = "false";
@@ -140,22 +190,29 @@ component extends="wheels.tests.Test" {
 		assert('e eq r');
 	}
 
-	function test_should_respect_only_ajax() {
+	function test_should_respect_only_ajax_no_match() {
 		request.cgi.http_x_requested_with = "XMLHTTPRequest";
 		args = {template="mylayout", ajax="mylayout_ajax", only="index"};
-		params = {controller="dummy", action="index"};
-		_controller = controller("dummy", params);
 		_controller.usesLayout(argumentCollection=args);
 
 		e = "true";
 		r = _controller.$useLayout("show");
 		assert('e eq r');
+	}
+	
+	function test_should_respect_only_ajax_match() {
+		request.cgi.http_x_requested_with = "XMLHTTPRequest";
+		args = {template="mylayout", ajax="mylayout_ajax", only="index"};
+		_controller.usesLayout(argumentCollection=args);
 
 		e = "mylayout_ajax";
 		r = _controller.$useLayout("index");
 		assert('e eq r');
-
-		args.usedefault = false;
+	}
+	
+	function test_should_respect_only_ajax_no_match_no_default() {
+		request.cgi.http_x_requested_with = "XMLHTTPRequest";
+		args = {template="mylayout", ajax="mylayout_ajax", only="index", usedefault = false};
 		_controller.usesLayout(argumentCollection=args);
 
 		e = "false";


### PR DESCRIPTION
This is the fix to #891.

The _usesLayout()_ function simply created/overwrote a key each time it was called from **anywhere** in the controller.  Confusion arises because on any subsequent call of _usesLayout()_, the "only" or "except" keys would get overwriiten.  Because of that the rendering function _useLayout()_ wouldn't be able to use those very important keys to decide while layout needed to be used.

The solution was to convert that struct into an array of structs and respect the order in which the _usesLayout()_ functions were declared.  

For example:

```
function config(){
	usesLayout(template="/layouts/default1",except="show");
	usesLayout(template="/layouts/default2",only="show");	
}

function index(){
	usesLayout("/layouts/default3");
}	

function show(){
}	
```

If we were to call the show template, it should use the default2 layout.  If we were to call index, it should use the default3 layout because it was declared last.

Becase _config()_ is always processed first and only once while the actions can be called repeatedly, it was necessary to create some logic to compare the structs within the array to the struct to be inserted to avoid duplication.

It was also necessary to break apart the tests to simulate individual requests.