### PR TITLE
Puts scope dumps in PRE block to preserve line feeds.

### DIFF
--- a/wheels/events/onerror/cfmlerror.cfm
+++ b/wheels/events/onerror/cfmlerror.cfm
@@ -66,7 +66,9 @@
 							<cfset local.hide = ListAppend(local.hide, ListRest(local.j, "."))>
 						</cfif>
 					</cfloop>
-					<cfdump var="#local.scope#" format="text" showUDFs="false" hide="#local.hide#">
+					<pre>
+						<cfdump var="#local.scope#" format="text" showUDFs="false" hide="#local.hide#">
+					</pre>
 					</p>
 				</cfif>
 				<cfcatch type="any"><!--- just keep going, we need to send out error emails ---></cfcatch>


### PR DESCRIPTION
This PR surrounds the scope dumps in the error emails with a PRE tag which will cause the block to preserve their line feeds thus making the email easier to read.