### PR TITLE
Fix for issue #1232

### DIFF
--- a/vendor/wheels/events/onerror/cfmlerror.cfm
+++ b/vendor/wheels/events/onerror/cfmlerror.cfm
@@ -128,7 +128,7 @@
 										<cfset local.key = local.keyList[local.k]>
 										<cfif local.k EQ local.depth>
 											<cfif StructKeyExists(local.ref, local.key)>
-												<cfset local.ref[local.key] = "[hidden]">
+												<cfset StructDelete(local.ref, local.key)>
 											</cfif>
 										<cfelse>
 											<cfif StructKeyExists(local.ref, local.key) AND isStruct(local.ref[local.key])>


### PR DESCRIPTION
#1232 fix(error-handling): support excludeFromErrorEmail for nested and bracketed keys

instead of using [hidden], we just removed that variable from that scope in the dump for the email to match the function (excludeFromErrorEmail) property.