### PR TITLE
use github build vars to remove the hardcoded version number

### DIFF
--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -62,7 +62,7 @@
 
 	// Set up containers for routes, caches, settings etc.
 	// TODO remove the static version number
-	application.$wheels.version = "3.0.0-SNAPSHOT";
+	application.$wheels.version = "@build.version@";
 	try {
 		application.$wheels.hostName = CreateObject("java", "java.net.InetAddress").getLocalHost().getHostName();
 	} catch (any e) {
@@ -942,8 +942,8 @@
 	// Create the mapper that will handle creating routes.
 	// Needs to be before $loadRoutes and after $loadPlugins.
 	application.$wheels.mapper = $createObjectFromRoot(
-		path = "wheels", 
-		fileName = "Mapper", 
+		path = "wheels",
+		fileName = "Mapper",
 		method = "$init",
 		executeArgs = {
 			resourceControllerNaming = application.$wheels.resourceControllerNaming

--- a/wheels/events/onapplicationstart.cfm
+++ b/wheels/events/onapplicationstart.cfm
@@ -61,7 +61,6 @@
 	request.cgi = $cgiScope();
 
 	// Set up containers for routes, caches, settings etc.
-	// TODO remove the static version number
 	application.$wheels.version = "@build.version@";
 	try {
 		application.$wheels.hostName = CreateObject("java", "java.net.InetAddress").getLocalHost().getHostName();

--- a/wheels/plugins/initialization.cfm
+++ b/wheels/plugins/initialization.cfm
@@ -109,7 +109,11 @@ public void function $pluginDelete() {
 public void function $pluginsProcess() {
 	local.plugins = $pluginFolders();
 	local.pluginKeys = ListSort(StructKeyList(local.plugins), "textnocase", variables.sort);
-	local.wheelsVersion = SpanExcluding(variables.$class.wheelsVersion, " ");
+	if (SpanExcluding(variables.$class.wheelsVersion, " ") == "@build.version@") {
+		local.wheelsVersion = "0.0.0";
+	} else {
+		local.wheelsVersion = SpanExcluding(variables.$class.wheelsVersion, " ");
+	}
 	for (local.pluginKey in local.pluginKeys) {
 		local.pluginValue = local.plugins[local.pluginKey];
 		local.plugin = CreateObject("component", $componentPathToPlugin(local.pluginKey, local.pluginValue.name)).init();


### PR DESCRIPTION
This PR removes the hard coded version number in wheels/events/onApplicationStart.cfm.

This removed another manual process in releasing builds.