### PR TITLE
add .env processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - By default the Core tests will run in the the application datasouce, but the developer can setup a different database for running the Core tests to ensure there is no side effects from running the tests. If you do end up setting a different database for the coreTestDatasouceName, make sure to reload your application after running the Core tests. - [Peter Amiri]
 - Fix two broken links in README. [John Bampton -  * *New Contributor* *]
 - Fix spelling - [John Bampton -  * *New Contributor* *]
+- Add .evn parser to parse .env files and add the properties found in the file to this.env scope. [#1157](https://github.com/cfwheels/cfwheels/pull/1157) - [Peter Amiri]
 
 ### Guides
 - Fix broken links throughout the guides. - [Peter Amiri]

--- a/wheels/functions.cfm
+++ b/wheels/functions.cfm
@@ -36,6 +36,30 @@ for (this.wheels.folder in this.wheels.pluginFolders) {
 	}
 }
 
+// Put environment vars into env struct
+if ( !structKeyExists(this,"env") ) {
+  this.env = {};
+  envFilePath = this.wheels.rootPath & ".env";
+  if (fileExists(envFilePath)) {
+    envStruct = {};
+
+    envFile = fileRead(envFilePath);
+    if (isJSON(envFile)) {
+      envStruct = deserializeJSON(envFile);
+    }
+    else { // assume it is a .properties file
+      properties = createObject('java', 'java.util.Properties').init();
+      properties.load(CreateObject('java', 'java.io.FileInputStream').init(envFilePath));
+      envStruct = properties;
+    }
+
+    // Append to env struct
+    for (key in envStruct) {
+      this.env["#key#"] = envStruct[key];
+    }
+  }
+}
+
 // Include developer's app config so they can set their own variables in this scope (or override "sessionManagement").
 // Include Wheels controller and global functions.
 // Include Wheels event functions (which in turn includes the developer's event files).


### PR DESCRIPTION
This PR adds a parser for a .env file that will add it's contents to the this.env structure. The contents can be in Java properties format or a JSON object.