### PR TITLE
cli/remove bugs

### DIFF
--- a/cli/src/commands/wheels/destroy.cfc
+++ b/cli/src/commands/wheels/destroy.cfc
@@ -71,8 +71,8 @@ component aliases='wheels d'  extends="base"  {
 		var modelFile      		 = fileSystemUtil.resolvePath("app/models/#obj.objectNameSingularC#.cfc");
 		var controllerFile 		 = fileSystemUtil.resolvePath("app/controllers/#obj.objectNamePluralC#.cfc");
 		var viewFolder     		 = fileSystemUtil.resolvePath("app/views/#obj.objectNamePlural#/");
-		var testmodelFile  		 = fileSystemUtil.resolvePath("tests/specs/models/#obj.objectNameSingularC#.cfc");
-		var testcontrollerFile = fileSystemUtil.resolvePath("tests/specs/controllers/#obj.objectNamePluralC#.cfc");
+		var testmodelFile  		 = fileSystemUtil.resolvePath("tests/specs/models/#obj.objectNameSingularC#Spec.cfc");
+		var testcontrollerFile = fileSystemUtil.resolvePath("tests/specs/controllers/#obj.objectNamePluralC#ControllerSpec.cfc");
 		var testviewFolder     = fileSystemUtil.resolvePath("tests/specs/views/#obj.objectNamePlural#/");
 		var routeFile   			 = fileSystemUtil.resolvePath("config/routes.cfm");
 		var resourceName			 = '.resources("' & obj.objectNamePlural & '")';
@@ -91,7 +91,8 @@ component aliases='wheels d'  extends="base"  {
 			 .line("#testviewFolder#")
 			 .line("#routeFile#")
 			 .line("#resourceName#")
-			 .line();
+			 .line()
+			 .toConsole();
 
 		if(confirm("Are you sure? [y/n]")){
 			command('delete').params(path=modelFile, force=true).run();
@@ -121,7 +122,7 @@ component aliases='wheels d'  extends="base"  {
 	private function destroyController(required string name) {
 		var obj = helpers.getNameVariants(arguments.name);
 		var controllerFile = fileSystemUtil.resolvePath("app/controllers/#obj.objectNamePluralC#.cfc");
-		var testcontrollerFile = fileSystemUtil.resolvePath("tests/specs/controllers/#obj.objectNamePluralC#.cfc");
+		var testcontrollerFile = fileSystemUtil.resolvePath("tests/specs/controllers/#obj.objectNamePluralC#ControllerSpec.cfc");
 		
 		print.redBoldLine("================================================")
 			 .redBoldLine("= Watch Out!                                   =")
@@ -154,7 +155,7 @@ component aliases='wheels d'  extends="base"  {
 	private function destroyModel(required string name) {
 		var obj = helpers.getNameVariants(arguments.name);
 		var modelFile = fileSystemUtil.resolvePath("app/models/#obj.objectNameSingularC#.cfc");
-		var testmodelFile = fileSystemUtil.resolvePath("tests/specs/models/#obj.objectNameSingularC#.cfc");
+		var testmodelFile = fileSystemUtil.resolvePath("tests/specs/models/#obj.objectNameSingularC#Spec.cfc");
 		
 		print.redBoldLine("================================================")
 			 .redBoldLine("= Watch Out!                                   =")

--- a/cli/src/commands/wheels/generate/helper.cfc
+++ b/cli/src/commands/wheels/generate/helper.cfc
@@ -296,18 +296,18 @@ set(functionName = "includeHelpers", helper = "#arguments.name#");', "cfscript")
      * Create test file for helper
      */
     private void function createHelperTest(required string helperName, required array functions, required string type) {
-        var testsDir = helpers.getTestPath() & "/helpers";
-        
+        var testsDir = helpers.getTestPath() & "/specs/helpers";
+
         if (!directoryExists(testsDir)) {
-            directoryCreate(testsDir);
+            directoryCreate(testsDir, true);
         }
-        
-        var testPath = testsDir & "/" & helperName & "Test.cfc";
-        
+
+        var testPath = testsDir & "/" & helperName & "Spec.cfc";
+
         if (!fileExists(testPath)) {
             var testContent = generateHelperTest(helperName, functions, type);
             fileWrite(testPath, testContent);
-            detailOutput.output("Created test: /tests/helpers/#helperName#Test.cfc");
+            detailOutput.output("Created test: /tests/specs/helpers/#helperName#Spec.cfc");
         }
     }
     

--- a/cli/src/commands/wheels/generate/job.cfc
+++ b/cli/src/commands/wheels/generate/job.cfc
@@ -274,18 +274,18 @@ job.enqueueAt(datetime: dateAdd("h", 1, now()), data: data);', "cfscript");
      * Create test file for job
      */
     private void function createJobTest(required string jobName) {
-        var testsDir = helpers.getTestPath() & "/jobs";
-        
+        var testsDir = helpers.getTestPath() & "/specs/jobs";
+
         if (!directoryExists(testsDir)) {
-            directoryCreate(testsDir);
+            directoryCreate(testsDir, true);
         }
-        
-        var testPath = testsDir & "/" & jobName & "Test.cfc";
-        
+
+        var testPath = testsDir & "/" & jobName & "Spec.cfc";
+
         if (!fileExists(testPath)) {
             var testContent = generateJobTest(jobName);
             fileWrite(testPath, testContent);
-            detailOutput.output("Created test: /tests/jobs/#jobName#Test.cfc");
+            detailOutput.output("Created test: /tests/specs/jobs/#jobName#Spec.cfc");
         }
     }
     

--- a/cli/src/commands/wheels/generate/mailer.cfc
+++ b/cli/src/commands/wheels/generate/mailer.cfc
@@ -214,18 +214,18 @@ mailer.#methodList[1]#(to="user@example.com", subject="Welcome!");', "cfscript")
      * Create test file for mailer
      */
     private void function createMailerTest(required string mailerName, required array methods) {
-        var testsDir = helpers.getTestPath() & "/mailers";
-        
+        var testsDir = helpers.getTestPath() & "/specs/mailers";
+
         if (!directoryExists(testsDir)) {
-            directoryCreate(testsDir);
+            directoryCreate(testsDir, true);
         }
-        
-        var testPath = testsDir & "/" & mailerName & "Test.cfc";
-        
+
+        var testPath = testsDir & "/" & mailerName & "Spec.cfc";
+
         if (!fileExists(testPath)) {
             var testContent = generateMailerTest(mailerName, methods);
             fileWrite(testPath, testContent);
-            detailOutput.output("Created test: /tests/mailers/#mailerName#Test.cfc");
+            detailOutput.output("Created test: /tests/specs/mailers/#mailerName#Spec.cfc");
         }
     }
     

--- a/cli/src/commands/wheels/generate/resource.cfc
+++ b/cli/src/commands/wheels/generate/resource.cfc
@@ -374,7 +374,7 @@ component aliases='wheels g resource' extends="../base" {
                 crud = true
             )
             .run();
-        arrayAppend(testPaths, "tests/specs/models/#obj.objectNameSingularC#.cfc");
+        arrayAppend(testPaths, "tests/specs/models/#obj.objectNameSingularC#Spec.cfc");
 
         // Generate controller test
         command("wheels generate test")
@@ -384,7 +384,7 @@ component aliases='wheels g resource' extends="../base" {
                 crud = true
             )
             .run();
-        arrayAppend(testPaths, "tests/specs/controllers/#obj.objectNamePluralC#.cfc");
+        arrayAppend(testPaths, "tests/specs/controllers/#obj.objectNamePluralC#ControllerSpec.cfc");
 
         return testPaths;
     }

--- a/cli/src/commands/wheels/generate/service.cfc
+++ b/cli/src/commands/wheels/generate/service.cfc
@@ -255,18 +255,18 @@ property name="#lCase(left(arguments.name, len(arguments.name)-7))#Service" inje
      * Create test file for service
      */
     private void function createServiceTest(required string serviceName, required array methods) {
-        var testsDir = helpers.getTestPath() & "/services";
-        
+        var testsDir = helpers.getTestPath() & "/specs/services";
+
         if (!directoryExists(testsDir)) {
-            directoryCreate(testsDir);
+            directoryCreate(testsDir, true);
         }
-        
-        var testPath = testsDir & "/" & serviceName & "Test.cfc";
-        
+
+        var testPath = testsDir & "/" & serviceName & "Spec.cfc";
+
         if (!fileExists(testPath)) {
             var testContent = generateServiceTest(serviceName, methods);
             fileWrite(testPath, testContent);
-            detailOutput.output("Created test: /tests/services/#serviceName#Test.cfc");
+            detailOutput.output("Created test: /tests/specs/services/#serviceName#Spec.cfc");
         }
     }
     

--- a/cli/src/commands/wheels/generate/snippets.cfc
+++ b/cli/src/commands/wheels/generate/snippets.cfc
@@ -21,7 +21,7 @@ component aliases="wheels g snippets" extends="../base" {
      * @force.hint Overwrite existing files
      */
     function run(
-        string pattern = "",
+        required string pattern,
         boolean list = false,
         string category = "",
         string output = "console",
@@ -30,6 +30,7 @@ component aliases="wheels g snippets" extends="../base" {
         boolean create = false,
         boolean force = false
     ) {
+        requireWheelsApp(getCWD());
         arguments = reconstructArgs(
             argStruct=arguments,
             allowedValues={
@@ -134,8 +135,11 @@ component aliases="wheels g snippets" extends="../base" {
      * Write snippet to file
      */
     private function writeSnippetToFile(required struct snippet, required string path, boolean force = false) {
-        if (fileExists(arguments.path) && !arguments.force) {
-            detailOutput.error("File already exists: #arguments.path#");
+        // Resolve path relative to application directory
+        var resolvedPath = fileSystemUtil.resolvePath(arguments.path);
+
+        if (fileExists(resolvedPath) && !arguments.force) {
+            detailOutput.error("File already exists: #resolvedPath#");
             detailOutput.getPrint().line("Use --force to overwrite");
             setExitCode(1);
             return;
@@ -144,13 +148,13 @@ component aliases="wheels g snippets" extends="../base" {
         var content = getSnippetContent(arguments.snippet);
 
         // Create directory if needed
-        var dir = getDirectoryFromPath(arguments.path);
+        var dir = getDirectoryFromPath(resolvedPath);
         if (!directoryExists(dir)) {
             directoryCreate(dir, true);
         }
 
-        fileWrite(arguments.path, content);
-        detailOutput.create("Created: #arguments.path#");
+        fileWrite(resolvedPath, content);
+        detailOutput.create("Created: #resolvedPath#");
     }
 
     /**

--- a/cli/src/commands/wheels/plugins/search.cfc
+++ b/cli/src/commands/wheels/plugins/search.cfc
@@ -34,14 +34,19 @@ component aliases="wheels plugin search" extends="../base" {
              .boldCyanLine("===========================================================")
              .boldCyanLine("  Searching ForgeBox for Wheels Plugins")
              .boldCyanLine("===========================================================")
-             .line();
+             .line()
+             .console();
 
         if (len(arguments.query)) {
             print.line("Search term: #arguments.query#")
-                 .line();
+                 .line().console();
         }
 
-        // try {
+        try {
+            print.line("Searching, Please wait ...")
+                 .line()
+                 .toConsole();
+
             // Use forgebox show command to get all cfwheels-plugins
             var forgeboxResult = command('forgebox show')
                 .params(type='cfwheels-plugins')
@@ -109,12 +114,15 @@ component aliases="wheels plugin search" extends="../base" {
                 }
             }
 
+            print.line()
+                 .toConsole();
+
             if (!arrayLen(results)) {
                 print.yellowLine("No plugins found" & (len(arguments.query) ? " matching '#arguments.query#'" : ""))
                      .line()
                      .line("Try:")
                      .cyanLine("  wheels plugin search <different-keyword>")
-                     .cyanLine("  wheels plugin list --available");
+                     .cyanLine("  wheels plugin list --available").console();
                 return;
             }
 
@@ -146,13 +154,17 @@ component aliases="wheels plugin search" extends="../base" {
 
                 // Calculate column widths
                 var maxNameLength = 20;
+                var maxSlugLength = 20;
                 var maxVersionLength = 10;
                 var maxDownloadsLength = 10;
-                var maxDescLength = 40;
+                var maxDescLength = 30;
 
                 for (var plugin in results) {
-                    if (len(plugin.slug) > maxNameLength) {
-                        maxNameLength = len(plugin.slug);
+                    if (len(plugin.name) > maxNameLength) {
+                        maxNameLength = len(plugin.name);
+                    }
+                    if (len(plugin.slug) > maxSlugLength) {
+                        maxSlugLength = len(plugin.slug);
                     }
                     if (len(plugin.version) > maxVersionLength) {
                         maxVersionLength = len(plugin.version);
@@ -164,16 +176,18 @@ component aliases="wheels plugin search" extends="../base" {
                 }
 
                 maxNameLength += 2;
+                maxSlugLength += 2;
                 maxVersionLength += 2;
                 maxDownloadsLength += 2;
 
                 // Print table header
                 print.boldText(padRight("Name", maxNameLength))
+                     .boldText(padRight("Slug", maxSlugLength))
                      .boldText(padRight("Version", maxVersionLength))
                      .boldText(padRight("Downloads", maxDownloadsLength))
                      .boldLine("Description");
 
-                print.line(repeatString("-", maxNameLength + maxVersionLength + maxDownloadsLength + maxDescLength));
+                print.line(repeatString("-", maxNameLength + maxSlugLength + maxVersionLength + maxDownloadsLength + maxDescLength));
 
                 // Display results
                 for (var plugin in results) {
@@ -182,7 +196,8 @@ component aliases="wheels plugin search" extends="../base" {
                         desc = left(desc, maxDescLength - 3) & "...";
                     }
 
-                    print.cyanText(padRight(plugin.slug, maxNameLength))
+                    print.boldText(padRight(plugin.name, maxNameLength))
+                         .cyanText(padRight(plugin.slug, maxSlugLength))
                          .greenText(padRight(plugin.version, maxVersionLength))
                          .yellowText(padRight(numberFormat(plugin.downloads ?: 0), maxDownloadsLength))
                          .line(desc);
@@ -196,14 +211,14 @@ component aliases="wheels plugin search" extends="../base" {
                      .cyanLine("  wheels plugin info <name>       View plugin details");
             }
 
-        // } catch (any e) {
-        //     print.line()
-        //          .boldRedText("[ERROR] ")
-        //          .redLine("Error searching for plugins")
-        //          .line()
-        //          .yellowLine("Error: #e.message#");
-        //     setExitCode(1);
-        // }
+        } catch (any e) {
+            print.line()
+                 .boldRedText("[ERROR] ")
+                 .redLine("Error searching for plugins")
+                 .line()
+                 .yellowLine("Error: #e.message#");
+            setExitCode(1);
+        }
     }
 
     /**

--- a/cli/src/models/CodeGenerationService.cfc
+++ b/cli/src/models/CodeGenerationService.cfc
@@ -392,43 +392,57 @@ component {
         array methods = [],
         string baseDirectory = ""
     ) {
+        // Follow the standard pattern from 'wheels generate test'
         var testName = arguments.name;
-        if (!reFindNoCase("Test$", testName)) {
-            testName &= "Test";
-        }
-        
-        var testDir = "tests/";
+
+        // Determine test directory and naming convention based on type
+        var testDir = "tests/specs/";
+        var suffix = "";
+
         switch (arguments.type) {
             case "model":
                 testDir &= "models/";
+                suffix = "Spec";
                 break;
             case "controller":
                 testDir &= "controllers/";
+                suffix = "ControllerSpec";
                 break;
             case "view":
                 testDir &= "views/";
+                suffix = "ViewSpec";
                 break;
             default:
                 if (arguments.unit) {
                     testDir &= "unit/";
+                    suffix = "Spec";
                 } else if (arguments.integration) {
                     testDir &= "integration/";
+                    suffix = "IntegrationSpec";
+                } else {
+                    testDir &= "unit/";
+                    suffix = "Spec";
                 }
         }
-        
+
+        // Remove existing Test/Spec/ControllerSpec suffix if present
+        testName = reReplaceNoCase(testName, "(Test|Spec|ControllerSpec|ViewSpec|IntegrationSpec)$", "");
+        // Add the correct suffix
+        testName &= suffix;
+
         var fileName = testName & ".cfc";
         var filePath = resolvePath(testDir & fileName, arguments.baseDirectory);
-        
+
         // Create directory if needed
         var dir = resolvePath(testDir, arguments.baseDirectory);
         if (!directoryExists(dir)) {
             directoryCreate(dir, true);
         }
-        
+
         // Prepare template context
         var context = {
             testName: testName,
-            targetName: replaceNoCase(testName, "Test", ""),
+            targetName: reReplaceNoCase(testName, "(Spec|Test|ControllerSpec|ViewSpec|IntegrationSpec)$", ""),
             type: arguments.type,
             methods: arguments.methods,
             timestamp: dateTimeFormat(now(), "yyyy-mm-dd HH:nn:ss")


### PR DESCRIPTION
- Fixed Scaffold Command Test Generation Updated CodeGenerationService.generateTest() to use correct path: tests/specs/{type}/ Fixed naming convention: {Name}Spec.cfc, {Name}ControllerSpec.cfc Scaffold now matches wheels generate test pattern

- Fixed Destroy Command Updated destroyResource(), destroyController(), destroyModel() to delete correct test files Changed from tests/specs/models/{Name}.cfc to tests/specs/models/{Name}Spec.cfc Changed from tests/specs/controllers/{Name}.cfc to tests/specs/controllers/{Name}ControllerSpec.cfc

- Fixed Multiple Generate Commands job.cfc: tests/jobs/ → tests/specs/jobs/, Test.cfc → Spec.cfc helper.cfc: tests/helpers/ → tests/specs/helpers/, Test.cfc → Spec.cfc mailer.cfc: tests/mailers/ → tests/specs/mailers/, Test.cfc → Spec.cfc service.cfc: tests/services/ → tests/specs/services/, Test.cfc → Spec.cfc resource.cfc: Updated test path references to include Spec suffix