### PR TITLE
feat(model): add UUID auto-generation support for unique identifier p…

### DIFF
--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -2667,5 +2667,18 @@ component output="false" {
 		return local.norm;
 	}
 
+	/**
+	 * Generates a 36-character UUID compatible with SQL Server's uniqueidentifier.
+	 *
+	 * [section: Global Helpers]
+	 * [category: UUID Functions]
+	 *
+	 * @return A valid 36-character UUID string (e.g., 123e4567-e89b-12d3-a456-426614174000)
+	 */
+	public string function generateUUID() {
+		// Use Java UUID generator for a 36-character format
+		return createObject("java", "java.util.UUID").randomUUID().toString();
+	}
+
 	include "/app/global/functions.cfm";
 }

--- a/vendor/wheels/model/adapters/Base.cfc
+++ b/vendor/wheels/model/adapters/Base.cfc
@@ -118,8 +118,7 @@ component output=false extends="wheels.Global"{
 			);
 			if (!ListFindNoCase(local.columnList, ListFirst(arguments.primaryKey))) {
 				local.rv = {};
-				local.tbl = SpanExcluding(Right(local.sql, Len(local.sql) - 12), " ");
-				query = $query(sql = "SELECT #arguments.primaryKey# AS lastId FROM #local.tbl# ORDER BY #arguments.primaryKey# DESC LIMIT 1", argumentCollection = arguments.queryAttributes);
+				query = $query(sql = "SELECT LAST_INSERT_ID() AS lastId", argumentCollection = arguments.queryAttributes);
 				local.rv[$generatedKey()] = query.lastId;
 				return local.rv;
 			}

--- a/vendor/wheels/model/adapters/SQLServer.cfc
+++ b/vendor/wheels/model/adapters/SQLServer.cfc
@@ -235,8 +235,7 @@ component extends="Base" output=false {
 			);
 			if (!ListFindNoCase(local.columnList, ListFirst(arguments.primaryKey))) {
 				local.rv = {};
-				local.tbl = SpanExcluding(Right(local.sql, Len(local.sql) - 12), " ");
-				query = $query(sql = "SELECT TOP 1 #arguments.primaryKey# as lastId FROM #local.tbl#", argumentCollection = arguments.queryAttributes);
+				query = $query(sql = "SELECT SCOPE_IDENTITY() AS lastId", argumentCollection = arguments.queryAttributes);
 				local.rv[$generatedKey()] = query.lastId;
 				return local.rv;
 			}


### PR DESCRIPTION
#1457 **feat(model): add UUID auto-generation support for unique identifier primary keys**

- Added `generateUUID()` helper using Java's UUID generator to produce 36-character UUIDs compatible with SQL Server and other strict RDBMS types. Introduced support for detecting UUID-compatible columns. 
- Enhanced model logic to auto-generate UUID values for any missing UUID-based primary keys in both single and composite primary key scenarios. 
- Ensures uniqueness by checking for existing UUIDs in the database before assignment. 
- Reset the query to handle integer values for MySQL and SQL Server