### PR TITLE
ignoreColumns model config method

### DIFF
--- a/wheels/model/initialization.cfm
+++ b/wheels/model/initialization.cfm
@@ -96,7 +96,7 @@ public any function $initModelClass(required string name, required string path) 
 		variables.wheels.class.adapter = $assignAdapter();
 
 		// get columns for the table
-		local.columns = variables.wheels.class.adapter.$getColumns(tableName()).filter((r) => {
+		local.columns = variables.wheels.class.adapter.$getColumns(tableName()).filter(function(r) {
 			return !StructKeyExists(variables.wheels.class.ignoredColumns, arguments.r.column_name);
 		});
 

--- a/wheels/model/initialization.cfm
+++ b/wheels/model/initialization.cfm
@@ -27,6 +27,7 @@ public any function $initModelClass(required string name, required string path) 
 	variables.wheels.class.properties = {};
 	variables.wheels.class.accessibleProperties = {};
 	variables.wheels.class.calculatedProperties = {};
+	variables.wheels.class.ignoredColumns = {};
 	variables.wheels.class.associations = {};
 	variables.wheels.class.callbacks = {};
 	variables.wheels.class.keys = "";
@@ -95,7 +96,9 @@ public any function $initModelClass(required string name, required string path) 
 		variables.wheels.class.adapter = $assignAdapter();
 
 		// get columns for the table
-		local.columns = variables.wheels.class.adapter.$getColumns(tableName());
+		local.columns = variables.wheels.class.adapter.$getColumns(tableName()).filter((r) => {
+			return !StructKeyExists(variables.wheels.class.ignoredColumns, arguments.r.column_name);
+		});
 
 		// do not process columns already assigned to a calculated property
 		local.processedColumns = {};
@@ -269,13 +272,13 @@ public any function $initModelClass(required string name, required string path) 
 
 				variables.wheels.class.propertyList = ListAppend(variables.wheels.class.propertyList, local.property);
 
-				/* 
+				/*
 					To fix the issue below:
 					https://github.com/cfwheels/cfwheels/issues/580
 
 					Added a new property called aliasedPropertyList in model class that will contain column names list that are prepended with the tablename.
 					For example, if there is a "user" table then the columns "id,createdat,updatedat,deletedat" will be added in the list with "user" prepended to it.
-					
+
 					Then the list will contain, userid,usercreatedat,userupdatedat,userdeletedat.
 				  */
 				variables.wheels.class.aliasedPropertyList = ListAppend(variables.wheels.class.aliasedPropertyList, variables.wheels.class.modelname & local.property);

--- a/wheels/model/properties.cfm
+++ b/wheels/model/properties.cfm
@@ -37,6 +37,22 @@ public void function protectedProperties(string properties = "") {
 }
 
 /**
+ * Use this method to specify which columns cannot be used by the wheels ORM.
+ *
+ * [section: Model Configuration]
+ * [category: Miscellaneous Functions]
+ *
+ * @columns Array of columns names that will be ignored.
+ */
+public void function ignoredColumns(array columns = []) {
+	local.rv = {};
+	for (local.column in arguments.columns) {
+		local.rv[local.column] = 1;
+	}
+	variables.wheels.class.ignoredColumns = local.rv;
+}
+
+/**
  * Use this method to map an object property to either a table column with a different name than the property or to a SQL expression.
  * You only need to use this method when you want to override the default object relational mapping that CFWheels performs.
  *

--- a/wheels/tests/_assets/models/Shop.cfc
+++ b/wheels/tests/_assets/models/Shop.cfc
@@ -5,6 +5,7 @@ component extends="Model" {
 		property(name = "id", sql = "shops.shopid");
 		belongsTo(name = "city", foreignKey = "citycode");
 		hasmany(name = "trucks", foreignKey = "shopid");
+		ignoredColumns(columns = ["isblackmarket"]);
 	}
 
 }

--- a/wheels/tests/model/properties/ignoredcolumns.cfc
+++ b/wheels/tests/model/properties/ignoredcolumns.cfc
@@ -1,0 +1,11 @@
+component extends="wheels.tests.Test" {
+
+	function test_ignoredColumns() {
+		shop = model("shop").findOne();
+
+		debug("shop.properties()", true);
+
+		assert('StructKeyExists(shop, "isblackmarket") eq false');
+	}
+
+}

--- a/wheels/tests/model/properties/ignoredcolumns.cfc
+++ b/wheels/tests/model/properties/ignoredcolumns.cfc
@@ -2,9 +2,6 @@ component extends="wheels.tests.Test" {
 
 	function test_ignoredColumns() {
 		shop = model("shop").findOne();
-
-		debug("shop.properties()", true);
-
 		assert('StructKeyExists(shop, "isblackmarket") eq false');
 	}
 

--- a/wheels/tests/populate.cfm
+++ b/wheels/tests/populate.cfm
@@ -195,6 +195,7 @@ CREATE TABLE shops
 	shopid char(9) NOT NULL
 	,citycode #local.intColumnType# NULL
 	,name varchar(80) NOT NULL
+	,isblackmarket #local.intColumnType# NULL
 	,PRIMARY KEY(shopid)
 ) #local.storageEngine#
 </cfquery>


### PR DESCRIPTION
An option to ignore columns in all select queries so the specified columns are not selected. Useful when used with an existing database with many irrelevant columns.

The `$initModelClass` uses `ignoredColumns` to filter columns from the results of `dbinfo`

I've elected to use an array for the `columns` argument type as lists have proven to be slow to parse/manipulate.

models/Shop.cfc
```
component extends="Model" {

	function config() {
		ignoredColumns(columns = ["isblackmarket"]);
	}

}
```

Inspired by my own requirement and https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema/ClassMethods.html#method-i-ignored_columns