### PR TITLE
Fixes #978 Disable Flash Storage

### DIFF
--- a/wheels/controller/flash.cfm
+++ b/wheels/controller/flash.cfm
@@ -173,7 +173,7 @@ public any function $writeFlash(struct flash = {}) {
 	} else {
 		if ($getFlashStorage() == "cookie") {
 			cookie.flash = SerializeJSON(arguments.flash);
-		} else {
+		} else if ($getFlashStorage() == "session") {
 			session.flash = arguments.flash;
 		}
 	}

--- a/wheels/tests/controller/flash/flashnone.cfc
+++ b/wheels/tests/controller/flash/flashnone.cfc
@@ -1,0 +1,17 @@
+component extends="wheels.tests.Test" {
+
+	function setup() {
+		include "setup.cfm";
+	}
+
+	function teardown() {
+		include "teardown.cfm";
+	}
+
+	function test_flash_none() {
+		_controller.$setFlashStorage("none");
+		_controller.flashInsert(success = "I should not exist", error = "I should not exist either");
+		actual = _controller.flashMessages();
+		assert("actual IS ''");
+	}
+}


### PR DESCRIPTION
A simple fix; basically, if flashstorage = "none" don't write the flash to session or cookie; this has the advantage of not massively breaking other functionality. It means wheels apps can now actually pass security audits where `SameSite = strict` is required on all cookies (by handling our own cookies and not using wheels).