### PR TITLE
issue #1319 model datasource bug

### DIFF
--- a/wheels/model/read.cfm
+++ b/wheels/model/read.cfm
@@ -47,7 +47,7 @@ public any function findAll(
 	boolean callbacks = "true",
 	boolean includeSoftDeletes = "false",
 	struct useIndex = {},
-	string dataSource = application.wheels.dataSourceName,
+	string dataSource = variables.wheels.class.dataSource,
 	numeric $limit = "0",
 	numeric $offset = "0"
 ) {

--- a/wheels/model/read.cfm
+++ b/wheels/model/read.cfm
@@ -396,7 +396,7 @@ public any function findByKey(
 	string returnAs,
 	boolean callbacks = "true",
 	boolean includeSoftDeletes = "false",
-	string dataSource = application.wheels.dataSourceName
+	string dataSource = variables.wheels.class.dataSource
 ) {
 	$args(name = "findByKey", args = arguments);
 	$setDebugName(name = "FindByKey", args = arguments);
@@ -445,7 +445,7 @@ public any function findOne(
 	string returnAs,
 	boolean includeSoftDeletes = "false",
 	struct useIndex = {},
-	string dataSource = application.wheels.dataSourceName
+	string dataSource = variables.wheels.class.dataSource
 ) {
 	$args(name = "findOne", args = arguments);
 	$setDebugName(name = "findOne", args = arguments);

--- a/wheels/tests/_assets/models/AuthorAlternateDatasource.cfc
+++ b/wheels/tests/_assets/models/AuthorAlternateDatasource.cfc
@@ -1,0 +1,8 @@
+component extends="Model" {
+
+	function config() {
+		table("authors");
+		dataSource("wheelstestdb_h2");
+	}
+
+}

--- a/wheels/tests/model/read/datasource.cfc
+++ b/wheels/tests/model/read/datasource.cfc
@@ -6,9 +6,6 @@ component extends="wheels.tests.Test" {
 		isTestable = true;
 		if (application.wheels.dataSourceName eq altDatasource) {
 			isTestable = false;
-		} else if (application.wheels.serverName contains "Coldfusion") {
-			// seems ACF can't handle H2 datasources
-			isTestable = false;
 		}
 	}
 
@@ -32,6 +29,17 @@ component extends="wheels.tests.Test" {
 			datasource = altDatasource
 		);
 		finderArgs = {where = "firstName = '#firstName#'", datasource = altDatasource};
+	}
+
+	function test_findall_respects_model_config_datasource() {
+		if (!isTestable) return;
+		transaction {
+			this.db_setup();
+			// ensure this is using the wheelstestdb_h2 as defined in the model config
+			actual = model("AuthorAlternateDatasource").findAll(where = "firstName = '#firstName#'");
+			TransactionRollback();
+		}
+		assert("actual.recordCount");
 	}
 
 	function test_findall_with_datasource_argument() {

--- a/wheels/tests/model/read/datasource.cfc
+++ b/wheels/tests/model/read/datasource.cfc
@@ -6,6 +6,9 @@ component extends="wheels.tests.Test" {
 		isTestable = true;
 		if (application.wheels.dataSourceName eq altDatasource) {
 			isTestable = false;
+		} else if (application.wheels.serverName contains "Coldfusion") {
+			// seems ACF can't handle H2 datasources
+			isTestable = false;
 		}
 	}
 


### PR DESCRIPTION
- Use class datasource as default finder datasource
- Adds test asset model for using alternate datasource
- Unit test case

NOTE: Can this condition be removes so this tests ACF too?
```
} else if (application.wheels.serverName contains "Coldfusion") {
	// seems ACF can't handle H2 datasources
	isTestable = false;
```