### PR TITLE
Issue/issue#1524

### DIFF
--- a/vendor/wheels/model/errors.cfc
+++ b/vendor/wheels/model/errors.cfc
@@ -93,9 +93,7 @@ component {
 			local.iEnd = ArrayLen(variables.wheels.errors);
 			for (local.i = local.iEnd; local.i >= 1; local.i--) {
 				local.error = variables.wheels.errors[local.i];
-				if (local.error.property == arguments.property && local.error.name == arguments.name) {
-					ArrayDeleteAt(variables.wheels.errors, local.i);
-				} else if (local.error.property == arguments.property && !Len(arguments.name)) {
+				if (local.error.property == arguments.property && (local.error.name == arguments.name || !Len(arguments.name))) {
 					ArrayDeleteAt(variables.wheels.errors, local.i);
 				}
 			}
@@ -134,9 +132,7 @@ component {
 		local.iEnd = ArrayLen(variables.wheels.errors);
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			local.error = variables.wheels.errors[local.i];
-			if (local.error.property == arguments.property && local.error.name == arguments.name) {
-				ArrayAppend(local.rv, variables.wheels.errors[local.i]);
-			} else if (local.error.property == arguments.property && !Len(arguments.name)) {
+			if (local.error.property == arguments.property && (local.error.name == arguments.name || !Len(arguments.name))) {
 				ArrayAppend(local.rv, variables.wheels.errors[local.i]);
 			}
 		}

--- a/vendor/wheels/model/errors.cfc
+++ b/vendor/wheels/model/errors.cfc
@@ -95,6 +95,8 @@ component {
 				local.error = variables.wheels.errors[local.i];
 				if (local.error.property == arguments.property && local.error.name == arguments.name) {
 					ArrayDeleteAt(variables.wheels.errors, local.i);
+				} else if (local.error.property == arguments.property && !Len(arguments.name)) {
+					ArrayDeleteAt(variables.wheels.errors, local.i);
 				}
 			}
 		}
@@ -133,6 +135,8 @@ component {
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			local.error = variables.wheels.errors[local.i];
 			if (local.error.property == arguments.property && local.error.name == arguments.name) {
+				ArrayAppend(local.rv, variables.wheels.errors[local.i]);
+			} else if (local.error.property == arguments.property && !Len(arguments.name)) {
 				ArrayAppend(local.rv, variables.wheels.errors[local.i]);
 			}
 		}

--- a/vendor/wheels/model/validations.cfc
+++ b/vendor/wheels/model/validations.cfc
@@ -498,7 +498,8 @@ component {
 						) {
 							addError(
 								message = $validationErrorMessage(local.propertyName, local.thisValidation.args.message),
-								property = local.propertyName
+								property = local.propertyName,
+								name = replace(local.thisValidation.method, "$validates", "", "one")
 							);
 						}
 					} else {
@@ -514,7 +515,8 @@ component {
 						) {
 							addError(
 								message = $validationErrorMessage(local.thisValidation.args.property, local.thisValidation.args.message),
-								property = local.thisValidation.args.property
+								property = local.thisValidation.args.property,
+								name = replace(local.thisValidation.method, "$validates", "", "one")
 							);
 						} else if (
 							!StructKeyExists(local.thisValidation.args, "property")

--- a/vendor/wheels/tests_testbox/specs/model/errors.cfc
+++ b/vendor/wheels/tests_testbox/specs/model/errors.cfc
@@ -68,7 +68,11 @@ component extends="testbox.system.BaseSpec" {
 
 				r = user.errorCount(property = "lastname")
 
-				expect(r).toBe(3)
+				expect(r).toBe(5)
+
+				r = user.errorCount(property = "lastname", name = 'lastname_errors')
+
+				expect(r).toBe(2)
 
 				user.clearErrors(property = "lastname")
 				r = user.errorCount(property = "lastname")
@@ -85,7 +89,7 @@ component extends="testbox.system.BaseSpec" {
 
 				r = user.hasErrors(property = "lastname", name = "lastname_errors")
 
-				expect(r).toBeTrue()
+				expect(r).toBeFalse()
 			})
 
 			it("give error information for lastname property name provided", () => {
@@ -122,7 +126,7 @@ component extends="testbox.system.BaseSpec" {
 
 				r = user.errorCount(property = "firstname")
 
-				expect(r).toBe(2)
+				expect(r).toBe(5)
 
 				user.clearErrors(property = "firstname")
 				r = user.errorCount(property = "firstname")
@@ -139,7 +143,7 @@ component extends="testbox.system.BaseSpec" {
 
 				r = user.hasErrors(property = "firstname", name = "firstname_errors")
 
-				expect(r).toBeTrue()
+				expect(r).toBeFalse()
 			})
 
 			it("give error information for firstname property name provided", () => {
@@ -290,32 +294,32 @@ component extends="testbox.system.BaseSpec" {
 				r = user.hasErrors(name = "base_errorsx")
 
 				expect(r).toBeFalse()
-				
+
 				r = user.errorCount(name = "base_errorsx")
 
 				expect(r).toBe(0)
-				
+
 				user.clearErrors(name = "base_errorsx")
 				r = user.hasErrors(name = "base_errors")
 
 				expect(r).toBeTrue()
-				
+
 				r = user.hasErrors(property = "lastname")
 
 				expect(r).toBeTrue()
-				
+
 				r = user.hasErrors(property = "lastname", name = "lastname_errors")
 
 				expect(r).toBeTrue()
-				
+
 				r = user.hasErrors(property = "firstname")
 
 				expect(r).toBeTrue()
-				
+
 				r = user.hasErrors(property = "firstname", name = "firstname_errors")
 
 				expect(r).toBeTrue()
-				
+
 			})
 		})
 	}


### PR DESCRIPTION
#1524 feat(validation): add named error support and improve error filtering

Assigned `name` properties to all validatesX validation rules (e.g., PresenceOf for validatesPresenceOf, UniquenessOf for validatesUniquenessOf).

Updated `errorsOn()` to support conditional filtering:
 If a `name` is provided, only return errors matching both `property` and `name`.
 If `name` is not provided, return all errors for the given `property`.
Applied similar conditional logic in `clearErrors()` to allow targeted clearing of named validations.

This enables more precise error inspection and handling in views and controllers.

Also updated the unit tests as per the new filtering.