### PR TITLE
fix for issue #1400

### DIFF
--- a/vendor/wheels/model/properties.cfc
+++ b/vendor/wheels/model/properties.cfc
@@ -224,8 +224,14 @@ component {
 
 			This will return a numeric value if the primary key is Numeric and a String otherwise.
 		*/
-		if(isNumeric(local.rv)){
-			return JavaCast("int", local.rv);
+		if (isNumeric(local.rv) && !reFind("^0\d*$", local.rv)) {
+			if (local.rv <= 2147483647) {
+				return JavaCast("int", local.rv);
+			} else if (local.rv <= 9223372036854775807) {
+				return JavaCast("long", local.rv);
+			} else {
+				return local.rv;
+			}
 		} else {
 			return local.rv;
 		}

--- a/vendor/wheels/model/read.cfc
+++ b/vendor/wheels/model/read.cfc
@@ -564,6 +564,13 @@ component {
 			try {
 				local.property = ListGetAt(local.properties, local.i);
 				this[local.property] = local.query[local.property][1];
+				if (isNumeric(this[local.property]) && !reFind("^0\d*$", this[local.property])) {
+					if (this[local.property] <= 2147483647) {
+						this[local.property] =  JavaCast("int", this[local.property]);
+					} else if (this[local.property] <= 9223372036854775807) {
+						this[local.property] = JavaCast("long", this[local.property]);
+					}
+				}
 			} catch (any e) {
 				this[local.property] = "";
 			}


### PR DESCRIPTION
Fix for #1400: Prevent invalid JavaCast for large numeric primary keys

Resolved an issue where key() would incorrectly cast large numeric string primary keys (e.g., "047707948279") to an integer, causing data mismatch during reload. Now it checks for values exceeding the max `int `limit and preserves them as `strings `to avoid casting errors and maintain data integrity.