### PR TITLE
add trim to find all returns sql test

### DIFF
--- a/wheels/tests/model/crud/findall.cfc
+++ b/wheels/tests/model/crud/findall.cfc
@@ -94,6 +94,9 @@ component extends="wheels.tests.Test" {
 		actual = ReplaceList(actual, "#Chr(13)#,#Chr(10)#", " , ");
 		// remove double spaces
 		actual = ReplaceList(actual, "  ", " ", "all");
+		// trim extra whitespace
+		actual = Trim(actual);
+
 		expected = "SELECT authors.id FROM authors";
 
 		assert("actual eq expected");


### PR DESCRIPTION
While working on getting the test suite to work on a M1 Mac I came across this failing test. The actual had a trailing space that was making the test fail. I've modified it to make it pass.