### PR TITLE
Fix: Namespaced Select Alias

### DIFF
--- a/core/src/wheels/model/sql.cfc
+++ b/core/src/wheels/model/sql.cfc
@@ -342,6 +342,13 @@ component {
 			includeSoftDeletes = arguments.includeSoftDeletes,
 			returnAs = arguments.returnAs
 		);
+		
+		// Look for " AS " followed by text containing multiple dots (namespaced aliases)
+		if (Find(" AS ", local.rv)) {
+			// Wrap column aliases that contain multiple dots with double quotes (ANSI SQL standard)
+			local.rv = REReplace(local.rv, " AS ([^,\s]+\.[^,\s]*\.[^,\s]*)", " AS ""\1""", "all");
+		}
+		
 		local.rv = "SELECT " & local.rv;
 		return local.rv;
 	}


### PR DESCRIPTION
fix(sql): ensure alias compatibility for namespaced fields across all DBs

Wrapped column aliases containing multiple dots (e.g., table.namespace.field) in double quotes to ensure compatibility across all databases.

This resolves issues with alias parsing in SELECT clauses for nested object mappings in the ORM.