### PR TITLE
issue 908 enable paginationLinks() to set active class on parent

### DIFF
--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -601,6 +601,7 @@ public void function onApplicationStart() {
 		prepend = "",
 		append = "",
 		prependToPage = "",
+		addActiveClassToPrependedParent = false,
 		prependOnFirst = true,
 		prependOnAnchor = true,
 		appendToPage = "",

--- a/wheels/tests/view/links/paginationlinks.cfc
+++ b/wheels/tests/view/links/paginationlinks.cfc
@@ -85,4 +85,18 @@ component extends="wheels.tests.Test" {
 		assert("result Contains '/pag/ina/tion/99/3'");
 	}
 
+	function test_pagination_links_adds_active_class_to_parent_element() {
+		authors = model("author").findAll(page = 2, perPage = 3, order = "lastName");
+		result = _controller.paginationLinks(
+			prepend                         = "<ul class='pagination'>", 
+			append                          = "</ul>", 
+			prependToPage                   = "<li class='page-item'>", 
+			appendToPage                    = "</li>", 
+			addActiveClassToPrependedParent = true,
+			linkToCurrentPage               = true, 
+			encode                          = "attributes",
+			class                           = "page-link"
+		);
+		assert("result Contains '<li class=''active page-item''>'");
+	}
 }


### PR DESCRIPTION
We need the paginationLinks() function to set the active class to the parent of the current page item. The changes made here set the active class to the immediate parent of the current page element in case nested elements are passed in.