### PR TITLE
Fix wheels path resolution to avoid folder name conflicts

### DIFF
--- a/vendor/wheels/controller/miscellaneous.cfc
+++ b/vendor/wheels/controller/miscellaneous.cfc
@@ -190,12 +190,21 @@ component {
 			// https://github.com/cfwheels/cfwheels/issues/873 Don't expand path if already contains root
 			if (local.fullPath DOES NOT CONTAIN Replace(local.root, "\", "/", "all")) {
 				//added this section for the "/wheels" mapping to work correctly
-				if(local.fullPath CONTAINS "/wheels"){
-					local.fullPath = ExpandPath(mid(local.fullPath,findNoCase("/wheels", local.fullPath),len(local.fullPath)-findNoCase("/wheels", local.fullPath)+1));
-					local.file = ListLast(local.fullPath, "\");
-					local.directory = Reverse(ListRest(Reverse(local.fullPath), "\"));
-				}
-				else{
+				if (local.fullPath CONTAINS "/wheels") {
+					local.startPos = findNoCase("/wheels", local.fullPath);
+					
+					// Prefer /vendor/wheels if available
+					local.vendorWheelsPos = findNoCase("/vendor/wheels/", local.fullPath);
+					if (local.vendorWheelsPos > 0) {
+						local.startPos = local.vendorWheelsPos + len("/vendor");
+					}
+
+					if (local.startPos > 0) {
+						local.fullPath = ExpandPath(mid(local.fullPath, local.startPos, len(local.fullPath) - local.startPos + 1));
+						local.file = listLast(local.fullPath, "\");
+						local.directory = reverse(listRest(reverse(local.fullPath), "\"));
+					}
+				} else{
 					local.fullPath = ExpandPath(local.fullPath);
 					local.fullPath = Replace(local.fullPath, "\", "/", "all");
 					local.file = ListLast(local.fullPath, "/");


### PR DESCRIPTION
Updated the sendfile function to correctly resolve paths to the `/wheels` folder, prioritizing `/vendor/wheels` when available. This prevents conflicts when the project folder is also named 'wheels'.