### PR TITLE
fix: fix for issue #1197

### DIFF
--- a/vendor/wheels/controller/rendering.cfc
+++ b/vendor/wheels/controller/rendering.cfc
@@ -295,7 +295,7 @@ component {
 	 */
 	public string function response() {
 		if ($performedRender()) {
-			return Trim(variables.$instance.response);
+			return variables.$instance.response;
 		} else {
 			return "";
 		}

--- a/vendor/wheels/tests_testbox/specs/controller/rendering.cfc
+++ b/vendor/wheels/tests_testbox/specs/controller/rendering.cfc
@@ -70,7 +70,7 @@ component extends="testbox.system.BaseSpec" {
 			it("is rendering without layout", () => {
 				_controller.renderView(layout = false)
 
-				expect(_controller.response()).toBe("view template content")
+				expect(trim(_controller.response())).toBe("view template content")
 			})
 
 			it("is rendering with default layout in controller folder", () => {


### PR DESCRIPTION

#1197 Removed Trim() from the controller's response() function to allow for exact output formatting.

This enables support for protocols where trailing whitespace is significant (e.g., Server-Sent Events) and aligns with separation of concerns.

Developers are now responsible for trimming response content if needed.