### PR TITLE
fix : refactor scope resolution to get in onapplicationstart.cfc

### DIFF
--- a/public/Application.cfc
+++ b/public/Application.cfc
@@ -85,7 +85,7 @@ component output="false" {
 		application.wo = wirebox.getInstance("global");
 		initArgs.path="wheels";
 		initArgs.filename="onapplicationstart";
-		application.wirebox.getInstance(name = "wheels.events.onapplicationstart", initArguments = initArgs).$init();
+		application.wirebox.getInstance(name = "wheels.events.onapplicationstart", initArguments = initArgs).$init(this);
 	}
 
 	public void function onApplicationEnd( struct ApplicationScope ) {

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -2,20 +2,13 @@ component {
 
 	property name="Mixins" inject="id:Plugins";
 
-	public void function $init() {
+	public void function $init(struct keys = {}) {
 
-		application.appDir     = expandPath("../app/");
-		application.vendorDir  = expandPath("../vendor/");
-		application.wheelsDir  = application.vendorDir & "wheels/";
-		application.wireboxDir = application.vendorDir & "wirebox/";
-		application.testboxDir = application.vendorDir & "testbox/";
+		// Embedding values from `Application.cfc`'s `this` scope into the current component's `this` scope.
+		for (key in keys) {
+			this[key] = keys[key];
+		}
 
-		// Set up the mappings for the application.
-		application.mappings["/app"]     = application.appDir;
-		application.mappings["/vendor"]  = application.vendorDir;
-		application.mappings["/wheels"]  = application.wheelsDir;
-		application.mappings["/wirebox"] = application.wireboxDir;
-		application.mappings["/testbox"] = application.testboxDir;
 		// Abort if called from incorrect file.
 		application.wo.$abortInvalidRequest();
 

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -6,7 +6,7 @@ component {
 
 		// Embedding values from `Application.cfc`'s `this` scope into the current component's `this` scope.
 		for (key in keys) {
-			this[key] = keys[key];
+			application[key] = keys[key];
 		}
 
 		// Abort if called from incorrect file.
@@ -49,7 +49,7 @@ component {
 		);
 		if (
 			Len(local.upgradeTo)
-			&& !StructKeyExists(this, "disableEngineCheck")
+			&& !StructKeyExists(application, "disableEngineCheck")
 			&& !StructKeyExists(url, "disableEngineCheck")
 		) {
 			local.type = "Wheels.EngineNotSupported";
@@ -147,8 +147,8 @@ component {
 		}
 
 		// Set datasource name to same as the folder the app resides in unless the developer has set it with the global setting already.
-		if (StructKeyExists(this, "dataSource")) {
-			application.$wheels.dataSourceName = this.dataSource;
+		if (StructKeyExists(application, "dataSource")) {
+			application.$wheels.dataSourceName = application.dataSource;
 		} else {
 			application.$wheels.dataSourceName = LCase(
 				ListLast(GetDirectoryFromPath(GetBaseTemplatePath()), Right(GetDirectoryFromPath(GetBaseTemplatePath()), 1))
@@ -325,7 +325,7 @@ component {
 		application.$wheels.resetPropertiesStructKeyCase = true;
 
 		// If session management is enabled in the application we default to storing Flash data in the session scope, if not we use a cookie.
-		if (StructKeyExists(this, "sessionManagement") && this.sessionManagement) {
+		if (StructKeyExists(application, "sessionManagement") && application.sessionManagement) {
 			application.$wheels.sessionManagement = true;
 			application.$wheels.flashStorage = "session";
 		} else {


### PR DESCRIPTION
Refactor onApplicationStart to inject Application.cfc 'this' scope into $init function

Removed direct passing of 'this' from Application.cfc to onapplicationstart.cfc Modified $init() to accept a struct argument (keys) representing Application.cfc's 'this' scope Embedded all keys from the passed-in struct into the current component's 'this' scope Cleaned up onApplicationStart by removing unnecessary argument passing