### PR TITLE
Removed the original IF/ELSE condition that invalidates calculated props and added condition

### DIFF
--- a/wheels/model/sql.cfm
+++ b/wheels/model/sql.cfm
@@ -272,7 +272,13 @@ public string function $createSQLFieldList(
 	}
 
 	// go through the properties and map them to the database unless the developer passed in a table name or an alias in which case we assume they know what they're doing and leave the select clause as is
-	if (!Find(".", arguments.list) && !Find(" AS ", arguments.list)) {
+	
+	/* To fix the issue below:
+		https://github.com/cfwheels/cfwheels/issues/1048
+
+		The original issue was due to the alias not being passed in to identify the same columns in multiple tables. When we pass in the alias/dot notation in the select clause, it does not add the calculated properties due to the below condition which causes the orignal name of calculated property to be passed in the final query instead of the definition of calculated property, and that gives an invalid column when executed. Commented the below if and else condition and made fixes in case "." and " AS " is passed in.
+	*/
+	// if (!Find(".", arguments.list) && !Find(" AS ", arguments.list)) {
 		local.rv = "";
 		local.addedProperties = "";
 		local.addedPropertiesByModel = {};
@@ -283,6 +289,16 @@ public string function $createSQLFieldList(
 			// look for duplicates
 			local.duplicateCount = ListValueCountNoCase(local.addedProperties, local.iItem);
 			local.addedProperties = ListAppend(local.addedProperties, local.iItem);
+
+			/* To fix the issue below:
+				https://github.com/cfwheels/cfwheels/issues/1048
+
+				In case "." or " AS " is passed in the column name item, append that as it is in the select query and then move onto the next iteration.
+			*/
+			if (Find(".", local.iItem) || Find(" AS ", local.iItem)) {
+				local.rv = ListAppend(local.rv, local.iItem);
+				continue;
+			}
 
 			// loop through all classes (current and all included ones)
 			local.jEnd = ArrayLen(local.classes);
@@ -396,12 +412,16 @@ public string function $createSQLFieldList(
 			}
 			local.rv = local.newSelect;
 		}
-	} else {
-		local.rv = arguments.list;
+		
 		if (arguments.clause == "groupBy" && Find(" AS ", local.rv)) {
 			local.rv = ReReplace(local.rv, variables.wheels.class.RESQLAs, "", "all");
 		}
-	}
+	// } else {
+	// 	local.rv = arguments.list;
+	// 	if (arguments.clause == "groupBy" && Find(" AS ", local.rv)) {
+	// 		local.rv = ReReplace(local.rv, variables.wheels.class.RESQLAs, "", "all");
+	// 	}
+	// }
 	return local.rv;
 }
 

--- a/wheels/tests/model/crud/findall.cfc
+++ b/wheels/tests/model/crud/findall.cfc
@@ -102,4 +102,9 @@ component extends="wheels.tests.Test" {
 		assert("actual eq expected");
 	}
 
+	function test_select_calculated_property_when_implicitly_selecting_fields() {
+		posts = model("Post").findAll(select="posts.id,posts.title,posts.authorid,comments.id AS commentid,comments.name,titleAlias", include="Comments");
+
+		assert("isDefined('posts.titleAlias')");
+	}
 }


### PR DESCRIPTION
The original issue was due to the alias not being passed in to identify the same columns in multiple tables. When we pass in the alias/dot notation in the select clause, it does not add the calculated properties due to the below condition which causes the orignal name of calculated property to be passed in the final query instead of the definition of calculated property, and that gives an invalid column when executed. Commented the below if and else condition and made fixes in case "." and " AS " is passed in.