### PR TITLE
runs restoreTestRunnerApplicationScope on other events

### DIFF
--- a/wheels/events/onabort.cfm
+++ b/wheels/events/onabort.cfm
@@ -1,5 +1,6 @@
 <cfscript>
 public void function onAbort(required targetpage) {
+	$restoreTestRunnerApplicationScope();
 	$include(template = "#application.wheels.eventPath#/onabort.cfm");
 }
 </cfscript>

--- a/wheels/events/onerror.cfm
+++ b/wheels/events/onerror.cfm
@@ -22,6 +22,7 @@ public void function onError(required exception, required eventName) {
 
 public string function $runOnError(required exception, required eventName) {
 	if (StructKeyExists(application, "wheels") && StructKeyExists(application.wheels, "initialized")) {
+		$restoreTestRunnerApplicationScope();
 		if (application.wheels.sendEmailOnError) {
 			local.args = {};
 			$args(name = "sendEmail", args = local.args);
@@ -64,26 +65,27 @@ public string function $runOnError(required exception, required eventName) {
 			if (StructKeyExists(arguments.exception, "rootCause") && Left(arguments.exception.rootCause.type, 6) == "Wheels") {
 				local.wheelsError = arguments.exception.rootCause;
 			} else if (
-				StructKeyExists(arguments.exception, "cause") && StructKeyExists(arguments.exception.cause, "rootCause") && Left(
-					arguments.exception.cause.rootCause.type,
-					6
-				) == "Wheels"
+				StructKeyExists(arguments.exception, "cause")
+				&& StructKeyExists(arguments.exception.cause, "rootCause")
+				&& Left(arguments.exception.cause.rootCause.type, 6) == "Wheels"
 			) {
 				local.wheelsError = arguments.exception.cause.rootCause;
 			}
 			if (StructKeyExists(local, "wheelsError")) {
 				local.rv = "";
 
-				if (!StructKeyExists(request.wheels, "internalHeaderLoaded"))
+				if (!StructKeyExists(request.wheels, "internalHeaderLoaded")) {
 					local.rv &= $includeAndReturnOutput($template = "wheels/public/layout/_header_simple.cfm");
+				}
 
 				local.rv &= $includeAndReturnOutput(
 					$template = "wheels/events/onerror/wheelserror.cfm",
 					wheelsError = local.wheelsError
 				);
 
-				if (!StructKeyExists(request.wheels, "internalHeaderLoaded"))
+				if (!StructKeyExists(request.wheels, "internalHeaderLoaded")) {
 					local.rv &= $includeAndReturnOutput($template = "wheels/public/layout/_footer_simple.cfm");
+				}
 			} else {
 				Throw(object = arguments.exception);
 			}

--- a/wheels/events/onrequestend.cfm
+++ b/wheels/events/onrequestend.cfm
@@ -19,10 +19,7 @@ public void function $runOnRequestEnd(required targetpage) {
 	if (application.wheels.showDebugInformation) {
 		$debugPoint("requestEnd");
 	}
-	// restore the application scope modified by the test runner
-	if (StructKeyExists(request, "wheels") && StructKeyExists(request.wheels, "testRunnerApplicationScope")) {
-		application.wheels = request.wheels.testRunnerApplicationScope;
-	}
+	$restoreTestRunnerApplicationScope();
 	$include(template = "#application.wheels.eventPath#/onrequestend.cfm");
 	if (application.wheels.showDebugInformation) {
 		$debugPoint("requestEnd,total");

--- a/wheels/global/internal.cfm
+++ b/wheels/global/internal.cfm
@@ -1437,4 +1437,13 @@ public void function $setCORSHeaders(
 		$header(name = "Access-Control-Allow-Credentials", value = true);
 	}
 }
+
+/**
+ * Restore the application scope modified by the test runner
+ */
+public void function $restoreTestRunnerApplicationScope() {
+	if (StructKeyExists(request, "wheels") && StructKeyExists(request.wheels, "testRunnerApplicationScope")) {
+		application.wheels = request.wheels.testRunnerApplicationScope;
+	}
+}
 </cfscript>

--- a/wheels/global/internal.cfm
+++ b/wheels/global/internal.cfm
@@ -423,7 +423,8 @@ public void function $abortInvalidRequest() {
 	);
 	local.callingPath = Replace(GetBaseTemplatePath(), "\", "/", "all");
 	if (
-		ListLen(local.callingPath, "/") > ListLen(local.applicationPath, "/") || GetFileFromPath(local.callingPath) == "root.cfm"
+		ListLen(local.callingPath, "/") > ListLen(local.applicationPath, "/")
+		|| GetFileFromPath(local.callingPath) == "root.cfm"
 	) {
 		if (StructKeyExists(application, "wheels")) {
 			if (StructKeyExists(application.wheels, "showErrorInformation") && !application.wheels.showErrorInformation) {
@@ -680,10 +681,8 @@ public string function $objectFileName(required string name, required string obj
 	local.fullObjectPath = arguments.objectPath & "/" & ListChangeDelims(arguments.name, '/', '.');
 
 	if (
-		!ListFindNoCase(application.wheels.existingObjectFiles, local.fullObjectPath) && !ListFindNoCase(
-			application.wheels.nonExistingObjectFiles,
-			local.fullObjectPath
-		)
+		!ListFindNoCase(application.wheels.existingObjectFiles, local.fullObjectPath)
+		&& !ListFindNoCase(application.wheels.nonExistingObjectFiles, local.fullObjectPath)
 	) {
 		// we have not yet checked if this file exists or not so let's do that
 		// here (the function below will return the file name with the correct
@@ -774,11 +773,9 @@ public void function $addToCache(
 	string category = "main"
 ) {
 	if (
-		application.wheels.cacheCullPercentage > 0 && application.wheels.cacheLastCulledAt < DateAdd(
-			"n",
-			-application.wheels.cacheCullInterval,
-			Now()
-		) && $cacheCount() >= application.wheels.maximumItemsToCache
+		application.wheels.cacheCullPercentage > 0
+		&& application.wheels.cacheLastCulledAt < DateAdd("n", -application.wheels.cacheCullInterval, Now())
+		&& $cacheCount() >= application.wheels.maximumItemsToCache
 	) {
 		// cache is full so flush out expired items from this cache to make more room if possible
 		local.deletedItems = 0;
@@ -909,17 +906,14 @@ public void function $loadRoutes() {
  */
 public void function $lockedLoadRoutes() {
 	local.appKey = $appKey();
-
 	// clear out the route info
 	ArrayClear(application[local.appKey].routes);
 	StructClear(application[local.appKey].namedRoutePositions);
-
 	// load wheels internal gui routes
 	// TODO skip this if mode != development|testing?
 	$include(template = "wheels/public/routes.cfm");
 	// load developer routes next
 	$include(template = "config/routes.cfm");
-
 	// set lookup info for the named routes
 	$setNamedRoutePositions();
 }
@@ -992,12 +986,15 @@ private string function $checkMinimumVersion(required string engine, required st
 	}
 	if (StructKeyExists(local, "minimumMajor")) {
 		if (
-			local.major < local.minimumMajor || (local.major == local.minimumMajor && local.minor < local.minimumMinor) || (
-				local.major == local.minimumMajor && local.minor == local.minimumMinor && local.patch < local.minimumPatch
-			) || (
-				local.major == local.minimumMajor && local.minor == local.minimumMinor && local.patch == local.minimumPatch && Len(
-					local.minimumBuild
-				) && local.build < local.minimumBuild
+			local.major < local.minimumMajor
+			|| (local.major == local.minimumMajor && local.minor < local.minimumMinor)
+			|| (local.major == local.minimumMajor && local.minor == local.minimumMinor && local.patch < local.minimumPatch)
+			|| (
+				local.major == local.minimumMajor
+				&& local.minor == local.minimumMinor
+				&& local.patch == local.minimumPatch
+				&& Len(local.minimumBuild)
+				&& local.build < local.minimumBuild
 			)
 		) {
 			local.rv = local.minimumMajor & "." & local.minimumMinor & "." & local.minimumPatch;
@@ -1008,9 +1005,8 @@ private string function $checkMinimumVersion(required string engine, required st
 		if (StructKeyExists(local, local.major)) {
 			// special requirements for having a specific minor or patch version within a major release exists
 			if (
-				local.minor < local[local.major].minimumMinor || (
-					local.minor == local[local.major].minimumMinor && local.patch < local[local.major].minimumPatch
-				)
+				local.minor < local[local.major].minimumMinor
+				|| (local.minor == local[local.major].minimumMinor && local.patch < local[local.major].minimumPatch)
 			) {
 				local.rv = local.major & "." & local[local.major].minimumMinor & "." & local[local.major].minimumPatch;
 			}
@@ -1172,10 +1168,7 @@ public string function $prependUrl(required string path) {
 /**
  * NB: url rewriting files need to be removed from here.
  */
-public string function $buildReleaseZip(
-	string version = application.wheels.version,
-	string directory = ExpandPath("/")
-) {
+public string function $buildReleaseZip(string version = application.wheels.version, string directory = ExpandPath("/")) {
 	local.name = "cfwheels-" & LCase(Replace(arguments.version, " ", "-", "all"));
 	local.name = Replace(local.name, "alpha-", "alpha.");
 	local.name = Replace(local.name, "beta-", "beta.");
@@ -1250,11 +1243,7 @@ public string function $buildReleaseZip(
  * Throw a developer friendly CFWheels error if set (typically in development mode).
  * Otherwise show the 404 page for end users (typically in production mode).
  */
-public void function $throwErrorOrShow404Page(
-	required string type,
-	required string message,
-	string extendedInfo = ""
-) {
+public void function $throwErrorOrShow404Page(required string type, required string message, string extendedInfo = "") {
 	if ($get("showErrorInformation")) {
 		Throw(type = arguments.type, message = arguments.message, extendedInfo = arguments.extendedInfo);
 	} else {
@@ -1272,14 +1261,11 @@ public void function $throwErrorOrShow404Page(
  * @domain string to test against e.g *.foo.com
  * @cgi Fake CGI Scope for Testing; will default to normal cgi scope
  */
-public boolean function $wildcardDomainMatchCGI(required string domain, struct cgi){
+public boolean function $wildcardDomainMatchCGI(required string domain, struct cgi) {
 	local.domain = arguments.domain;
-	local.cgi = structKeyExists(arguments, "cgi") ? arguments.cgi : $cgiScope();
+	local.cgi = StructKeyExists(arguments, "cgi") ? arguments.cgi : $cgiScope();
 
-	return $wildcardDomainMatch(
-		$fullDomainString(local.domain),
-		$fullCgiDomainString(local.cgi)
-	);
+	return $wildcardDomainMatch($fullDomainString(local.domain), $fullCgiDomainString(local.cgi));
 }
 
 /**
@@ -1288,29 +1274,27 @@ public boolean function $wildcardDomainMatchCGI(required string domain, struct c
  * @domain string to test against e.g *.foo.com
  * @origin string to test against e.g bar.foo.com
  */
-public boolean function $wildcardDomainMatch(required string domain, required string origin){
+public boolean function $wildcardDomainMatch(required string domain, required string origin) {
 	local.rv = false;
 	local.domainfull = $fullDomainString(arguments.domain);
 	local.originfull = $fullDomainString(arguments.origin);
 
 	// Do we have a wildcard subdomain?
-	local.hasWildcard = listContainsNoCase(local.domainfull, "*", '.') && len(local.domainfull > 1);
+	local.hasWildcard = ListContainsNoCase(local.domainfull, "*", '.') && Len(local.domainfull > 1);
 
 	// If not, is it an exact match?
-	if(!local.hasWildcard && local.domainfull == local.originfull){
+	if (!local.hasWildcard && local.domainfull == local.originfull) {
 		local.rv = true;
 	}
 
 	// Loop over domain backwards and test the corresponding position in the other array
-	if(local.hasWildcard){
-		local.domainReversed = 		 listToArray(Reverse(SpanExcluding(Reverse(local.domainfull), ".")));
-		local.serverNameReversed = listToArray(Reverse(SpanExcluding(Reverse(local.originfull), ".")));
+	if (local.hasWildcard) {
+		local.domainReversed = ListToArray(Reverse(SpanExcluding(Reverse(local.domainfull), ".")));
+		local.serverNameReversed = ListToArray(Reverse(SpanExcluding(Reverse(local.originfull), ".")));
 		local.wildcardPassed = true;
 		// Check each part with corresponding part in other array
-		for (i=1;i LTE ArrayLen(local.domainReversed);i=i+1) {
-			if( local.domainReversed[i] != local.serverNameReversed[i]
-				&& local.domainReversed[i] DOES NOT CONTAIN '*'
-			){
+		for (i = 1; i LTE ArrayLen(local.domainReversed); i = i + 1) {
+			if (local.domainReversed[i] != local.serverNameReversed[i] && local.domainReversed[i] DOES NOT CONTAIN '*') {
 				local.wildcardPassed = false;
 				break;
 			}
@@ -1321,47 +1305,50 @@ public boolean function $wildcardDomainMatch(required string domain, required st
 	return local.rv;
 }
 /**
-* Get full domain string from cgi scope: includes protocol and port
-* e.g https://www.cfwheels.com:443
-*
-* @cgi Fake CGI Scope for Testing; will default to normal cgi scope
-**/
-public string function $fullCgiDomainString(struct cgi){
-	local.cgi = structKeyExists(arguments, "cgi") ? arguments.cgi : $cgiScope();
+ * Get full domain string from cgi scope: includes protocol and port
+ * e.g https://www.cfwheels.com:443
+ *
+ * @cgi Fake CGI Scope for Testing; will default to normal cgi scope
+ **/
+public string function $fullCgiDomainString(struct cgi) {
+	local.cgi = StructKeyExists(arguments, "cgi") ? arguments.cgi : $cgiScope();
 	local.server_name = local.cgi.server_name;
 	local.server_port = local.cgi.server_port;
 	local.server_protocol =
-		(
-			 (structKeyExists(local.cgi, 'http_x_forwarded_proto') && local.cgi.http_x_forwarded_proto == "https")
-			|| (structKeyExists(local.cgi, 'server_port_secure') && local.cgi.server_port_secure)
-		)
-		? "https":"http";
+	(
+		(StructKeyExists(local.cgi, 'http_x_forwarded_proto') && local.cgi.http_x_forwarded_proto == "https")
+		|| (StructKeyExists(local.cgi, 'server_port_secure') && local.cgi.server_port_secure)
+	)
+	 ? "https" : "http";
 	return local.server_protocol & '://' & local.server_name & ':' & local.server_port;
 }
 
 /**
-* Get full domain string from a passed in string: includes protocol and port
-* e.g https://www.cfwheels.com -> https://www.cfwheels.com:443
-* e.g www.cfwheels.com -> http://www.cfwheels.com:80
-*
-* @domain The string to look at
-**/
-public string function $fullDomainString(required string domain){
+ * Get full domain string from a passed in string: includes protocol and port
+ * e.g https://www.cfwheels.com -> https://www.cfwheels.com:443
+ * e.g www.cfwheels.com -> http://www.cfwheels.com:80
+ *
+ * @domain The string to look at
+ **/
+public string function $fullDomainString(required string domain) {
 	local.domain = arguments.domain;
-	local.protocol = listFirst(local.domain, "://");
-	local.port = listLast(local.domain, ":");
+	local.protocol = ListFirst(local.domain, "://");
+	local.port = ListLast(local.domain, ":");
 
-	if(!listFindNoCase("http,https", local.protocol)){
-		if(local.port == 443){
+	if (!ListFindNoCase("http,https", local.protocol)) {
+		if (local.port == 443) {
 			local.protocol = "https";
 		} else {
 			local.protocol = "http";
 		}
 		local.domain = local.protocol & '://' & local.domain;
 	}
-	if(!isNumeric(local.port)){
-		if(local.protocol == 'http') local.port = 80;
-		if(local.protocol == 'https') local.port = 443;
+	if (!IsNumeric(local.port)) {
+		if (local.protocol == 'http') {
+			local.port = 80;
+		} else if (local.protocol == 'https') {
+			local.port = 443;
+		}
 		local.domain &= ':' & local.port;
 	}
 	return local.domain;
@@ -1389,8 +1376,8 @@ public void function $setCORSHeaders(
 		local.originArr = ListToArray(arguments.allowOrigin);
 
 		// Is this origin in the allowed Array?
-		for(local.o in local.originArr){
-			if($wildcardDomainMatch(local.o, local.incomingOrigin)){
+		for (local.o in local.originArr) {
+			if ($wildcardDomainMatch(local.o, local.incomingOrigin)) {
 				$header(name = "Access-Control-Allow-Origin", value = local.incomingOrigin);
 				$header(name = "Vary", value = "Origin");
 				break;


### PR DESCRIPTION
Since onrequestend doesn't run onerror, tear down the overloaded test application scope onerror and onabort also.