### PR TITLE
Fix: Removed syntax error and changed path

### DIFF
--- a/cli/src/commands/wheels/deps.cfc
+++ b/cli/src/commands/wheels/deps.cfc
@@ -363,6 +363,7 @@ component extends="base" {
                     }
                 } catch (any e) {
                     // Ignore errors
+                } 
             }
             
             // Check installed modules
@@ -490,7 +491,7 @@ component extends="base" {
      */
     private boolean function checkIfInstalled(required string packageName) {
         // Check modules directory
-        local.modulesPath = fileSystemUtil.resolvePath("vendor");
+        local.modulesPath = fileSystemUtil.resolvePath("core");
         if (directoryExists(local.modulesPath)) {
             // Simple name check
             local.simpleName = listLast(arguments.packageName, ":");


### PR DESCRIPTION
Error in Command "deps install plugin_name" : Fixed a missing closing brace } and updated path from "vendor" to "core"