### PR TITLE
Fix: SYNC images to centralized Server

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Sync to shared docs folder
         run: |
           rsync -av --no-perms --no-owner --no-group --del docs/src/ /mnt/shared/docs/3.0.0/guides
-          rsync -av --no-perms --no-owner --no-group --del docs/src/.gitbook/assets/ /mnt/shared/public/images
+          rsync -av --no-perms --no-owner --no-group docs/src/.gitbook/assets/ /mnt/shared/public/images
 


### PR DESCRIPTION
updated the image sync command in the docs-sync.yml file so that older images are not deleted in the server when the images are synced