### PR TITLE
Prevent for-index variable leakage.

### DIFF
--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -1537,7 +1537,7 @@ component output="false" {
 			local.serverNameReversed = ListToArray(Reverse(SpanExcluding(Reverse(local.originfull), ".")));
 			local.wildcardPassed = true;
 			// Check each part with corresponding part in other array
-			for (i = 1; i LTE ArrayLen(local.domainReversed); i = i + 1) {
+			for (local.i = 1; i LTE ArrayLen(local.domainReversed); i = i + 1) {
 				if (local.domainReversed[i] != local.serverNameReversed[i] && local.domainReversed[i] DOES NOT CONTAIN '*') {
 					local.wildcardPassed = false;
 					break;
@@ -2618,7 +2618,7 @@ component output="false" {
 		local.insideFunction = false;
 		local.bracketCount = 0;
 
-		for (i = 1; i <= len(arguments.list); i++) {
+		for (local.i = 1; i <= len(arguments.list); i++) {
 			local.char = mid(arguments.list, i, 1);
 
 			// Check if we are entering or exiting a function's parentheses

--- a/vendor/wheels/Plugins.cfc
+++ b/vendor/wheels/Plugins.cfc
@@ -41,7 +41,7 @@ component output="false" extends="wheels.Global"{
 		local.plugins = {};
 		local.folders = $folders();
 		// Within plugin folders, grab info about each plugin and package up into a struct.
-		for (i = 1; i <= local.folders.recordCount; i++) {
+		for (local.i = 1; i <= local.folders.recordCount; i++) {
 			// For *nix, we need a case-sensitive name for the plugin component, so we must reference its CFC file name.
 			local.subfolder = DirectoryList("#local.folders["directory"][i]#/#local.folders["name"][i]#", false, "query");
 			local.pluginCfc = $query(
@@ -62,7 +62,7 @@ component output="false" extends="wheels.Global"{
 		// get all plugin zip files
 		local.plugins = {};
 		local.files = $files();
-		for (i = 1; i <= local.files.recordCount; i++) {
+		for (local.i = 1; i <= local.files.recordCount; i++) {
 			local.name = ListFirst(local.files["name"][i], "-");
 			local.temp = {};
 			local.temp.file = $fullPathToPlugin(local.files["name"][i]);

--- a/vendor/wheels/model/adapters/H2.cfc
+++ b/vendor/wheels/model/adapters/H2.cfc
@@ -166,7 +166,7 @@ component extends="Base" output=false {
 		}
 		arguments.type = "columns";
 		local.columns = $dbinfo(argumentCollection = arguments);
-		for (i = 1; i <= local.columns.recordCount; i++) {
+		for (local.i = 1; i <= local.columns.recordCount; i++) {
 			if (ListFind(pkList, local.columns["COLUMN_NAME"][i])) {
 				QuerySetCell(local.columns, "IS_PRIMARYKEY", "YES", i);
 			}

--- a/vendor/wheels/public/helpers.cfm
+++ b/vendor/wheels/public/helpers.cfm
@@ -291,9 +291,9 @@ struct function $returnInternalDocumentation(required array documentScope, requi
 	local.rv["sections"] = $populateDocSections(local.rv.functions);
 
 	// Look for [see:something] tags to pull in other function param hints
-	for (i = 1; i LTE ArrayLen(local.rv["functions"]); i = i + 1) {
+	for (local.i = 1; i LTE ArrayLen(local.rv["functions"]); i = i + 1) {
 		if (StructKeyExists(local.rv["functions"][i], "parameters")) {
-			for (p = 1; p LTE ArrayLen(local.rv["functions"][i]["parameters"]); p = p + 1) {
+			for (local.p = 1; p LTE ArrayLen(local.rv["functions"][i]["parameters"]); p = p + 1) {
 				if (StructKeyExists(local.rv["functions"][i]["parameters"][p], "hint")) {
 					local.rv["functions"][i]["parameters"][p]["hint"] = $replaceSeeTag(
 						local.rv["functions"][i]["parameters"][p]["hint"],


### PR DESCRIPTION
The missing `var`|`local.` in `$splitOutsideFunctions()` was causing a race condition when trying to use a `model()` call inside an asynchronous iteration. The lack of local scoping was causing the concurrent threads to clobber each other's SQL statements. When I was looking for this issue, I found few others that looked suspicious.