### PR TITLE
Fix for issue#1457

### DIFF
--- a/vendor/wheels/model/adapters/Base.cfc
+++ b/vendor/wheels/model/adapters/Base.cfc
@@ -119,7 +119,6 @@ component output=false extends="wheels.Global"{
 			if (!ListFindNoCase(local.columnList, ListFirst(arguments.primaryKey))) {
 				local.rv = {};
 				local.tbl = SpanExcluding(Right(local.sql, Len(local.sql) - 12), " ");
-				// query = $query(sql = "SELECT LAST_INSERT_ID() AS lastId", argumentCollection = arguments.queryAttributes);
 				query = $query(sql = "SELECT #arguments.primaryKey# AS lastId FROM #local.tbl# ORDER BY #arguments.primaryKey# DESC LIMIT 1", argumentCollection = arguments.queryAttributes);
 				local.rv[$generatedKey()] = query.lastId;
 				return local.rv;

--- a/vendor/wheels/model/adapters/Base.cfc
+++ b/vendor/wheels/model/adapters/Base.cfc
@@ -118,7 +118,9 @@ component output=false extends="wheels.Global"{
 			);
 			if (!ListFindNoCase(local.columnList, ListFirst(arguments.primaryKey))) {
 				local.rv = {};
-				query = $query(sql = "SELECT LAST_INSERT_ID() AS lastId", argumentCollection = arguments.queryAttributes);
+				local.tbl = SpanExcluding(Right(local.sql, Len(local.sql) - 12), " ");
+				// query = $query(sql = "SELECT LAST_INSERT_ID() AS lastId", argumentCollection = arguments.queryAttributes);
+				query = $query(sql = "SELECT #arguments.primaryKey# AS lastId FROM #local.tbl# ORDER BY #arguments.primaryKey# DESC LIMIT 1", argumentCollection = arguments.queryAttributes);
 				local.rv[$generatedKey()] = query.lastId;
 				return local.rv;
 			}

--- a/vendor/wheels/model/adapters/SQLServer.cfc
+++ b/vendor/wheels/model/adapters/SQLServer.cfc
@@ -236,7 +236,6 @@ component extends="Base" output=false {
 			if (!ListFindNoCase(local.columnList, ListFirst(arguments.primaryKey))) {
 				local.rv = {};
 				local.tbl = SpanExcluding(Right(local.sql, Len(local.sql) - 12), " ");
-				// query = $query(sql = "SELECT SCOPE_IDENTITY() AS lastId", argumentCollection = arguments.queryAttributes);
 				query = $query(sql = "SELECT TOP 1 #arguments.primaryKey# as lastId FROM #local.tbl#", argumentCollection = arguments.queryAttributes);
 				local.rv[$generatedKey()] = query.lastId;
 				return local.rv;

--- a/vendor/wheels/model/adapters/SQLServer.cfc
+++ b/vendor/wheels/model/adapters/SQLServer.cfc
@@ -235,7 +235,9 @@ component extends="Base" output=false {
 			);
 			if (!ListFindNoCase(local.columnList, ListFirst(arguments.primaryKey))) {
 				local.rv = {};
-				query = $query(sql = "SELECT SCOPE_IDENTITY() AS lastId", argumentCollection = arguments.queryAttributes);
+				local.tbl = SpanExcluding(Right(local.sql, Len(local.sql) - 12), " ");
+				// query = $query(sql = "SELECT SCOPE_IDENTITY() AS lastId", argumentCollection = arguments.queryAttributes);
+				query = $query(sql = "SELECT TOP 1 #arguments.primaryKey# as lastId FROM #local.tbl#", argumentCollection = arguments.queryAttributes);
 				local.rv[$generatedKey()] = query.lastId;
 				return local.rv;
 			}


### PR DESCRIPTION
#1457 **fix(model): support reload=true for tables with non-numeric primary keys**

Previously, Wheels used `SCOPE_IDENTITY() (SQL Server) `and `LAST_INSERT_ID() (MySQL)` to fetch the last inserted ID after create(). These functions only work for numeric primary keys.

This update replaces those queries with a fallback `SELECT` on the target table using the provided primary key column, supporting UUIDs and other non-numeric PKs.

Fixes the issue where reload=true would not populate the primary key field for GUID/UUID-based tables.