### PR TITLE
Change release candidate version format from -rc.1 to -SNAPSHOT.rc.1

### DIFF
--- a/core/box.json
+++ b/core/box.json
@@ -1,5 +1,5 @@
 {
     "name": "wheels-core",
-    "version": "3.0.0-rc.1",
+    "version": "3.0.0-SNAPSHOT.rc.1",
     "location": "https://github.com/cfwheels/cfwheels/tree/3.0/core"
 }

--- a/templates/base/box.json
+++ b/templates/base/box.json
@@ -1,5 +1,5 @@
 {
     "name": "wheels-base-template",
-    "version": "3.0.0-rc.1",
+    "version": "3.0.0-SNAPSHOT.rc.1",
     "location": "https://github.com/wheels-dev/wheels/tree/3.0/templates/base"
 }

--- a/templates/base/src/box.json
+++ b/templates/base/src/box.json
@@ -1,6 +1,6 @@
 {
     "name":"Wheels.fw",
-    "version":"3.0.0-rc.1",
+    "version":"3.0.0-SNAPSHOT.rc.1",
     "author":"Wheels Core Team and Community",
     "shortDescription":"Wheels MVC Framework Core Directory",
     "location":"ForgeboxStorage",
@@ -21,7 +21,7 @@
     "dependencies": {
         "wirebox": "^7.0.0",
         "testbox": "^6.0.0",
-        "wheels-core": "^3.0.0-rc.1"
+        "wheels-core": "^3.0.0-SNAPSHOT.rc.1"
     },
     "installPaths": {
         "wirebox": "vendor/wirebox/",


### PR DESCRIPTION
This change improves version sorting in ForgeBox by using the -SNAPSHOT prefix for release candidates. The new format ensures release candidates appear at the top of the version list.

Changes:
- Updated core/box.json version to 3.0.0-SNAPSHOT.rc.1
- Updated templates/base/box.json version to 3.0.0-SNAPSHOT.rc.1
- Updated templates/base/src/box.json version to 3.0.0-SNAPSHOT.rc.1
- Updated dependency reference to wheels-core ^3.0.0-SNAPSHOT.rc.1

Note: The workflow validation update (.github/workflows/release-candidate.yml) needs to be committed separately by a user with workflow permissions.