### PR TITLE
Richtext option for TextArea()

### DIFF
--- a/config/settings.cfm
+++ b/config/settings.cfm
@@ -10,4 +10,7 @@
 	// set(dataSourceUserName="");
 	// set(dataSourcePassword="");
 
+	// set CKEditor URL for the CDN to Use
+	set(ckeditorURl="https://cdn.ckeditor.com/ckeditor5/11.1.1/classic/ckeditor.js");
+
 </cfscript>

--- a/wheels/events/onerror.cfm
+++ b/wheels/events/onerror.cfm
@@ -67,7 +67,12 @@ public string function $runOnError(required exception, required eventName) {
 				);
 				local.rv &= $includeAndReturnOutput($template="wheels/styles/footer.cfm");
 			} else {
-				Throw(object=arguments.exception);
+				if ( StructKeyExists(server, "coldfusion") AND ListFirst(server.coldfusion.productVersion) GTE 2018 ) {
+					WriteDump(arguments.exception);
+					abort;
+				} else {
+					Throw(object=arguments.exception);
+				}
 			}
 		} else {
 			$header(statusCode=500, statusText="Internal Server Error");
@@ -78,7 +83,12 @@ public string function $runOnError(required exception, required eventName) {
 			);
 		}
 	} else {
-		Throw(object=arguments.exception);
+		if ( StructKeyExists(server, "coldfusion") AND ListFirst(server.coldfusion.productVersion) GTE 2018 ) {
+			WriteDump(arguments.exception);
+			abort;
+		} else {
+			Throw(object=arguments.exception);
+		}
 	}
 	return local.rv;
 }

--- a/wheels/migrator/adapters/MicrosoftSQLServer.cfc
+++ b/wheels/migrator/adapters/MicrosoftSQLServer.cfc
@@ -4,15 +4,15 @@ component extends="Abstract" {
 	variables.sqlTypes['primaryKey'] = "int NOT NULL IDENTITY (1, 1)";
 	variables.sqlTypes['binary'] = {name='IMAGE'};
 	variables.sqlTypes['boolean'] = {name='BIT'};
-	variables.sqlTypes['date'] = {name='DATETIME'};
+	variables.sqlTypes['date'] = {name='date'};
 	variables.sqlTypes['datetime'] = {name='DATETIME'};
 	variables.sqlTypes['decimal'] = {name='DECIMAL'};
 	variables.sqlTypes['float'] = {name='FLOAT'};
 	variables.sqlTypes['integer'] = {name='INT'};
 	variables.sqlTypes['string'] = {name='VARCHAR',limit=255};
 	variables.sqlTypes['text'] = {name='TEXT'};
-	variables.sqlTypes['time'] = {name='DATETIME'};
-	variables.sqlTypes['timestamp'] = {name='DATETIME'};
+	variables.sqlTypes['time'] = {name='time'};
+	variables.sqlTypes['timestamp'] = {name='timestamp'};
 	variables.sqlTypes['uniqueidentifier'] = {name='UNIQUEIDENTIFIER'} ;
 	variables.sqlTypes['char'] = {name='CHAR',limit=10};
 

--- a/wheels/styles/header.cfm
+++ b/wheels/styles/header.cfm
@@ -14,6 +14,7 @@ wheelsInternalAssetPath=get("webpath") & "wheels/public/assets";
 	<link rel="stylesheet" href="#wheelsInternalAssetPath#/css/cfwheels.css">
 	<script src="#wheelsInternalAssetPath#/js/jquery-2.2.4.min.js"></script>
 	<script src="#wheelsInternalAssetPath#/js/qjax.min.js"></script>
+	<script src="#application.wheels.ckeditorURl#"></script>
 </head>
 <body>
 	<header>

--- a/wheels/view/formsobject.cfm
+++ b/wheels/view/formsobject.cfm
@@ -233,6 +233,7 @@ public string function textArea(
 	string appendToLabel,
 	string errorElement,
 	string errorClass,
+	boolean richText = false,
 	any encode
 ) {
 	$args(name="textArea", reserved="name", args=arguments);
@@ -242,6 +243,16 @@ public string function textArea(
 	}
 	local.before = $formBeforeElement(argumentCollection=arguments);
 	local.after = $formAfterElement(argumentCollection=arguments);
+	if ( arguments.richText AND StructKeyExists(arguments, "id") ) {
+		local.after = local.after & "
+		<script>
+			ClassicEditor
+				.create( document.querySelector( '###arguments.id#' ) )
+				.catch( error => {
+						console.error( error );
+				} );
+		</script>";
+	}
 	arguments.name = $tagName(arguments.objectName, arguments.property);
 	local.content = $formValue(argumentCollection=arguments);
 	return local.before & $element(name="textarea", skip="objectName,property,label,labelPlacement,prepend,append,prependToLabel,appendToLabel,errorElement,errorClass,association,position,encode", skipStartingWith="label", content=local.content, attributes=arguments, encode=arguments.encode) & local.after;


### PR DESCRIPTION
I have added an option in the textArea() function to use ckEditor5 for a basic rich text editor.  The CDN to use is set in the setting.cfm file so it can be updated and changed per user's needs.  The script may need to be loaded in another file other than wheels/styles/header if you are using the example-app as your starting point.