### PR TITLE
fix: issue #1528

### DIFF
--- a/vendor/wheels/model/serialize.cfc
+++ b/vendor/wheels/model/serialize.cfc
@@ -184,6 +184,12 @@ component {
 				local.rv[local.item] = "";
 			}
 		}
+
+		for (local.column in arguments.properties.columnList) {
+			if (!StructKeyExists(local.rv, local.column)) {
+				local.rv[local.column] = arguments.properties[local.column][arguments.row];
+			}
+		}
 		return local.rv;
 	}
 


### PR DESCRIPTION
#1528 fix(core): include extra query columns in $queryRowToStruct when return Type is structs in Select for findAll()

Ensures that columns returned in custom SELECT queries (e.g., subqueries, aliases) are included in returnAs="structs" output, even if they aren't defined as model properties.