### PR TITLE
Returns 404 header status even in development mode

### DIFF
--- a/wheels/global/internal.cfm
+++ b/wheels/global/internal.cfm
@@ -1244,10 +1244,10 @@ public string function $buildReleaseZip(string version = application.wheels.vers
  * Otherwise show the 404 page for end users (typically in production mode).
  */
 public void function $throwErrorOrShow404Page(required string type, required string message, string extendedInfo = "") {
+	$header(statusCode = 404, statustext = "Not Found");
 	if ($get("showErrorInformation")) {
 		Throw(type = arguments.type, message = arguments.message, extendedInfo = arguments.extendedInfo);
 	} else {
-		$header(statusCode = 404, statustext = "Not Found");
 		local.template = $get("eventPath") & "/onmissingtemplate.cfm";
 		$includeAndOutput(template = local.template);
 		abort;

--- a/wheels/public/tests/json.cfm
+++ b/wheels/public/tests/json.cfm
@@ -1,6 +1,8 @@
 <cfsilent>
 <cfif testResults.numErrors || testResults.numFailures>
 	<cfheader statuscode="417" statustext="Expectation Failed" />
+<cfelse>
+	<cfheader statuscode="200" statustext="OK" />
 </cfif>
 <!---cfscript>
   content(type="text/json");

--- a/wheels/public/tests/junit.cfm
+++ b/wheels/public/tests/junit.cfm
@@ -1,6 +1,8 @@
 <cfoutput><cfsilent>
 <cfif testResults.numErrors || testResults.numFailures>
 	<cfheader statuscode="417" statustext="Expectation Failed" />
+<cfelse>
+	<cfheader statuscode="200" statustext="OK" />
 </cfif>
 <cfsetting showdebugoutput="false">
 <cfset request.wheels.showDebugInformation = false>

--- a/wheels/public/tests/txt.cfm
+++ b/wheels/public/tests/txt.cfm
@@ -2,6 +2,8 @@
 	<cfscript>
 	if (testResults.numErrors || testResults.numFailures) {
 		cfheader(statustext="Expectation Failed", statuscode=417);
+	} else {
+		cfheader(statustext="OK", statuscode=200);
 	}
 	cfsetting(showdebugoutput=false);
 	request.wheels.showDebugInformation = false;


### PR DESCRIPTION
#1065 In development (or any) mode, always returns 404 header status on $throwErrorOrShow404Page as all the requests which end up here are 404-able, i.e route not found, view file not found etc, even if we're displaying a friendly developer error