### PR TITLE
Sorting the test bundles before execution

### DIFF
--- a/vendor/wheels/tests_testbox/runner.cfm
+++ b/vendor/wheels/tests_testbox/runner.cfm
@@ -2,6 +2,11 @@
 <cfscript>
     testBox = new testbox.system.TestBox(directory="wheels.tests_testbox.specs")
 
+    //Sorting the bundles Alphabetically
+    local.sortedArray = testBox.getBundles();
+    arraySort(local.sortedArray, "textNoCase");
+    testBox.setBundles(local.sortedArray)
+
     setTestboxEnvironment()
 
     if(structKeyExists(url, "format")){


### PR DESCRIPTION
Sorting the available test bundles before execution so some tests don't fail on linux and MacOS machines.