### PR TITLE
CFWheels default 2.0.1 installation uses deprecated code application.getApplicationSettings().sessionManagement

### DIFF
--- a/wheels/controller/verifies.cfm
+++ b/wheels/controller/verifies.cfm
@@ -82,7 +82,7 @@ public void function $runVerifications(
 	// Default to the Wheels setting but get it on a per request basis if possible (from Application.cfc).
 	local.sessionManagement = $get("sessionManagement");
 	try {
-		local.sessionManagement = application.getApplicationSettings().sessionManagement;
+		local.sessionManagement = getApplicationMetaData().sessionManagement;
 	} catch (any e) {}
 	if (StructIsEmpty(arguments.sessionScope) && local.sessionManagement) {
 		arguments.sessionScope = session;


### PR DESCRIPTION
Expression Exception - in {root}/wheels/controller/verifies.cfm : line 85

     Element SESSIONMANAGEMENT is undefined in a Java object of type class coldfusion.runtime.StructBean.

CF 10 and greater now uses the getApplicationMetaData() to access application settings