### PR TITLE
fix for issue #1166

### DIFF
--- a/guides/command-line-tools/wheels-generate-commands.md
+++ b/guides/command-line-tools/wheels-generate-commands.md
@@ -189,13 +189,13 @@ wheels generate property user isActive boolean 1
  ```
 
  All columnType options:
- biginteger,binary,boolean,date,datetime,decimal,float,integer,string,limit,text,time,timestamp,uuid
+ biginteger,binary,boolean,date,datetime,decimal,float,integer,string,text,time,timestamp,uuid
 
 | Parameter  | Required | Default | Description                                                           |
 | ---------- | -------- | ------- |---------------------------------------------------------------------- |
 | name       | true     |         | Table Name                                                            |
 | columnName | false    |         | Name of Column                                                        |
-| columnType | false    |         | Type of Column on of biginteger, binary, boolean, date, datetime, decimal, float,integer, string, limit, text, time, timestamp, uuid    |
+| columnType | false    |         | Type of Column on of biginteger, binary, boolean, date, datetime, decimal, float,integer, string, text, time, timestamp, uuid    |
 | default    | false    |         | Default Value for column                                              |
 | null       | false    |         | Whether to allow null values |
 | limit      | false    |         | character or integer size limit for column |


### PR DESCRIPTION
Fixed the typo error in the wheels guides, for the limit type mentioned in the datatype.

I just removed limit from the data types because limit is not a datatype