### PR TITLE
add addForeignKeyOptions function. fixes #862

### DIFF
--- a/wheels/migrator/adapters/MySQL.cfc
+++ b/wheels/migrator/adapters/MySQL.cfc
@@ -22,6 +22,18 @@ component extends="Abstract" {
 		return "MySQL";
 	}
 
+	public string function addForeignKeyOptions(required string sql, struct options = {}) {
+		arguments.sql = arguments.sql & " FOREIGN KEY (" & arguments.options.column & ")";
+		if (StructKeyExists(arguments.options, "referenceTable")){
+			if (StructKeyExists(arguments.options, "referenceColumn")){
+				arguments.sql = arguments.sql & " REFERENCES ";
+				arguments.sql = arguments.sql & arguments.options.referenceTable;
+				arguments.sql = arguments.sql & " (" & arguments.options.referenceColumn & ")";
+			}
+		}
+		return arguments.sql;
+	}
+
 	/**
 	* generates sql for primary key options
 	*/


### PR DESCRIPTION
I tested locally with the following `up()` migration defintion

```
// Services
				t = createTable(name='services');
				t.string(columnNames='title', limit='45', null=false);
				t.text(columnNames='description', null=false);
				t.integer(columnNames='defaultTeamPrice', null=false);
				t.timestamps();
				t.create();

				// Timezones
				t = createTable(name='timezones');
				t.string(columnNames='timezone', limit='45', default='US/Pacific');
				t.string(columnNames='abreviation', limit='5', default='PDT');
				t.timestamps();
				t.create();

				// Events
				t = createTable(name='events');
				t.string(columnNames='title,slug', limit='45', null=false);
				t.string(columnNames='password', limit='45', null=true);
				t.string(columnNames='location', limit='255', null=false);
				t.text(columnNames='description,notes', null=false);
				t.datetime(columnNames='startAt,endAt', null=false);
				t.integer(columnNames='teamPriceOverride', null=true);
				t.boolean(columnNames='allowDownloads,sendTransactionEmails,allowPublicSlideshow', default=true);
				t.boolean(columnNames='isSlideshowPublic,isDrinkingOk,isInnuendoOk,IsNudityOk', default=false);
				// t.integer(columnNames="serviceId,timezoneId", null=true, limit=11);
				t.references('services');
				t.references('timezones');
				t.timestamps();
				t.create();

				// EventUsers
				t = createTable(name='eventusers');
				t.primaryKey(name='eventId', null=false, limit=11);
				t.primaryKey(name='userId', null=false, limit=11);
				t.string(columnNames='roles', limit="45", default="player");
				t.timestamps();
				t.create();

				// EventRoles
				t = createTable(name='users');
				t.string(columnNames='firstName,lastName,username,mobile', limit='45', null=true);
				t.string(columnNames='email,password', limit='255', null=false);
				t.string(columnNames='resetToken', limit='255', null=true);
				t.datetime(columnNames='lastSeen,resetTokenExpirery,waiverAt', null=true);
				t.timestamps();
				t.create();
```