### PR TITLE
Issue 580 select ambiguous column name using the wheels alias

### DIFF
--- a/wheels/model/initialization.cfm
+++ b/wheels/model/initialization.cfm
@@ -48,6 +48,7 @@ public any function $initModelClass(required string name, required string path) 
 	}
 
 	variables.wheels.class.propertyList = "";
+	variables.wheels.class.aliasedPropertyList = "";
 	variables.wheels.class.columnList = "";
 	variables.wheels.class.calculatedPropertyList = "";
 
@@ -255,6 +256,20 @@ public any function $initModelClass(required string name, required string path) 
 					}
 				}
 				variables.wheels.class.propertyList = ListAppend(variables.wheels.class.propertyList, local.property);
+
+				/* 
+					To fix the issue below:
+					https://github.com/cfwheels/cfwheels/issues/580
+
+					Added a new property called aliasedPropertyList in model class that will contain column names list that are prepended with the tablename.
+					For example, if there is a "user" table then the columns "id,createdat,updatedat,deletedat" will be added in the list with "user" prepended to it.
+					
+					Then the list will contain, userid,usercreatedat,userupdatedat,userdeletedat.
+				  */
+				if(ListFindNoCase('id,createdat,updatedat,deletedat', local.property)) {
+					variables.wheels.class.aliasedPropertyList = ListAppend(variables.wheels.class.aliasedPropertyList, variables.wheels.class.modelname & local.property);
+				}
+
 				variables.wheels.class.columnList = ListAppend(
 					variables.wheels.class.columnList,
 					variables.wheels.class.properties[local.property].column

--- a/wheels/tests/model/crud/findall.cfc
+++ b/wheels/tests/model/crud/findall.cfc
@@ -102,4 +102,10 @@ component extends="wheels.tests.Test" {
 		assert("actual eq expected");
 	}
 
+	function test_select_ambiguous_column_name_using_alias() {
+		loc.query = model("Post").findAll(select="createdat,commentcreatedat", include="Comments");
+	    loc.columnList = ListSort(loc.query.columnList, "text");
+	    assert('loc.columnList eq "commentcreatedat,createdat"');
+	}
+
 }


### PR DESCRIPTION
Added a new aliasedProperyList node in the classData which will have the specific columns prepended with the model name so that we can get the column in the select clause if include table is specified.
This is then compared with select argument's values and returns the correct column of the table.

A test case is also added which is copied from @chapmandu issue 580's description. Tested it as well and it is successful.