### PR TITLE
Wheels `save(allowExplicitTimestamps=true)` doesn't produce the expected result

### DIFF
--- a/wheels/model/create.cfm
+++ b/wheels/model/create.cfm
@@ -35,8 +35,7 @@ public any function create(
 		parameterize = arguments.parameterize,
 		reload = arguments.reload,
 		transaction = arguments.transaction,
-		validate = arguments.validate,
-		allowExplicitTimestamps = arguments.allowExplicitTimestamps
+		validate = arguments.validate
 	);
 	return local.rv;
 }
@@ -51,8 +50,13 @@ public any function create(
  *
  * @properties The properties you want to set on the object (can also be passed in as named arguments).
  * @callbacks [see:findAll].
+ * @allowExplicitTimestamps Set this to `true` to allow explicit assignment of `createdAt` or `updatedAt` properties
  */
-public any function new(struct properties = {}, boolean callbacks = true) {
+public any function new(
+	struct properties = {}, 
+	boolean callbacks = true,
+	boolean allowExplicitTimestamps = false
+) {
 	arguments.properties = $setProperties(
 		argumentCollection = arguments,
 		filterList = "properties,reload,transaction,callbacks",
@@ -75,15 +79,13 @@ public any function new(struct properties = {}, boolean callbacks = true) {
  * @validate Set to `false` to skip validations for this operation.
  * @transaction Set this to `commit` to update the database, `rollback` to run all the database queries but not commit them, or `none` to skip transaction handling altogether.
  * @callbacks [see:findAll].
- * @allowExplicitTimestamps Set this to `true` to allow explicit assignment of `createdAt` or `updatedAt` properties
  */
 public boolean function save(
 	any parameterize,
 	boolean reload,
 	boolean validate = true,
 	string transaction = $get("transactionMode"),
-	boolean callbacks = true,
-	boolean allowExplicitTimestamps = false
+	boolean callbacks = true
 ) {
 	$args(name = "save", args = arguments);
 	clearErrors();

--- a/wheels/tests/model/crud/create.cfc
+++ b/wheels/tests/model/crud/create.cfc
@@ -81,7 +81,7 @@ component extends="wheels.tests.Test" {
 				allowExplicitTimestamps=true
 			);
 			
-			assert("newPost.createdAt == twentyDaysAgo");
+			assert("newPost.createdAt eq twentyDaysAgo");
 			
 			transaction action="rollback";
 		}
@@ -105,7 +105,7 @@ component extends="wheels.tests.Test" {
 				allowExplicitTimestamps=true
 			);
 			
-			assert("newPost.updatedAt == twentyDaysAgo");
+			assert("newPost.updatedAt eq twentyDaysAgo");
 			
 			transaction action="rollback";
 		}

--- a/wheels/tests/model/crud/create.cfc
+++ b/wheels/tests/model/crud/create.cfc
@@ -63,4 +63,52 @@ component extends="wheels.tests.Test" {
 		}
 	}
 
+	function test_override_created_at_with_allow_explicit_timestamps() {
+
+		author = model("author").findOne(order = "id");
+		
+		transaction {
+
+			twentyDaysAgo = dateAdd("d", -20, now());
+			
+			newPost = model("post").create(
+				authorId = author.id,
+				title = "New title",
+				body = "New Body",
+				createdAt = twentyDaysAgo,
+				updatedAt = twentyDaysAgo,
+				transaction="none",
+				allowExplicitTimestamps=true
+			);
+			
+			assert("newPost.createdAt == twentyDaysAgo");
+			
+			transaction action="rollback";
+		}
+	}
+
+	function test_override_updated_at_with_allow_explicit_timestamps() {
+
+		author = model("author").findOne(order = "id");
+		
+		transaction {
+
+			twentyDaysAgo = dateAdd("d", -20, now());
+			
+			newPost = model("post").create(
+				authorId = author.id,
+				title = "New title",
+				body = "New Body",
+				createdAt = twentyDaysAgo,
+				updatedAt = twentyDaysAgo,
+				transaction="none",
+				allowExplicitTimestamps=true
+			);
+			
+			assert("newPost.updatedAt == twentyDaysAgo");
+			
+			transaction action="rollback";
+		}
+	}
+
 }

--- a/wheels/tests/model/crud/new.cfc
+++ b/wheels/tests/model/crud/new.cfc
@@ -17,7 +17,7 @@ component extends="wheels.tests.Test" {
 
 			newPost.save(transaction="none");
 			
-			assert("newPost.createdAt == twentyDaysAgo");
+			assert("newPost.createdAt eq twentyDaysAgo");
 			
 			transaction action="rollback";
 		}
@@ -39,7 +39,7 @@ component extends="wheels.tests.Test" {
 			newPost.updatedAt = twentyDaysAgo;
 			newPost.save(transaction="none");
 			
-			assert("newPost.updatedAt == twentyDaysAgo");
+			assert("newPost.updatedAt eq twentyDaysAgo");
 			
 			transaction action="rollback";
 		}

--- a/wheels/tests/model/crud/new.cfc
+++ b/wheels/tests/model/crud/new.cfc
@@ -1,0 +1,47 @@
+component extends="wheels.tests.Test" {
+
+	function test_override_created_at_with_allow_explicit_timestamps() {
+
+		author = model("author").findOne(order = "id");
+		
+		transaction {
+
+			twentyDaysAgo = dateAdd("d", -20, now());
+			
+			newPost = model("post").new(allowExplicitTimestamps=true);
+			newPost.authorId = author.id;
+			newPost.title = "New title";
+			newPost.body = "New Body";
+			newPost.createdAt = twentyDaysAgo;
+			newPost.updatedAt = twentyDaysAgo;
+
+			newPost.save(transaction="none");
+			
+			assert("newPost.createdAt == twentyDaysAgo");
+			
+			transaction action="rollback";
+		}
+	}
+
+	function test_override_updated_at_with_allow_explicit_timestamps() {
+
+		author = model("author").findOne(order = "id");
+		
+		transaction {
+
+			twentyDaysAgo = dateAdd("d", -20, now());
+			
+			newPost = model("post").new(allowExplicitTimestamps=true);
+			newPost.authorId = author.id;
+			newPost.title = "New title";
+			newPost.body = "New Body";
+			newPost.createdAt = twentyDaysAgo;
+			newPost.updatedAt = twentyDaysAgo;
+			newPost.save(transaction="none");
+			
+			assert("newPost.updatedAt == twentyDaysAgo");
+			
+			transaction action="rollback";
+		}
+	}
+}

--- a/wheels/tests/model/properties/properties.cfc
+++ b/wheels/tests/model/properties/properties.cfc
@@ -22,6 +22,7 @@ component extends="wheels.tests.Test" {
 		args.birthday = "11/01/1975";
 		args.birthdaymonth = "11";
 		args.birthdayyear = "1975";
+		args.allowExplicitTimestamps = false;
 
 		user.setProperties(args);
 
@@ -76,7 +77,7 @@ component extends="wheels.tests.Test" {
 
 		_properties = author.properties();
 		actual = ListSort(StructKeyList(_properties), "text");
-		expected = "firstName,lastName";
+		expected = "allowExplicitTimestamps,firstName,lastName";
 
 		assert('actual eq expected');
 		assert("author.firstName eq 'Foo'");
@@ -113,7 +114,7 @@ component extends="wheels.tests.Test" {
 
 		_properties = author.properties(returnIncluded = false);
 		actual = ListSort(StructKeyList(_properties), "text");
-		expected = "firstName,lastName";
+		expected = "allowExplicitTimestamps,firstName,lastName";
 
 		debug("author.properties()", _debug);
 

--- a/wheels/tests/model/properties/timestamps.cfc
+++ b/wheels/tests/model/properties/timestamps.cfc
@@ -113,11 +113,6 @@ component extends="wheels.tests.Test" {
 		}
 	}
 
-	function test_allowexplicittimestamps_is_not_an_object_property() {
-		author = model("Author").new();
-		assert("author.propertyIsBlank('allowExplicitTimestamps')");
-	}
-
 	function teardown() {
 		// reset all changes to post model class
 		model("Post").getClass().timeStampOnCreateProperty = "createdAt";


### PR DESCRIPTION
Hello there,

I found some confusion in the documentation regarding the usage of `allowExplicitTimestamps`. After looking into wheels source code, it seems `allowExplicitTimestamps` has been wrongly indicated as a parameter for the `model.save()` function while it's missing for `model.new()` (note: `model.create()` is properly documented).

I've updated their signatures:

- I've removed `allowExplicitTimestamps=true` from `model.save()` signature as it doesn't produce the effect indicated in the documentation. The following test would show the error:

```
component extends="wheels.tests.Test" {

	function test_override_created_at_with_allow_explicit_timestamps() {

		author = model("author").findOne(order = "id");
		
		transaction {

			twentyDaysAgo = dateAdd("d", -20, now());
			
			newPost = model("post").new();
			newPost.authorId = author.id;
			newPost.title = "New title";
			newPost.body = "New Body";
			newPost.createdAt = twentyDaysAgo;
			newPost.updatedAt = twentyDaysAgo;

			newPost.save(transaction="none", allowExplicitTimestamps=true);  // Note: `allowExplicitTimestamps` has no effect here and should be added to the `new` call instead
			
			assert("newPost.createdAt == twentyDaysAgo");
			
			transaction action="rollback";
		}
	}
}
```

- I've added `allowExplicitTimestamps = false` to the `model.new()` signature. While this isn't required (it's passed through arguments.properties) I thought it'd be more consistent with the existing `model.create()` signature.
- I've added a couple tests for both `create` and `new` to show how the `allowExplicitTimestamps` should be used
- I've updated the test `model.properties.properties.test_nested_property_is_not_returned_when_returnincluded_is_false` to expect the new explicit property from new()
- I've updated the test `model.properties.properties.test_setting_and_getting_properties_with_named_arguments` to expect the new explicit property from new()
- I've updated the test `model.properties.properties.test_setting_and_getting_properties` to expect the new explicit property from new()
- I've removed the test `model.properties.timestamps.test_allowexplicittimestamps_is_not_an_object_property` as it's not relevant anymore now that the property is defaulted.

The documentation should also be updated. Specifically the following pages (I'm not sure how to get this done):
- [model.save](https://api.cfwheels.org/v2.2#model.save): `allowExplicitTimestamps` should be removed from the list of parameters 
- [model.new](https://api.cfwheels.org/v2.2#model.new):  `allowExplicitTimestamps` should be added to the list of parameters

