### PR TITLE
Adding addClass attribute in the function textField

### DIFF
--- a/tests/functions/Example.cfc
+++ b/tests/functions/Example.cfc
@@ -38,37 +38,4 @@ component extends="app.tests.Test" {
 	function packageTeardown() {
 	}
 
-	/* 
-		Test case for the bug below:
-		https://github.com/cfwheels/cfwheels/issues/1115
-
-		This test was made by creating a user scaffold and adding a textfield through function in the 
-		_form partial that was used in the new.cfm for users.
-		Then we add an addClass='text-dark' attribute in the textField method call.
-		The response should be 'text-dark' appended to the "class" attribute of the input field.
-	*/
-	function testUsersFirstnameNotContainAddClassAttribute() {
-		local.params = {
-			controller = "users",
-			action = "new"
-		};
-
-		result = processRequest(params=local.params, returnAs="struct");
-
-		assert("result.status eq 200");
-		assert("!(result.body contains 'addClass')");
-	}
-
-	function testUsersFirstnameContainsTextDarkClassAddedByAddClassAttribute() {
-		local.params = {
-			controller = "users",
-			action = "new"
-		};
-
-		result = processRequest(params=local.params, returnAs="struct");
-
-		assert("result.status eq 200");
-		assert("result.body contains 'text-dark'");
-	}
-
 }

--- a/wheels/tests/view/miscellaneous/tag.cfc
+++ b/wheels/tests/view/miscellaneous/tag.cfc
@@ -31,5 +31,11 @@ component extends="wheels.tests.Test" {
 		r = controller("dummy").paginationLinks(classForCurrent = "active", handle = "testPaginationLinksQuery");
 		assert(Find("<span class=""active"">2</span>", r));
 	}
-
+	
+	function test_addclass_attribute_adds_value_in_class() {
+		args.addClass = "newClass";
+		e = _controller.$tag(argumentCollection = args);
+		r = '<input class="wheelstest newClass" id="inputtest" maxlength="50" name="inputtest" onmouseover="function(this){this.focus();}" size="30" type="text">';
+		assert("e eq r");
+	}
 }


### PR DESCRIPTION
Added functionality to check if "addClass" attribute is present then add that attribute's value to class so that it does not overwrite the default class value present in config/settings.cfm