### PR TITLE
Fix for issue # 1199

### DIFF
--- a/vendor/wheels/model/adapters/Base.cfc
+++ b/vendor/wheels/model/adapters/Base.cfc
@@ -349,7 +349,7 @@ component output=false extends="wheels.Global"{
 		if (!StructKeyExists(arguments.settings, "value")) {
 			Throw(
 				type = "Wheels.QueryParamValue",
-				message = "The value for `cfqueryparam` cannot be determined",
+				message = "The value for `cfqueryparam` cannot be determined for property `#arguments.settings.property#`.<br>This usually happens due to a syntax error in the WHERE clause (e.g., using unquoted strings or invalid values).",
 				extendedInfo = "This is usually caused by a syntax error in the `WHERE` statement, such as forgetting to quote strings for example."
 			);
 		}

--- a/vendor/wheels/model/sql.cfc
+++ b/vendor/wheels/model/sql.cfc
@@ -630,7 +630,8 @@ component {
 						type = local.params[local.i].type,
 						dataType = local.params[local.i].dataType,
 						scale = local.params[local.i].scale,
-						list = local.params[local.i].list
+						list = local.params[local.i].list,
+						property = local.column
 					};
 					ArrayAppend(local.rv, local.param);
 				}
@@ -695,6 +696,9 @@ component {
 			local.iEnd = ArrayLen(arguments.sql);
 			for (local.i = local.iEnd; local.i > 0; local.i--) {
 				if (IsStruct(arguments.sql[local.i]) && local.pos > 0) {
+					if (structKeyExists(arguments.sql[local.i], 'property') && local.originalValues[local.pos] != 'null'){
+						structDelete(arguments.sql[local.i], 'property');
+					}
 					arguments.sql[local.i].value = local.originalValues[local.pos];
 					if (local.originalValues[local.pos] == "") {
 						arguments.sql[local.i].null = true;


### PR DESCRIPTION
 #1199
Previously, the Wheels.QueryParamValue exception only included static messages with minimal context and Resolved the issue by displaying the exact attribute.