### PR TITLE
Overwriting wheels methods

### DIFF
--- a/core/src/wheels/Model.cfc
+++ b/core/src/wheels/Model.cfc
@@ -537,6 +537,10 @@ component output="false" displayName="Model" extends="wheels.Global"{
 				if (!local.methodExists) {
 					variables[local.functionName] = componentInstance[local.functionName];
 					this[local.functionName] = componentInstance[local.functionName];
+				} else {
+					local.superMethodName = "super" & local.functionName;
+					variables[local.superMethodName] = componentInstance[local.functionName];
+					this[local.superMethodName] = componentInstance[local.functionName];
 				}
 				
 				// Only add super prefix for functions that will be overridden by plugins/mixins


### PR DESCRIPTION
In wheels 2.5, developers could overwrite wheels functions and still were able to call them using "super." syntax. Due to the architectural change in wheels 3.0, this workaround is no longer possible. Now developers can override the methods and still be able to call them by prefixing their name with "super".

So, if a developer overrides wheels findAll function, they can still call wheels function by using superfindAll().