### PR TITLE
Don't require an environment settings file

### DIFF
--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -410,7 +410,9 @@ public void function onApplicationStart() {
 
 	// Load general developer settings first, then override with environment specific ones.
 	$include(template="config/settings.cfm");
-	$include(template="config/#application.$wheels.environment#/settings.cfm");
+	if (FileExists(ExpandPath("/app/config/#application.$wheels.environment#/settings.cfm"))) {
+		$include(template="config/#application.$wheels.environment#/settings.cfm");
+	}
 
 	// Clear query (cfquery) and page (cfcache) caches.
 	if (application.$wheels.clearQueryCacheOnReload or !StructKeyExists(application.$wheels, "cacheKey")) {


### PR DESCRIPTION
There are times when this file is redundant. Eg: in production when loading settings from environment variables. This change just checks for existence of the file, it doesn't break backwards compatibility. I'd like someone to test it on ACF. 