### PR TITLE
restore test application scope on requestend

### DIFF
--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -264,6 +264,10 @@ public void function onApplicationStart() {
 	application.$wheels.viewPath = "views";
 	application.$wheels.controllerPath = "controllers";
 
+	// Test framework settings.
+	application.$wheels.validateTestPackageMetaData = true;
+	application.$wheels.restoreTestApplicationScope = true;
+
 	// Miscellaneous settings.
 	application.$wheels.encodeURLs = true;
 	application.$wheels.encodeHtmlTags = true;
@@ -301,7 +305,6 @@ public void function onApplicationStart() {
 	if (ListFindNoCase("production,maintenance", application.$wheels.environment)) {
 		application.$wheels.redirectAfterReload = true;
 	}
-	application.$wheels.validateTestPackageMetaData = true;
 	application.$wheels.resetPropertiesStructKeyCase = true;
 
 	// If session management is enabled in the application we default to storing Flash data in the session scope, if not we use a cookie.

--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -266,7 +266,6 @@ public void function onApplicationStart() {
 
 	// Test framework settings.
 	application.$wheels.validateTestPackageMetaData = true;
-	application.$wheels.restoreTestApplicationScope = true;
 
 	// Miscellaneous settings.
 	application.$wheels.encodeURLs = true;

--- a/wheels/events/onrequestend.cfm
+++ b/wheels/events/onrequestend.cfm
@@ -19,6 +19,10 @@ public void function $runOnRequestEnd(required targetpage) {
 	if (application.wheels.showDebugInformation) {
 		$debugPoint("requestEnd");
 	}
+	// restore the application scope modified by the test runner
+	if (StructKeyExists(request, "wheels") && StructKeyExists(request.wheels, "testRunnerApplicationScope")) {
+		application.wheels = request.wheels.testRunnerApplicationScope;
+	}
 	$include(template = "#application.wheels.eventPath#/onrequestend.cfm");
 	if (application.wheels.showDebugInformation) {
 		$debugPoint("requestEnd,total");

--- a/wheels/test/functions.cfm
+++ b/wheels/test/functions.cfm
@@ -487,9 +487,7 @@ public any function $wheelsRunner(struct options = {}) {
 	local.resultKey = "WheelsTests";
 
 	// save the original environment for overloading
-	if (application.wheels.restoreTestApplicationScope) {
-		local.wheelsApplicationScope = Duplicate(application);
-	}
+	request.wheels.testRunnerApplicationScope = Duplicate(application.wheels);
 	// to enable unit testing controllers without actually performing the redirect
 	set(functionName = "redirectTo", delay = true);
 
@@ -526,10 +524,6 @@ public any function $wheelsRunner(struct options = {}) {
 			local.instance.afterAll();
 		}
 	};
-	// swap back the enviroment
-	if (application.wheels.restoreTestApplicationScope) {
-		StructAppend(application, local.wheelsApplicationScope, true);
-	}
 	// return the results
 	return $results(local.resultKey);
 }

--- a/wheels/test/functions.cfm
+++ b/wheels/test/functions.cfm
@@ -487,7 +487,9 @@ public any function $wheelsRunner(struct options = {}) {
 	local.resultKey = "WheelsTests";
 
 	// save the original environment for overloading
-	local.wheelsApplicationScope = Duplicate(application);
+	if (application.wheels.restoreTestApplicationScope) {
+		local.wheelsApplicationScope = Duplicate(application);
+	}
 	// to enable unit testing controllers without actually performing the redirect
 	set(functionName = "redirectTo", delay = true);
 
@@ -525,7 +527,9 @@ public any function $wheelsRunner(struct options = {}) {
 		}
 	};
 	// swap back the enviroment
-	StructAppend(application, local.wheelsApplicationScope, true);
+	if (application.wheels.restoreTestApplicationScope) {
+		StructAppend(application, local.wheelsApplicationScope, true);
+	}
 	// return the results
 	return $results(local.resultKey);
 }


### PR DESCRIPTION
Allow a user to do the application scope swapping manually.

Sometimes when an exception occurs in a test case, later test cases error due to application.wheels being restored.

I have implemented this scope swapping manually in my own base Test.cfc component and /events/onrequestend.cfm