### PR TITLE
Fix for the issue #1458

### DIFF
--- a/vendor/wheels/controller/flash.cfc
+++ b/vendor/wheels/controller/flash.cfc
@@ -136,9 +136,21 @@ component {
 			local.lockName = "flashLock" & application.applicationName;
 			local.rv = $simpleLock(name = local.lockName, type = "readonly", execute = "$readFlash", executeArgs = arguments);
 		} else if ($getFlashStorage() == "cookie" && StructKeyExists(cookie, "flash")) {
-			local.rv = DeserializeJSON(cookie.flash);
+			if (isJSON(cookie.flash)) {
+				local.rv = DeserializeJSON(cookie.flash);
+			} else {
+				local.rv = {
+					"action": cookie.flash
+				};
+			}
 		} else if ($getFlashStorage() == "session" && StructKeyExists(session, "flash")) {
-			local.rv = Duplicate(session.flash);
+			if (isStruct(session.flash)) {
+				local.rv = Duplicate(session.flash);
+			} else {
+				local.rv = {
+					"action": Duplicate(session.flash)
+				};
+			}
 		}
 		return local.rv;
 	}


### PR DESCRIPTION
#1458 **fix(flash): prevent exception when cookie.flash is not valid JSON**

Previously, `$$readFlash` would throw a deserialization error if `cookie.flash` was a non-JSON string. 
This update adds a check using `isJSON()` before attempting `DeserializeJSON()`, and gracefully falls back to wrapping the raw value. It also adds a similar guard for session-based flash storage to handle unexpected non-struct values.