### PR TITLE
Migration fix and guides update

### DIFF
--- a/app/config/app.cfm
+++ b/app/config/app.cfm
@@ -6,10 +6,9 @@
 		this.name = "MyAppName";
 		this.sessionTimeout = CreateTimeSpan(0,0,5,0);
 	*/
+	this.name = "wheels.dev";
 
-	this.name = "wheels.fw";
-
-	this.datasources['wheels.fw'] = {
+	this.datasources['wheels.dev'] = {
 		class: 'org.h2.Driver'
 	, connectionString: 'jdbc:h2:file:./db/h2/wheels.fw;MODE=MySQL'
 	, username = 'sa'

--- a/app/config/settings.cfm
+++ b/app/config/settings.cfm
@@ -7,13 +7,13 @@
 	*/
 
 	/*
-		You can change the "wheels.fw" value from the two functions below to set your datasource.
+		You can change the "wheels.dev" value from the two functions below to set your datasource.
 		You can change the the value for the "dataSourceName" to set a default datasource to be used throughout your application.
 		You can also change the value for the "coreTestDataSourceName" to set your testing datasource.
 		You can also uncomment the 2 "set" functions below them to set the username and password for the datasource.
 	*/
-	set(coreTestDataSourceName="wheels.fw");
-	set(dataSourceName="wheels.fw");
+	set(coreTestDataSourceName="wheels.dev");
+	set(dataSourceName="wheels.dev");
 	// set(dataSourceUserName="");
 	// set(dataSourcePassword="");
 
@@ -25,8 +25,8 @@
 	*/
 	set(URLRewriting="On");
 
-	// Reload your application with ?reload=true&password=wheels.fw
-	set(reloadPassword="wheels.fw");
+	// Reload your application with ?reload=true&password=wheels.dev
+	set(reloadPassword="wheels.dev");
 
 	// CLI-Appends-Here
 </cfscript>

--- a/box.json
+++ b/box.json
@@ -1,5 +1,5 @@
 {
-    "name":"Wheels.fw",
+    "name":"Wheels.dev",
     "version":"3.0.0-SNAPSHOT",
     "author":"CFWheels Core Team and Community",
     "shortDescription":"CFWheels MVC Framework Core Directory",

--- a/guides/README.md
+++ b/guides/README.md
@@ -28,7 +28,7 @@ version
 
 This is a good concept to grasp, cause depending on your workflow, you may find it easier to do one versus the other. Most of the commands you will see in these CLI guides will assume that you are entering the command in the actual CommandBox shell so the `box` prefix is left off.
 
-### Install the cfwheels-cli CommandBox Module
+### Install the wheels-cli CommandBox Module
 
 Okay, now that we have CommandBox installed, let's add the CFWheels CLI module.
 
@@ -42,7 +42,7 @@ Installing this module will add a number of commands to your default CommandBox 
 
 ### Start a new Application using the Wizard
 
-To install a new application using the 3.0 Snapshot architecture, we can uise the new application wizard and select Bleeding Edge when promted to select the template to use.
+To install a new application using version 3.0, we can use the new application wizard and select Bleeding Edge when prompted to select the template to use.
 
 {% tabs %}
 {% tab title="CommandBox" %}
@@ -50,9 +50,9 @@ wheels new
 {% endtab %}
 {% endtabs %}
 
-### Start a new Application
+### Start a New Application Using the Command Line
 
-Now that we have CommandBox installed and extended it with the CFWheels CLI module, let's start our first CFWheels app from the command line. We'll look at the simplest method for creating a CFWheels app and starting our development server.
+Now that we have CommandBox installed and extended it with the Wheels CLI module, let's start our first Wheels app from the command line. We'll look at the simplest method for creating a Wheels app and starting our development server.
 
 {% tabs %}
 {% tab title="CommandBox" %}
@@ -67,7 +67,7 @@ A few minutes after submitting the above commands a new browser window should op
 
 <figure><img src=".gitbook/assets/Screenshot 2025-01-23 at 11.21.18 AM.png" alt=""><figcaption></figcaption></figure>
 
-So what just happened? Since we only passed the application name `myApp` to the `wheels generate app` command, it used default values for most of its parameters and downloaded our Base template (cfwheels-base-template) from ForgeBox.io, then downloaded the framework core files (cfwheels) from ForgeBox.io and placed it in the wheels directory, then configured the application name and reload password, and started a Lucee server on a random port.
+So what just happened? Since we only passed the application name `myApp` to the `wheels generate app` command, it used default values for most of its parameters and downloaded our Base template (cfwheels-base-template) from ForgeBox.io, then downloaded the framework core files (wheels.dev) from ForgeBox.io and placed it in the `vendor/wheels` directory, then configured the application name and reload password, and started a Lucee server on a random port.
 
 {% hint style="info" %}
 **A Word About Command Aliases**
@@ -79,4 +79,4 @@ In addition to shortening `generate` to `g`, aliases can completely change the n
 This command has the normal alias referenced above at `wheels g app-wizard` but it also has an additional alias at `wheels new` which is the command more prevalent in the Rails community. So the three commands `wheels generate app-wizard`, `wheels g app-wizard`, and `wheels new` all call the same functionality which guides the user though a set of menus, collecting details on how to configure the desired app. Once all the parameters have been gathered, this command actually calls the `wheels generate app` command to create the actual CFWheels application.
 {% endhint %}
 
-This getting started guide has taken you from the very beginning and gotten you to the point where you can go into any empty directory on your local development machine and start a CFWheels project by issuing a couple of CLI commands. In later guides we'll explore these options further and see what else the CLI can do for us.
+This **Getting Started** guide has taken you from the very beginning and gotten you to the point where you can go into any empty directory on your local development machine and start a CFWheels project by issuing a couple of CLI commands. In later guides we'll explore these options further and see what else the CLI can do for us.

--- a/guides/command-line-tools/cli-commands.md
+++ b/guides/command-line-tools/cli-commands.md
@@ -26,7 +26,7 @@ version
 
 This is a good concept to grasp, cause depending on your workflow, you may find it easier to do one versus the other. Most of the commands you will see in these CLI guides will assume that you are entering the command in the actual CommandBox shell so the `box` prefix is left off.
 
-### Install the cfwheels-cli CommandBox Module
+### Install the wheels-cli CommandBox Module
 
 Okay, now that we have CommandBox installed, let's add the CFWheels CLI module.
 

--- a/guides/command-line-tools/wheels-dbmigrate-commands.md
+++ b/guides/command-line-tools/wheels-dbmigrate-commands.md
@@ -23,7 +23,7 @@ wheels dbmigrate info
 Sending: http://127.0.0.1:59144/?controller=wheels&action=wheels&view=cli&command=info
 Call to bridge was successful.
 +-----------------------------------------+-----------------------------------------+
-| Datasource:                   wheels.fw | Total Migrations:                     3 |
+| Datasource:                  wheels.dev | Total Migrations:                     3 |
 | Database Type:                       H2 | Available Migrations:                 2 |
 |                                         | Current Version:         20220619110404 |
 |                                         | Latest Version:          20220619110706 |

--- a/guides/introduction/getting-started/beginner-tutorial-hello-database.md
+++ b/guides/introduction/getting-started/beginner-tutorial-hello-database.md
@@ -20,7 +20,7 @@ You can download all the source code for this sample application from [https://g
 
 ### Setting up the Data Source
 
-By default, CFWheels will connect to a data source `wheels.fw`. To change this default behavior, open the file at `app/config/settings.cfm`. In a fresh install of CFWheels, you'll see the follwing code:
+By default, CFWheels will connect to a data source `wheels.dev`. To change this default behavior, open the file at `app/config/settings.cfm`. In a fresh install of CFWheels, you'll see the follwing code:
 
 {% code title="app/config/settings.cfm" %}
 ```html
@@ -33,12 +33,12 @@ By default, CFWheels will connect to a data source `wheels.fw`. To change this d
 	*/
 
 	/*
-		You can change the "wheels.fw" value from the two functions below to set your datasource.
+		You can change the "wheels.dev" value from the two functions below to set your datasource.
 		You can change the the value for the "dataSourceName" to set a default datasource to be used throughout your application.
 		You can also change the value for the "coreTestDataSourceName" to set your testing datasource.
 	*/
-	set(coreTestDataSourceName="wheels.fw");
-	set(dataSourceName="wheels.fw");
+	set(coreTestDataSourceName="wheels.dev");
+	set(dataSourceName="wheels.dev");
     // set(dataSourceUserName="");
     // set(dataSourcePassword="");
 
@@ -50,8 +50,8 @@ By default, CFWheels will connect to a data source `wheels.fw`. To change this d
 	*/
 	set(URLRewriting="On");
 
-	// Reload your application with ?reload=true&password=wheels.fw
-	set(reloadPassword="wheels.fw");
+	// Reload your application with ?reload=true&password=wheels.dev
+	set(reloadPassword="wheels.dev");
 
 	// CLI-Appends-Here
 </cfscript>

--- a/guides/introduction/getting-started/running-local-development-servers.md
+++ b/guides/introduction/getting-started/running-local-development-servers.md
@@ -1,4 +1,4 @@
-# Running Local Development servers
+# Running Local Development Servers
 
 ### Starting a local development server
 

--- a/guides/introduction/readme/beginner-tutorial-hello-database.md
+++ b/guides/introduction/readme/beginner-tutorial-hello-database.md
@@ -20,7 +20,7 @@ You can download all the source code for this sample application from [https://g
 
 ### Setting up the Data Source
 
-By default, CFWheels will connect to a data source `wheels.fw`. To change this default behavior, open the file at `app/config/settings.cfm`. In a fresh install of CFWheels, you'll see the follwing code:
+By default, CFWheels will connect to a data source `wheels.dev`. To change this default behavior, open the file at `app/config/settings.cfm`. In a fresh install of CFWheels, you'll see the follwing code:
 
 {% code title="app/config/settings.cfm" %}
 ```html
@@ -33,12 +33,12 @@ By default, CFWheels will connect to a data source `wheels.fw`. To change this d
 	*/
 
 	/*
-		You can change the "wheels.fw" value from the two functions below to set your datasource.
+		You can change the "wheels.dev" value from the two functions below to set your datasource.
 		You can change the the value for the "dataSourceName" to set a default datasource to be used throughout your application.
 		You can also change the value for the "coreTestDataSourceName" to set your testing datasource.
 	*/
-	set(coreTestDataSourceName="wheels.fw");
-	set(dataSourceName="wheels.fw");
+	set(coreTestDataSourceName="wheels.dev");
+	set(dataSourceName="wheels.dev");
     // set(dataSourceUserName="");
     // set(dataSourcePassword="");
 
@@ -50,8 +50,8 @@ By default, CFWheels will connect to a data source `wheels.fw`. To change this d
 	*/
 	set(URLRewriting="On");
 
-	// Reload your application with ?reload=true&password=wheels.fw
-	set(reloadPassword="wheels.fw");
+	// Reload your application with ?reload=true&password=wheels.dev
+	set(reloadPassword="wheels.dev");
 
 	// CLI-Appends-Here
 </cfscript>

--- a/guides/introduction/readme/running-local-development-servers.md
+++ b/guides/introduction/readme/running-local-development-servers.md
@@ -1,4 +1,4 @@
-# Running Local Development servers
+# Running Local Development Servers
 
 ### Starting a local development server
 

--- a/guides/plugins/developing-plugins.md
+++ b/guides/plugins/developing-plugins.md
@@ -192,7 +192,7 @@ install:
   # Check it's working
   - box version
   # Install CLI: needed to repackage the plugin to a zip on install
-  - box install cfwheels-cli
+  - box install wheels-cli
   # Install Master Branch; nb, installed into folder of the git repo name, i.e neokoenig/cfwheels-ical4j
   - box install cfwheels/cfwheels
   # Install the Plugin: use gitHub path to get the absolute latest rather than the forgebox version

--- a/guides/plugins/publishing-plugins.md
+++ b/guides/plugins/publishing-plugins.md
@@ -14,7 +14,7 @@ This tutorial makes extensive use of CommandBox, GIT and the CFWheels CLI.
 
 We strongly recommend always having the latest version of [CommandBox](https://www.ortussolutions.com/products/commandbox).
 
-You'll also want the CFWheels CLI. You can install that in CommandBox via `install cfwheels-cli`. This will also update it if you've got an older version installed.
+You'll also want the CFWheels CLI. You can install that in CommandBox via `install wheels-cli`. This will also update it if you've got an older version installed.
 
 Some scripted commands also require the git CLI, although these are technically optional.
 
@@ -239,7 +239,7 @@ Set location = neokoenig/cfwheels-cli#v0.1.7
 Package is a Git repo.  Tagging...
 Tag [v0.1.7] created.
 Sending package information to ForgeBox, please wait...
-Package is alive, you can visit it here: https://www.forgebox.io/view/cfwheels-cli
+Package is alive, you can visit it here: https://www.forgebox.io/view/wheels-cli
 
 Running package script [postPublish].
 > !git push --follow-tags

--- a/guides/working-with-cfwheels/conventions.md
+++ b/guides/working-with-cfwheels/conventions.md
@@ -80,7 +80,7 @@ By default, the names of CFWheels models, model properties, database tables, and
 
 ### Data Sources
 
-By default, the datasource is set to `wheels.fw` in the `app/config/settings.cfm` file. You can change the value in the `set(dataSourceName="wheels.fw")` function to whatever you want the name of teh datasource to be. 
+By default, the datasource is set to `wheels.dev` in the `app/config/settings.cfm` file. You can change the value in the `set(dataSourceName="wheels.dev")` function to whatever you want the name of teh datasource to be.
 
 Refer to the [Configuration and Defaults](https://guides.cfwheels.org/2.5.0/v/3.0.0-snapshot/working-with-cfwheels/configuration-and-defaults) chapter for instructions on overriding data source information.
 

--- a/vendor/wheels/public/views/cli.cfm
+++ b/vendor/wheels/public/views/cli.cfm
@@ -1,6 +1,6 @@
 <!--- CLI & GUI Uses this file to talk to wheels via JSON when in maintenance/testing/development mode --->
 <cfscript>
-include "../../migrator/basefunctions.cfm";
+baseCfc = createObject("wheels.migrator.Base");
 setting showDebugOutput="no";
 migrator = application.wheels.migrator;
 try {
@@ -9,7 +9,7 @@ try {
 	data["datasource"] = application.wheels.dataSourceName;
 	data["wheelsVersion"] = application.wheels.version;
 	data["currentVersion"] = migrator.getCurrentMigrationVersion();
-	data["databaseType"] = $getDBType();
+	data["databaseType"] = baseCfc.$getDBType();
 	data["migrations"] = migrator.getAvailableMigrations();
 	data["lastVersion"] = 0;
 	data["message"] = "";

--- a/vendor/wheels/public/views/migrator.cfm
+++ b/vendor/wheels/public/views/migrator.cfm
@@ -11,7 +11,7 @@ try {
 	message = err.message;
 }
 // Get any remaining Missing Migrations
-if(currentVersion == latestVersion){
+if(structKeyExists(variables, "latestVersion") && currentVersion == latestVersion){
 	local.remainingMigrations = [];
 	for(local.migration in availableMigrations){
 		if(local.migration.status != "migrated") arrayAppend(local.remainingMigrations, local.migration);


### PR DESCRIPTION
Updated the wheels.fw in the code to wheels.dev
Updated the guides by fixing mistakes, using wheels-cli instead of cfwheels-cli and updated outdated content. Added a validation to the migrator.cfm to check if the latestVersion variable exists in the current scope. Updated the cli.cfm. Removed the include and created an object for the Base.cfc file and used that to call functions.