### PR TITLE
adds paginationCountMode findAll argument

### DIFF
--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -285,6 +285,7 @@ public void function onApplicationStart() {
 	application.$wheels.timeStampOnCreateProperty = "createdAt";
 	application.$wheels.timeStampOnUpdateProperty = "updatedAt";
 	application.$wheels.timeStampMode = "utc";
+	application.$wheels.paginationCountMode = "count";
 	application.$wheels.ipExceptions = "";
 	application.$wheels.overwritePlugins = true;
 	application.$wheels.deletePluginDirectories = true;

--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -285,7 +285,6 @@ public void function onApplicationStart() {
 	application.$wheels.timeStampOnCreateProperty = "createdAt";
 	application.$wheels.timeStampOnUpdateProperty = "updatedAt";
 	application.$wheels.timeStampMode = "utc";
-	application.$wheels.paginationCountMode = "count";
 	application.$wheels.ipExceptions = "";
 	application.$wheels.overwritePlugins = true;
 	application.$wheels.deletePluginDirectories = true;

--- a/wheels/model/read.cfm
+++ b/wheels/model/read.cfm
@@ -25,6 +25,7 @@
  * @callbacks Set to `false` to disable callbacks for this method.
  * @includeSoftDeletes Set to `true` to include soft-deleted records in the queries that this method runs.
  * @useIndex If you want to specify table index hints, pass in a structure of index names using your model names as the structure keys. Eg: `{user="idx_users", post="idx_posts"}`. This feature is only supported by MySQL and SQL Server.
+ * @paginationCountMode = Set to `query` to use a `query.recordCount` rather than `count()` in paginated queries. The following operators are supported: `count`, `query`
  */
 public any function findAll(
 	string where = "",
@@ -46,6 +47,7 @@ public any function findAll(
 	boolean callbacks = "true",
 	boolean includeSoftDeletes = "false",
 	struct useIndex = {},
+	string paginationCountMode = "count",
 	numeric $limit = "0",
 	numeric $offset = "0"
 ) {
@@ -111,7 +113,7 @@ public any function findAll(
 		if (arguments.count > 0) {
 			local.totalRecords = arguments.count;
 		} else {
-			arguments.$debugName &= "PaginationCount-" & $get("paginationCountMode");
+			arguments.$debugName &= "Pagination#titleize(arguments.paginationCountMode)#";
 			local.paginationCountArgs = {
 				where = arguments.where,
 				reload = arguments.reload,
@@ -121,7 +123,7 @@ public any function findAll(
 				$debugName = arguments.$debugName,
 				includeSoftDeletes = arguments.includeSoftDeletes
 			};
-			if ($get("paginationCountMode") == "query") {
+			if (arguments.paginationCountMode == "query") {
 				local.totalRecordsQuery = this.findAll(argumentCollection = local.paginationCountArgs, select = primaryKey());
 				local.totalRecords = local.totalRecordsQuery.recordCount;
 			} else {

--- a/wheels/model/read.cfm
+++ b/wheels/model/read.cfm
@@ -116,6 +116,7 @@ public any function findAll(
 			arguments.$debugName &= "Pagination#titleize(arguments.paginationCountMode)#";
 			local.paginationCountArgs = {
 				where = arguments.where,
+				include = arguments.include,
 				reload = arguments.reload,
 				cache = arguments.cache,
 				distinct = local.distinct,

--- a/wheels/model/read.cfm
+++ b/wheels/model/read.cfm
@@ -111,17 +111,22 @@ public any function findAll(
 		if (arguments.count > 0) {
 			local.totalRecords = arguments.count;
 		} else {
-			arguments.$debugName &= "PaginationCount";
-			local.totalRecords = this.count(
+			arguments.$debugName &= "PaginationCount-" & $get("paginationCountMode");
+			local.paginationCountArgs = {
 				where = arguments.where,
-				include = arguments.include,
 				reload = arguments.reload,
 				cache = arguments.cache,
 				distinct = local.distinct,
 				parameterize = arguments.parameterize,
 				$debugName = arguments.$debugName,
 				includeSoftDeletes = arguments.includeSoftDeletes
-			);
+			};
+			if ($get("paginationCountMode") == "query") {
+				local.totalRecordsQuery = this.findAll(argumentCollection = local.paginationCountArgs, select = primaryKey());
+				local.totalRecords = local.totalRecordsQuery.recordCount;
+			} else {
+				local.totalRecords = this.count(argumentCollection = local.paginationCountArgs, include = arguments.include);
+			}
 		}
 		local.currentPage = arguments.page;
 		if (local.totalRecords == 0) {

--- a/wheels/model/read.cfm
+++ b/wheels/model/read.cfm
@@ -128,7 +128,7 @@ public any function findAll(
 				local.totalRecordsQuery = this.findAll(argumentCollection = local.paginationCountArgs, select = primaryKey());
 				local.totalRecords = local.totalRecordsQuery.recordCount;
 			} else {
-				local.totalRecords = this.count(argumentCollection = local.paginationCountArgs, include = arguments.include);
+				local.totalRecords = this.count(argumentCollection = local.paginationCountArgs);
 			}
 		}
 		local.currentPage = arguments.page;

--- a/wheels/tests/model/crud/pagination.cfc
+++ b/wheels/tests/model/crud/pagination.cfc
@@ -168,4 +168,27 @@ component extends="wheels.tests.Test" {
 		assert('q.recordcount eq 3');
 	}
 
+	function test_paginated_records_with_paginationcountmode_as_query() {
+		$oldPaginationCountMode = get("paginationCountMode");
+		application.wheels.paginationCountMode = "query";
+		r = user.findAll(select = "id", order = "id");
+		/* 2nd page */
+		e = user.findAll(
+			perpage = "2",
+			page = "2",
+			handle = "pagination_test_3",
+			order = "id"
+		);
+		application.wheels.paginationCountMode = $oldPaginationCountMode;
+
+		assert('request.wheels.pagination_test_3.CURRENTPAGE eq 2');
+		assert('request.wheels.pagination_test_3.TOTALPAGES eq 3');
+		assert('request.wheels.pagination_test_3.TOTALRECORDS eq 5');
+		assert('request.wheels.pagination_test_3.ENDROW eq 4');
+		assert("e.recordcount eq 2");
+		assert('e.id[1] eq r.id[3]');
+		assert('e.id[2] eq r.id[4]');
+
+	}
+
 }

--- a/wheels/tests/model/crud/pagination.cfc
+++ b/wheels/tests/model/crud/pagination.cfc
@@ -170,7 +170,6 @@ component extends="wheels.tests.Test" {
 
 	function test_paginated_records_with_paginationcountmode_as_query() {
 		r = user.findAll(select = "id", order = "id");
-		/* 2nd page */
 		e = user.findAll(
 			perpage = "2",
 			page = "2",

--- a/wheels/tests/model/crud/pagination.cfc
+++ b/wheels/tests/model/crud/pagination.cfc
@@ -169,17 +169,15 @@ component extends="wheels.tests.Test" {
 	}
 
 	function test_paginated_records_with_paginationcountmode_as_query() {
-		$oldPaginationCountMode = get("paginationCountMode");
-		application.wheels.paginationCountMode = "query";
 		r = user.findAll(select = "id", order = "id");
 		/* 2nd page */
 		e = user.findAll(
 			perpage = "2",
 			page = "2",
 			handle = "pagination_test_3",
-			order = "id"
+			order = "id",
+			paginationCountMode = "query"
 		);
-		application.wheels.paginationCountMode = $oldPaginationCountMode;
 
 		assert('request.wheels.pagination_test_3.CURRENTPAGE eq 2');
 		assert('request.wheels.pagination_test_3.TOTALPAGES eq 3');


### PR DESCRIPTION
MySQL count() performs horrendously on large recordsets. 

Allow a pagination ~~configuration setting~~ argument to substitute the initial pagination `count()` for a `findAll()` that selects the primary key column then uses recordCount. This DOES introduce the overhead of sending the primary key column data across the network, but this may be an acceptable compromise.