### PR TITLE
fix(feat): fix for issue #1047

### DIFF
--- a/vendor/wheels/controller/caching.cfc
+++ b/vendor/wheels/controller/caching.cfc
@@ -46,14 +46,14 @@ component {
 		}
 
 		// Only remove specific actions from the cache list
-		var filtered = [];
-		for (var i = 1; i <= ArrayLen(variables.$class.cachableActions); i++) {
-			var a = variables.$class.cachableActions[i];
-			if (!ListFindNoCase(arguments.action, a.action)) {
-				ArrayAppend(filtered, a);
+		local.filtered = [];
+		for (local.i = 1; local.i <= ArrayLen(variables.$class.cachableActions); local.i++) {
+			local.cachableAction = variables.$class.cachableActions[i];
+			if (!ListFindNoCase(arguments.action, local.cachableAction.action)) {
+				ArrayAppend(local.filtered, local.cachableAction);
 			}
 		}
-		variables.$class.cachableActions = filtered;
+		variables.$class.cachableActions = local.filtered;
 	}
 
 	/**

--- a/vendor/wheels/controller/caching.cfc
+++ b/vendor/wheels/controller/caching.cfc
@@ -33,6 +33,30 @@ component {
 	}
 
 	/**
+	 * Clears cached action metadata for current controller.
+	 * 
+	 * [section: Controller]
+	 * [category: Configuration Functions]
+	 *
+	 * @action Optional. A single action or list of actions to clear. If not provided, clears all cached actions of current controller.
+	 */
+	public void function clearCachableActions(string action = "") {
+		if (!Len(arguments.action)) {
+			return $clearCachableActions();
+		}
+
+		// Only remove specific actions from the cache list
+		var filtered = [];
+		for (var i = 1; i <= ArrayLen(variables.$class.cachableActions); i++) {
+			var a = variables.$class.cachableActions[i];
+			if (!ListFindNoCase(arguments.action, a.action)) {
+				ArrayAppend(filtered, a);
+			}
+		}
+		variables.$class.cachableActions = filtered;
+	}
+
+	/**
 	 * Called from the caches function.
 	 */
 	public void function $addCachableAction(required struct action) {

--- a/vendor/wheels/tests_testbox/specs/controller/caching.cfc
+++ b/vendor/wheels/tests_testbox/specs/controller/caching.cfc
@@ -139,5 +139,61 @@ component extends="testbox.system.BaseSpec" {
 				expect(r.static).toBeTrue()
 			})
 		})
+
+		describe("Tests for clearCachableActions(action)", () => {
+
+			beforeEach(() => {
+				_controller = application.wo.controller(name = "dummy")
+				_controller.$clearCachableActions()
+			})
+
+			it("clears a specific cached action when only one is matched", () => {
+				_controller.caches(actions = "dummy1,dummy2", time = 10, static = true)
+				_controller.clearCachableActions("dummy1")
+				r = _controller.$cachableActions()
+
+				expect(r).toHaveLength(1)
+				expect(r[1].action).toBe("dummy2")
+			})
+
+			it("clears multiple specified cached actions", () => {
+				_controller.caches(actions = "dummy1,dummy2,dummy3", time = 5)
+				_controller.clearCachableActions("dummy1,dummy3")
+				r = _controller.$cachableActions()
+
+				expect(r).toHaveLength(1)
+				expect(r[1].action).toBe("dummy2")
+			})
+
+			it("clears nothing if specified action is not cached", () => {
+				_controller.caches(actions = "dummy1,dummy2")
+
+				_controller.clearCachableActions("doesNotExist")
+
+				r = _controller.$cachableActions()
+
+				expect(r).toHaveLength(2)
+				expect(r[1].action).toBe("dummy1")
+				expect(r[2].action).toBe("dummy2")
+			})
+
+			it("is case-insensitive when matching actions", () => {
+				_controller.caches(actions = "Dummy1,Dummy2")
+				_controller.clearCachableActions("dummy1")
+				r = _controller.$cachableActions()
+
+				expect(r).toHaveLength(1)
+				expect(r[1].action).toBe("Dummy2")
+			})
+
+			it("clears all when no action is passed (backward compatibility)", () => {
+				_controller.caches(actions = "dummy1,dummy2")
+				_controller.clearCachableActions()
+				r = _controller.$cachableActions()
+
+				expect(r).toHaveLength(0)
+			})
+		})
+
 	}
 }


### PR DESCRIPTION
feat(controller): add public clearCachableActions() function with optional action filter

- Exposes clearCachableActions() to allow clearing of specific or all cached controller actions.
- Supports single or comma-delimited list of actions to selectively clear cache metadata.
- Retains backward compatibility by clearing all if no argument is provided.
- Includes comprehensive TestBox test cases for all usage scenarios.