### PR TITLE
fix: Issue #933

### DIFF
--- a/guides/command-line-tools/cli-guides/migrations.md
+++ b/guides/command-line-tools/cli-guides/migrations.md
@@ -85,6 +85,8 @@ function up() {
         // Column types
         t.string("name", limit=100);
         t.text("description");
+        t.text("content", size="mediumtext"); // MySQL only: mediumtext (16MB)
+        t.text("longDescription", size="longtext"); // MySQL only: longtext (4GB)
         t.integer("quantity");
         t.bigInteger("views");
         t.float("weight");

--- a/guides/command-line-tools/commands/database/dbmigrate-create-table.md
+++ b/guides/command-line-tools/commands/database/dbmigrate-create-table.md
@@ -149,6 +149,10 @@ component extends="wheels.migrator.Migration" {
             t.string(columnName="name");
             t.integer(columnName="age");
             t.boolean(columnName="active", default=true);
+            t.text(columnName="description");
+            // MySQL only: use size parameter for larger text fields
+            t.text(columnName="content", size="mediumtext"); // 16MB
+            t.text(columnName="largeContent", size="longtext"); // 4GB
             t.timestamps();
             t.create();
         }

--- a/guides/database-interaction-through-models/database-migrations/README.md
+++ b/guides/database-interaction-through-models/database-migrations/README.md
@@ -173,6 +173,8 @@ For instance, here's the mySQL variants:
 * integer = INT&#x20;
 * string = VARCHAR',limit=255&#x20;
 * text = TEXT&#x20;
+* text (size="mediumtext") = MEDIUMTEXT (16MB)&#x20;
+* text (size="longtext") = LONGTEXT (4GB)&#x20;
 * time = TIME&#x20;
 * timestamp = TIMESTAMP&#x20;
 * uuid = VARBINARY', limit=16

--- a/vendor/wheels/migrator/TableDefinition.cfc
+++ b/vendor/wheels/migrator/TableDefinition.cfc
@@ -86,6 +86,19 @@ component extends="Base" {
 		arguments.adapter = this.adapter;
 		arguments.name = arguments.columnName;
 		arguments.type = arguments.columnType;
+		
+		if (StructKeyExists(arguments, "size") 
+			&& arguments.columnType == "text" 
+			&& arguments.adapter.adapterName() == "MySQL") {
+
+			local.size = LCase(arguments.size);
+			if (ListFindNoCase("mediumtext,longtext", local.size)) {
+				arguments.type = local.size;
+			} else {
+				arguments.type = "text";
+			}
+		}
+
 		local.column = CreateObject("component", "ColumnDefinition").init(argumentCollection = arguments);
 		ArrayAppend(this.columns, local.column);
 		return this;
@@ -262,12 +275,19 @@ component extends="Base" {
 	}
 
 	/**
-	 * adds text columns to table definition
+	 * Adds text columns to table definition.
+	 *
+	 * In MySQL databases, you can specify different text sizes:
+	 * - Regular TEXT (65KB) - default when no size is specified
+	 * - MEDIUMTEXT (16MB) - specify size="mediumtext"
+	 * - LONGTEXT (4GB) - specify size="longtext"
+	 *
+	 * For other database engines, the size parameter is ignored and the default text type is used.
 	 *
 	 * [section: Migrator]
 	 * [category: Table Definition Functions]
 	 */
-	public any function text(string columnNames, string default, boolean null) {
+	public any function text(string columnNames, string default, boolean null, string size) {
 		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
 		arguments.columnType = "text";
 		local.iEnd = ListLen(arguments.columnNames);

--- a/vendor/wheels/migrator/adapters/MySQL.cfc
+++ b/vendor/wheels/migrator/adapters/MySQL.cfc
@@ -11,6 +11,8 @@ component extends="Abstract" {
 	variables.sqlTypes['integer'] = {name = 'INT'};
 	variables.sqlTypes['string'] = {name = 'VARCHAR', limit = 255};
 	variables.sqlTypes['text'] = {name = 'TEXT'};
+	variables.sqlTypes['mediumtext'] = {name = 'MEDIUMTEXT'};
+	variables.sqlTypes['longtext'] = {name = 'LONGTEXT'};
 	variables.sqlTypes['time'] = {name = 'TIME'};
 	variables.sqlTypes['timestamp'] = {name = 'TIMESTAMP'};
 	variables.sqlTypes['uuid'] = {name = 'VARBINARY', limit = 16};
@@ -68,7 +70,7 @@ component extends="Abstract" {
 	 * MySQL text fields can't have default
 	 */
 	public boolean function optionsIncludeDefault(string type, string default = "", boolean null = true) {
-		if (ListFindNoCase("text,float", arguments.type)) {
+		if (ListFindNoCase("text,mediumtext,longtext,float", arguments.type)) {
 			return false;
 		} else {
 			return true;

--- a/vendor/wheels/tests_testbox/specs/migrator/migration/mysqlTextSizes.cfc
+++ b/vendor/wheels/tests_testbox/specs/migrator/migration/mysqlTextSizes.cfc
@@ -1,0 +1,316 @@
+component extends="testbox.system.BaseSpec" {
+
+	function beforeAll() {
+		migration = CreateObject("component", "wheels.migrator.Migration").init();
+		originalMigratorObjectCase = Duplicate(application.wheels.migratorObjectCase);
+	}
+
+	function afterAll() {
+		application.wheels.migratorObjectCase = originalMigratorObjectCase;
+	}
+
+	// Helper functions
+	private boolean function isMySQL() {
+		return migration.adapter.adapterName() == "MySQL";
+	}
+
+	private array function getTextType(string size = "") {
+		switch (LCase(arguments.size)) {
+			case "mediumtext":
+				return ["MEDIUMTEXT"];
+			case "longtext":
+				return ["LONGTEXT"];
+			default:
+				return ["TEXT"];
+		}
+	}
+
+	function run() {
+
+		g = application.wo
+
+		describe("MySQL Text Size Support Tests", function() {
+			
+			it("Creates a default text column", function() {
+				if (!isMySQL()) {
+					return true;
+				}
+
+				tableName = "dbm_mysql_text_tests";
+				columnName = "defaultTextColumn";
+				t = migration.createTable(name = tableName, force = true);
+				t.text(columnName = columnName);
+				t.create();
+
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = tableName, type = "columns");
+				actual = ListToArray(ValueList(info.TYPE_NAME))[2];
+				migration.dropTable(tableName);
+
+				expected = getTextType();
+
+				expect(ArrayContainsNoCase(expected, actual)).toBeTrue();
+			});
+
+			it("Creates a medium text column", function() {
+				if (!isMySQL()) {
+					return true;
+				}
+
+				tableName = "dbm_mysql_text_tests";
+				columnName = "mediumTextColumn";
+				t = migration.createTable(name = tableName, force = true);
+				t.text(columnName = columnName, size = "mediumtext");
+				t.create();
+
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = tableName, type = "columns");
+				actual = ListToArray(ValueList(info.TYPE_NAME))[2];
+				migration.dropTable(tableName);
+
+				expected = getTextType("mediumtext");
+
+				expect(ArrayContainsNoCase(expected, actual)).toBeTrue();
+			});
+
+			it("Creates a long text column", function() {
+				if (!isMySQL()) {
+					return true;
+				}
+
+				tableName = "dbm_mysql_text_tests";
+				columnName = "longTextColumn";
+				t = migration.createTable(name = tableName, force = true);
+				t.text(columnName = columnName, size = "longtext");
+				t.create();
+
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = tableName, type = "columns");
+				actual = ListToArray(ValueList(info.TYPE_NAME))[2];
+				migration.dropTable(tableName);
+
+				expected = getTextType("longtext");
+
+				expect(ArrayContainsNoCase(expected, actual)).toBeTrue();
+			});
+
+			it("Creates multiple text columns with different sizes", function() {
+				if (!isMySQL()) {
+					return true;
+				}
+
+				tableName = "dbm_mysql_text_tests";
+				t = migration.createTable(name = tableName, force = true);
+				t.text(columnName = "defaultTextCol");
+				t.text(columnName = "mediumTextCol", size = "mediumtext");
+				t.text(columnName = "longTextCol", size = "longtext");
+				t.create();
+
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = tableName, type = "columns");
+				actual = ListToArray(ValueList(info.TYPE_NAME));
+				migration.dropTable(tableName);
+
+				// The first column is the primary key
+				expect(ArrayContainsNoCase(getTextType(), actual[2])).toBeTrue();
+				expect(ArrayContainsNoCase(getTextType("mediumtext"), actual[3])).toBeTrue();
+				expect(ArrayContainsNoCase(getTextType("longtext"), actual[4])).toBeTrue();
+			});
+
+			it("Creates multiple text columns with the same size", function() {
+				if (!isMySQL()) {
+					return true;
+				}
+
+				tableName = "dbm_mysql_text_tests";
+				columnNames = "textA,textB";
+				t = migration.createTable(name = tableName, force = true);
+				t.text(columnNames = columnNames, size = "mediumtext");
+				t.create();
+
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = tableName, type = "columns");
+				actual = ListToArray(ValueList(info.TYPE_NAME));
+				migration.dropTable(tableName);
+
+				expected = getTextType("mediumtext");
+
+				expect(ArrayContainsNoCase(expected, actual[2])).toBeTrue();
+				expect(ArrayContainsNoCase(expected, actual[3])).toBeTrue();
+			});
+
+			it("Defaults to TEXT when invalid size is provided", function() {
+				if (!isMySQL()) {
+					return true;
+				}
+
+				tableName = "dbm_mysql_text_tests";
+				columnName = "invalidSizeColumn";
+				t = migration.createTable(name = tableName, force = true);
+				t.text(columnName = columnName, size = "invalid");
+				t.create();
+
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = tableName, type = "columns");
+				actual = ListToArray(ValueList(info.TYPE_NAME))[2];
+				migration.dropTable(tableName);
+
+				expected = getTextType();
+
+				expect(ArrayContainsNoCase(expected, actual)).toBeTrue();
+			});
+
+			it("Defaults to TEXT when empty size is provided", function() {
+				if (!isMySQL()) {
+					return true;
+				}
+
+				tableName = "dbm_mysql_text_tests";
+				columnName = "emptySizeColumn";
+				t = migration.createTable(name = tableName, force = true);
+				t.text(columnName = columnName, size = "");
+				t.create();
+
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = tableName, type = "columns");
+				actual = ListToArray(ValueList(info.TYPE_NAME))[2];
+				migration.dropTable(tableName);
+
+				expected = getTextType();
+
+				expect(ArrayContainsNoCase(expected, actual)).toBeTrue();
+			});
+
+			it("Creates nullable text columns of all sizes", function() {
+				if (!isMySQL()) {
+					return true;
+				}
+
+				tableName = "dbm_mysql_text_tests";
+				t = migration.createTable(name = tableName, force = true);
+				t.text(columnName = "nullableText", null = true);
+				t.text(columnName = "mediumNullableText", null = true, size = "mediumtext");
+				t.text(columnName = "longNullableText", null = true, size = "longtext");
+				t.create();
+
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = tableName, type = "columns");
+				migration.dropTable(tableName);
+
+				// Filter only our text columns
+				textCols = [];
+				for (var col in info) {
+					if (ListFind("nullableText,mediumNullableText,longNullableText", col.COLUMN_NAME)) {
+						ArrayAppend(textCols, col);
+					}
+				}
+
+				// All should be nullable
+				for (var col in textCols) {
+					expect(col.IS_NULLABLE).toBeTrue();
+				}
+			});
+
+			it("Creates non-nullable text columns of all sizes", function() {
+				if (!isMySQL()) {
+					return true;
+				}
+
+				tableName = "dbm_mysql_text_tests";
+				t = migration.createTable(name = tableName, force = true);
+				t.text(columnName = "nonNullText", null = false);
+				t.text(columnName = "mediumNonNullText", null = false, size = "mediumtext");
+				t.text(columnName = "longNonNullText", null = false, size = "longtext");
+				t.create();
+
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = tableName, type = "columns");
+				migration.dropTable(tableName);
+
+				// Filter only our text columns
+				textCols = [];
+				for (var col in info) {
+					if (ListFind("nonNullText,mediumNonNullText,longNonNullText", col.COLUMN_NAME)) {
+						ArrayAppend(textCols, col);
+					}
+				}
+
+				// All should be non-nullable
+				for (var col in textCols) {
+					expect(col.IS_NULLABLE).toBeFalse();
+				}
+			});
+
+			it("Changes a column from TEXT to MEDIUMTEXT", function() {
+				if (!isMySQL()) {
+					return true;
+				}
+
+				tableName = "dbm_mysql_text_tests";
+				columnName = "textToMedium";
+				
+				// Create table with regular text column
+				t = migration.createTable(name = tableName, force = true);
+				t.text(columnName = columnName);
+				t.create();
+				
+				// Change to mediumtext
+				migration.changeColumn(
+					table = tableName,
+					columnName = columnName,
+					columnType = "text",
+					size = "mediumtext"
+				);
+				
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = tableName, type = "columns");
+				
+				// Get column info
+				columnInfo = "";
+				for (var col in info) {
+					if (col.COLUMN_NAME == columnName) {
+						columnInfo = col;
+						break;
+					}
+				}
+				
+				migration.dropTable(tableName);
+				
+				expected = getTextType("mediumtext");
+				actual = columnInfo.TYPE_NAME;
+				
+				expect(ArrayContainsNoCase(expected, actual)).toBeTrue();
+			});
+
+			it("Changes a column from MEDIUMTEXT to LONGTEXT", function() {
+				if (!isMySQL()) {
+					return true;
+				}
+
+				tableName = "dbm_mysql_text_tests";
+				columnName = "mediumToLong";
+				
+				// Create table with medium text column
+				t = migration.createTable(name = tableName, force = true);
+				t.text(columnName = columnName, size = "mediumtext");
+				t.create();
+				
+				// Change to longtext
+				migration.changeColumn(
+					table = tableName,
+					columnName = columnName,
+					columnType = "text",
+					size = "longtext"
+				);
+				
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = tableName, type = "columns");
+				
+				// Get column info
+				columnInfo = "";
+				for (var col in info) {
+					if (col.COLUMN_NAME == columnName) {
+						columnInfo = col;
+						break;
+					}
+				}
+				
+				migration.dropTable(tableName);
+				
+				expected = getTextType("longtext");
+				actual = columnInfo.TYPE_NAME;
+				
+				expect(ArrayContainsNoCase(expected, actual)).toBeTrue();
+			});
+		});
+	}
+}


### PR DESCRIPTION
feat(migrations): add mediumtext and longtext support for MySQL text columns only

- Allow specifying a size parameter when adding text columns in migrations.
- Support "mediumtext" (16MB) and "longtext" (4GB) for MySQL databases.
- fallback to standard "text" for other databases.
- This lets you store larger amounts of text, for example large JSON or debug messages.
- Also updated guides and test cases for