### PR TITLE
#923 minimum versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added the `refresh` url parameter for auto refreshing test framework html - [#986](https://github.com/cfwheels/cfwheels/issues/986) - [Adam Chapman]
 - Allow custom migrator templates by scanning the `/migrator/templates` directory - [Adam Chapman]
 - Minimum Lucee 5 version is now 5.3.2.77 - Tests added - [Michael Diederich]
+- Minimum ColdFusion version is now ColdFusion (2018 release) Update 3 (2018,0,03,314033) / ColdFusion (2016 release) Update 10 (2016,0,10,314028) / ColdFusion 11 Update 18 (11,0,18,314030) [#923](https://github.com/cfwheels/cfwheels/issues/923) - [Michael Diederich]
 - Use `http_x_forwarded_proto` to determine if the application is running behind a loadbalancer that is performing SSL offloading - [Peter Amiri]
 - Allow the combination of `url` and `params` arguments with `redirectTo` - [Adam Chapman]
 - Display content in maintenance mode on newer Lucee versions [#848](https://github.com/cfwheels/cfwheels/issues/848) - [Per Djurner]

--- a/wheels/global/internal.cfm
+++ b/wheels/global/internal.cfm
@@ -987,9 +987,6 @@ private string function $checkMinimumVersion(required string engine, required st
 		local.minimumMinor = "0";
 		local.minimumPatch = "03";
 		local.minimumBuild = "314033";
-		// these keys are not used?
-		//local.11 = {minimumMinor = 0, minimumPatch = 18, minimumBuild = 314030};
-		//local.2016 = {minimumMinor = 0, minimumPatch = 10, minimumBuild = 314028};
 	} else {
 		local.rv = false;
 	}

--- a/wheels/global/internal.cfm
+++ b/wheels/global/internal.cfm
@@ -983,12 +983,13 @@ private string function $checkMinimumVersion(required string engine, required st
 		local.minimumBuild = "77";
 		local.5 = {minimumMinor = 2, minimumPatch = 1, minimumBuild = 9};
 	} else if (arguments.engine == "Adobe ColdFusion") {
-		local.minimumMajor = "10";
+		local.minimumMajor = "2018";
 		local.minimumMinor = "0";
-		local.minimumPatch = "23";
-		local.minimumBuild = "302580";
-		local.11 = {minimumMinor = 0, minimumPatch = 12, minimumBuild = 302575};
-		local.2016 = {minimumMinor = 0, minimumPatch = 4, minimumBuild = 302561};
+		local.minimumPatch = "03";
+		local.minimumBuild = "314033";
+		// these keys are not used?
+		//local.11 = {minimumMinor = 0, minimumPatch = 18, minimumBuild = 314030};
+		//local.2016 = {minimumMinor = 0, minimumPatch = 10, minimumBuild = 314028};
 	} else {
 		local.rv = false;
 	}

--- a/wheels/tests/global/internal/$checkMinimumVersion.cfc
+++ b/wheels/tests/global/internal/$checkMinimumVersion.cfc
@@ -23,11 +23,14 @@ component extends="wheels.tests.Test" {
 	}
 
 	function test_adobe_valid() {
-		assert('!Len($checkMinimumVersion(version="10,0,23,302580", engine="Adobe ColdFusion"))');
-		assert('!Len($checkMinimumVersion(version="11,0,12,302575", engine="Adobe ColdFusion"))');
+		assert('!Len($checkMinimumVersion(version="2018,0,03,314033", engine="Adobe ColdFusion"))');
+		assert('!Len($checkMinimumVersion(version="2016,0,10,314028", engine="Adobe ColdFusion"))');
+		assert('!Len($checkMinimumVersion(version="11,0,18,314030", engine="Adobe ColdFusion"))');
 	}
 
 	function test_adobe_invalid() {
+		assert('Len($checkMinimumVersion(version="10,0,23,302580", engine="Adobe ColdFusion"))');
+		assert('Len($checkMinimumVersion(version="11,0,12,302575", engine="Adobe ColdFusion"))');
 		assert('Len($checkMinimumVersion(version="9,0,0,251028", engine="Adobe ColdFusion"))');
 		assert('Len($checkMinimumVersion(version="8,0,1,195765", engine="Adobe ColdFusion"))');
 		assert('Len($checkMinimumVersion(version="10,0,4,277803", engine="Adobe ColdFusion"))');


### PR DESCRIPTION
#923 - the minimum lucee version is already set to 5.3.2.77
the changes are untested as I dont have a coldfusion installed.

if someone could post a good cfwheels development environment (not docker?), i would create a new virtual maschine for cfwheels development and adjust the settings to your defaults.