### PR TITLE
Fix location function error & refactor string split function

### DIFF
--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -165,7 +165,7 @@ component output="false" {
     StructDelete(arguments, "$args", false);
     if(NOT arguments.delay){
       StructDelete(arguments, "delay", false);
-      location(attributeCollection="#arguments#");
+      cflocation(attributeCollection="#arguments#");
     }
 	}
 
@@ -2611,5 +2611,45 @@ component output="false" {
 		return local.rv;
 	}
 
-		include "/app/global/functions.cfm";
+	public array function $splitOutsideFunctions(required string list, required string splitBy) {
+		local.rv = [];
+		local.temp = "";
+		local.insideFunction = false;
+		local.bracketCount = 0;
+
+		for (i = 1; i <= len(arguments.list); i++) {
+			local.char = mid(arguments.list, i, 1);
+
+			// Check if we are entering or exiting a function's parentheses
+			if (local.char == "(") {
+				local.bracketCount++;
+			} else if (local.char == ")") {
+				local.bracketCount--;
+			}
+
+			// Determine if we are inside a function (any content enclosed by parentheses)
+			if (local.bracketCount > 0) {
+				local.insideFunction = true;
+			} else if (local.bracketCount == 0) {
+				local.insideFunction = false;
+			}
+
+			// Split based on commas outside functions
+			if (local.char == arguments.splitBy && !local.insideFunction) {
+				arrayAppend(local.rv, trim(local.temp));
+				local.temp = "";
+			} else {
+				local.temp &= local.char;
+			}
+		}
+
+		// Append the final segment
+		if (len(trim(local.temp))) {
+			arrayAppend(local.rv, trim(local.temp));
+		}
+
+		return local.rv;
+	}
+
+	include "/app/global/functions.cfm";
 }

--- a/vendor/wheels/model/sql.cfc
+++ b/vendor/wheels/model/sql.cfc
@@ -282,7 +282,7 @@ component {
 			local.rv = "";
 			local.addedProperties = "";
 			local.addedPropertiesByModel = {};
-			local.selectArray = $splitByCommasOutsideFunctions(arguments.list);
+			local.selectArray = $splitOutsideFunctions(arguments.list, ",");
 			local.iEnd = arrayLen(local.selectArray);
 			for (local.i = 1; local.i <= local.iEnd; local.i++) {
 				local.iItem = Trim(local.selectArray[i]);
@@ -922,44 +922,5 @@ component {
 		return local.rv;
 	}
 
-	public array function $splitByCommasOutsideFunctions(required string list) {
-		local.rv = [];
-		local.temp = "";
-		local.insideFunction = false;
-		local.bracketCount = 0;
-
-		for (i = 1; i <= len(arguments.list); i++) {
-			local.char = mid(arguments.list, i, 1);
-
-			// Check if we are entering or exiting a function's parentheses
-			if (local.char == "(") {
-				local.bracketCount++;
-			} else if (local.char == ")") {
-				local.bracketCount--;
-			}
-
-			// Determine if we are inside a function (any content enclosed by parentheses)
-			if (local.bracketCount > 0) {
-				local.insideFunction = true;
-			} else if (local.bracketCount == 0) {
-				local.insideFunction = false;
-			}
-
-			// Split based on commas outside functions
-			if (local.char == "," && !local.insideFunction) {
-				arrayAppend(local.rv, trim(local.temp));
-				local.temp = "";
-			} else {
-				local.temp &= local.char;
-			}
-		}
-
-		// Append the final segment
-		if (len(trim(local.temp))) {
-			arrayAppend(local.rv, trim(local.temp));
-		}
-
-		return local.rv;
-	}
 
 }


### PR DESCRIPTION
Fixed the issue of the location function throwing error with the attribute collection Moved $splitByCommasOutsideFunctions to Global.cfc for broader use across components. 
Renamed the function to $splitOutsideFunctions and added an argument to specify the delimiter