### PR TITLE
fix for issue #1385

### DIFF
--- a/vendor/wheels/model/onmissingmethod.cfc
+++ b/vendor/wheels/model/onmissingmethod.cfc
@@ -323,7 +323,11 @@ component {
 						$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = local.info.foreignKey);
 					}
 				} else if (local.info.type == "hasMany") {
-					local.where = $keyWhereString(properties = local.info.foreignKey, keys = primaryKeys());
+					if (structKeyExists(local.info, "joinKey") AND Len(local.info.joinKey) AND local.info.joinKey NEQ primaryKeys()) {
+						local.where = $keyWhereString(properties = local.info.foreignKey, keys = local.info.joinKey);
+					} else {
+						local.where = $keyWhereString(properties = local.info.foreignKey, keys = primaryKeys());
+					}
 					if (StructKeyExists(arguments.missingMethodArguments, "where") && Len(arguments.missingMethodArguments.where)) {
 						local.where = "(#local.where#) AND (#arguments.missingMethodArguments.where#)";
 					}


### PR DESCRIPTION
#1385 fix(associations): allow joinKey to work with non-primary key columns in hasMany

Previously, hasMany associations always assumed the joinKey was the primary key, even when explicitly set to a different column.

This commit adds logic to check if `joinKey` exists, is not null, and is not equal to the primary key before constructing the WHERE clause. This ensures the correct association behavior when `joinKey` points to a non-PK column.