### PR TITLE
Fix for JSON, Junit and TXT formats

### DIFF
--- a/app/views/layout.cfm
+++ b/app/views/layout.cfm
@@ -1,13 +1,21 @@
 <!--- Place HTML here that should be used as the default layout of your application. --->
-<html>
-	<head>
-		<cfoutput>#csrfMetaTags()#</cfoutput>
-	</head>
-
-	<body>
-		<cfoutput>
-			#flashMessages()#
-			#includeContent()#
-		</cfoutput>
-	</body>
-</html>
+<!--- This condition prevents the content to be wrapped in HTML for the Junit, TXT and JSON formats when they are passed in the URL as "format=json","format=txt" and "format=junit" as these formats shouldn't have html wrapped around them --->
+<cfif application.contentOnly>
+	<cfoutput>
+		#flashMessages()#
+		#includeContent()#
+	</cfoutput>
+<cfelse>
+	<html>
+		<head>
+			<cfoutput>#csrfMetaTags()#</cfoutput>
+		</head>
+	
+		<body>
+			<cfoutput>
+				#flashMessages()#
+				#includeContent()#
+			</cfoutput>
+		</body>
+	</html>
+</cfif>

--- a/public/Application.cfc
+++ b/public/Application.cfc
@@ -123,6 +123,15 @@ component output="false" {
 	}
 
 	public boolean function onRequestStart( string targetPage ) {
+
+		// Added this section so that whenever the format parameter is passed in the URL and it is junit, json or txt then the content will be served without the head and body tags
+		if(structKeyExists(url, "format") && listFindNoCase("junit,json,txt", url.format))
+		{
+			application.contentOnly = true;
+		}else{
+			application.contentOnly = false;
+		}
+
 		local.lockName = "reloadLock" & application.applicationName;
 
 		// Abort if called from incorrect file.


### PR DESCRIPTION
**Summary**
 - Added a condition in onRequestStart function that sets the variable "contentOnly" to `true `if format in the URL is `JSON`, `JUNIT `or `TXT` and otherwise `false`. 
 
This is done so that whenever the format parameter is passed in the URL with `JSON`, `JUNIT `or `TXT` then the content will be served without the head and body tags.