### PR TITLE
fix for issue #1523

### DIFF
--- a/vendor/wheels/view/links.cfc
+++ b/vendor/wheels/view/links.cfc
@@ -242,6 +242,9 @@ component {
 		}
 
 		$args(name = "paginationLinks", args = arguments);
+		if (StructKeyExists(arguments, "params") && isStruct(arguments.params)) {
+			arguments.params = $paramsToQueryString(arguments.params);
+		}
 		local.skipArgs = "windowSize,alwaysShowAnchors,anchorDivider,linkToCurrentPage,prepend,append,prependToPage,addActiveClassToPrependedParent,prependOnFirst,prependOnAnchor,appendToPage,appendOnLast,appendOnAnchor,classForCurrent,handle,name,showSinglePage,pageNumberAsParam";
 		local.linkToArguments = Duplicate(arguments);
 		local.iEnd = ListLen(local.skipArgs);
@@ -486,4 +489,19 @@ component {
 		}
 		return arguments.text;
 	}
+
+	public string function $paramsToQueryString(required any params) {
+		if (!isStruct(arguments.params)) {
+			return arguments.params;
+		}
+		var queryString = "";
+		for (key in arguments.params) {
+			var value = arguments.params[key];
+			if (!isNull(value) && value != "") {
+				queryString &= (Len(queryString) ? "&" : "") & key & "=" & encodeForUrl(value);
+			}
+		}
+		return queryString;
+	}
+
 }


### PR DESCRIPTION
#1523 fix(paginationLinks): normalize `params` struct to query string early

Moved struct-to-string conversion of `arguments.params` to the top of the `paginationLinks()` function. This helps developer to pass a complete struct of variables instead of all variable separately.

Introduced new helper function `paramsToQueryString()` to convert a struct to a query string format using `encodeForUrl()`.