### PR TITLE
findall-performance-bottleneck

### DIFF
--- a/wheels/model/calculations.cfm
+++ b/wheels/model/calculations.cfm
@@ -225,12 +225,12 @@ public any function $calculate(
 	local.iEnd = ListLen(arguments.property);
 	for (local.i = 1; local.i <= local.iEnd; local.i++) {
 		local.item = Trim(ListGetAt(arguments.property, local.i));
-		if (ListFindNoCase(variables.wheels.class.propertyList, local.item)) {
+		if (StructKeyExists(variables.wheels.class.propertyStruct, local.item)) {
 			local.properties = ListAppend(
 				local.properties,
 				tableName() & "." & variables.wheels.class.properties[local.item].column
 			);
-		} else if (ListFindNoCase(variables.wheels.class.calculatedPropertyList, local.item)) {
+		} else if (StructKeyExists(variables.wheels.class.calculatedPropertyStruct, local.item)) {
 			local.properties = ListAppend(local.properties, variables.wheels.class.calculatedProperties[local.item].sql);
 		}
 	}

--- a/wheels/model/initialization.cfm
+++ b/wheels/model/initialization.cfm
@@ -47,6 +47,11 @@ public any function $initModelClass(required string name, required string path) 
 		variables.wheels.class.validations[ListGetAt(local.validations, local.i)] = [];
 	}
 
+	variables.wheels.class.propertyStruct = StructNew("ordered");
+	variables.wheels.class.columnStruct = StructNew("ordered");
+	variables.wheels.class.calculatedPropertyStruct = StructNew("ordered");
+
+	// TODO: deprecate these lists in favour of the structs to avoid ListFind (use StructKeyList to create the list)
 	variables.wheels.class.propertyList = "";
 	variables.wheels.class.columnList = "";
 	variables.wheels.class.calculatedPropertyList = "";
@@ -68,6 +73,8 @@ public any function $initModelClass(required string name, required string path) 
 			StructKeyExists(variables.wheels.class.mapping[local.key], "type")
 			&& variables.wheels.class.mapping[local.key].type != "column"
 		) {
+			variables.wheels.class.calculatedPropertyStruct[local.key] = true;
+			// TODO: deprecate (use StructKeyList of calculatedPropertyStruct)
 			variables.wheels.class.calculatedPropertyList = ListAppend(
 				variables.wheels.class.calculatedPropertyList,
 				local.key
@@ -92,19 +99,19 @@ public any function $initModelClass(required string name, required string path) 
 		local.columns = variables.wheels.class.adapter.$getColumns(tableName());
 
 		// do not process columns already assigned to a calculated property
-		local.processedColumns = variables.wheels.class.calculatedPropertyList;
+		local.processedColumns = variables.wheels.class.calculatedPropertyStruct;
 
 		local.iEnd = local.columns.recordCount;
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			// set up properties and column mapping
-			if (!ListFindNoCase(local.processedColumns, local.columns["column_name"][local.i])) {
+			if (!StructKeyExists(local.processedColumns, local.columns["column_name"][local.i])) {
 				// default the column to map to a property with the same name
 				local.property = local.columns["column_name"][local.i];
 				for (local.key in variables.wheels.class.mapping) {
 					if (
-						StructKeyExists(variables.wheels.class.mapping[local.key], "type") && variables.wheels.class.mapping[
-							local.key
-						].type == "column" && variables.wheels.class.mapping[local.key].value == local.property
+						StructKeyExists(variables.wheels.class.mapping[local.key], "type")
+						&& variables.wheels.class.mapping[local.key].type == "column"
+						&& variables.wheels.class.mapping[local.key].value == local.property
 					) {
 						// developer has chosen to map this column to a property with a different name so set that here
 						local.property = local.key;
@@ -254,12 +261,16 @@ public any function $initModelClass(required string name, required string path) 
 						}
 					}
 				}
+
+				variables.wheels.class.propertyStruct[local.property] = true;
+				variables.wheels.class.columnStruct[variables.wheels.class.properties[local.property].column] = true;
+
 				variables.wheels.class.propertyList = ListAppend(variables.wheels.class.propertyList, local.property);
 				variables.wheels.class.columnList = ListAppend(
 					variables.wheels.class.columnList,
 					variables.wheels.class.properties[local.property].column
 				);
-				local.processedColumns = ListAppend(local.processedColumns, local.columns["column_name"][local.i]);
+				local.processedColumns[local.columns["column_name"][local.i]] = true;
 			}
 		}
 

--- a/wheels/model/sql.cfm
+++ b/wheels/model/sql.cfm
@@ -148,14 +148,14 @@ public string function $orderByClause(required string order, required string inc
 					for (local.j = 1; local.j <= local.jEnd; local.j++) {
 						local.toAdd = "";
 						local.classData = local.classes[local.j];
-						if (ListFindNoCase(local.classData.propertyList, local.property)) {
+						if (StructKeyExists(local.classData.propertyStruct, local.property)) {
 							local.toAdd = local.classData.tableName & "." & local.classData.properties[local.property].column;
-						} else if (ListFindNoCase(local.classData.calculatedPropertyList, local.property)) {
+						} else if (StructKeyExists(local.classData.calculatedPropertyStruct, local.property)) {
 							local.sql = local.classData.calculatedProperties[local.property].sql;
 							local.toAdd = "(" & Replace(local.sql, ",", "[[comma]]", "all") & ")";
 						}
 						if (Len(local.toAdd)) {
-							if (!ListFindNoCase(local.classData.columnList, local.property)) {
+							if (!StructKeyExists(local.classData.columnStruct, local.property)) {
 								local.toAdd &= " AS " & local.property;
 							}
 							local.toAdd &= " " & UCase(ListLast(local.iItem, " "));
@@ -298,8 +298,8 @@ public string function $createSQLFieldList(
 				// if we find the property in this model and it's not already added we go ahead and add it to the select clause
 				if (
 					(
-						ListFindNoCase(local.classData.propertyList, local.iItem)
-						|| ListFindNoCase(local.classData.calculatedPropertyList, local.iItem)
+						StructKeyExists(local.classData.propertyStruct, local.iItem)
+						|| StructKeyExists(local.classData.calculatedPropertyStruct, local.iItem)
 					)
 					&& !ListFindNoCase(local.addedPropertiesByModel[local.classData.modelName], local.iItem)
 				) {
@@ -322,9 +322,9 @@ public string function $createSQLFieldList(
 					if (local.flagAsDuplicate) {
 						local.toAppend &= "[[duplicate]]" & local.j;
 					}
-					if (ListFindNoCase(local.classData.propertyList, local.iItem)) {
+					if (StructKeyExists(local.classData.propertyStruct, local.iItem)) {
 						local.toAppend &= local.classData.tableName & ".";
-						if (ListFindNoCase(local.classData.columnList, local.iItem)) {
+						if (StructKeyExists(local.classData.columnStruct, local.iItem)) {
 							local.toAppend &= local.iItem;
 						} else {
 							local.toAppend &= local.classData.properties[local.iItem].column;
@@ -332,7 +332,7 @@ public string function $createSQLFieldList(
 								local.toAppend &= " AS " & local.iItem;
 							}
 						}
-					} else if (ListFindNoCase(local.classData.calculatedPropertyList, local.iItem)) {
+					} else if (StructKeyExists(local.classData.calculatedPropertyStruct, local.iItem)) {
 						local.sql = Replace(local.classData.calculatedProperties[local.iItem].sql, ",", "[[comma]]", "all");
 						if (arguments.clause == "select" || !ReFind("^(SELECT )?(AVG|COUNT|MAX|MIN|SUM)\(.*\)", local.sql)) {
 							local.toAppend &= "(" & local.sql & ")";
@@ -480,13 +480,13 @@ public array function $whereClause(required string where, string include = "", b
 					local.table = ListFirst(local.param.property, ".");
 					local.column = ListLast(local.param.property, ".");
 					if (!Find(".", local.param.property) || local.table == local.classData.tableName) {
-						if (ListFindNoCase(local.classData.propertyList, local.column)) {
+						if (StructKeyExists(local.classData.propertyStruct, local.column)) {
 							local.param.column = local.classData.tableName & "." & local.classData.properties[local.column].column;
 							local.param.dataType = local.classData.properties[local.column].dataType;
 							local.param.type = local.classData.properties[local.column].type;
 							local.param.scale = local.classData.properties[local.column].scale;
 							break;
-						} else if (ListFindNoCase(local.classData.calculatedPropertyList, local.column)) {
+						} else if (StructKeyExists(local.classData.calculatedPropertyStruct, local.column)) {
 							local.param.column = "(" & local.classData.calculatedProperties[local.column].sql & ")";
 							if (StructKeyExists(local.classData.calculatedProperties[local.column], "dataType")) {
 								local.param.dataType = local.classData.calculatedProperties[local.column].dataType;
@@ -709,6 +709,10 @@ public array function $expandedAssociations(required string include, boolean inc
 		local.classAssociations[local.name].propertyList = local.associatedClass.$classData().propertyList;
 		local.classAssociations[local.name].calculatedProperties = local.associatedClass.$classData().calculatedProperties;
 		local.classAssociations[local.name].calculatedPropertyList = local.associatedClass.$classData().calculatedPropertyList;
+		// TODO: deprecate the lists above in favour of these structs to avoid listFind
+		local.classAssociations[local.name].columnStruct = local.associatedClass.$classData().columnStruct;
+		local.classAssociations[local.name].propertyStruct = local.associatedClass.$classData().propertyStruct;
+		local.classAssociations[local.name].calculatedPropertyStruct = local.associatedClass.$classData().calculatedPropertyStruct;
 
 		// create the join string if it hasn't already been done
 		if (!StructKeyExists(local.classAssociations[local.name], "join")) {


### PR DESCRIPTION
Addresses major performance bottleneck when using model finders on tables with a lot (hundreds) of columns.

- Creates new structs that mimic property lists
- Uses StructKeyExists rather than ListFindNoCase when looping through columns after findAll