### PR TITLE
Fix nested struct mapping with multiple belongsTo associations

### DIFF
--- a/core/src/wheels/model/serialize.cfc
+++ b/core/src/wheels/model/serialize.cfc
@@ -154,7 +154,7 @@ component {
 								properties = arguments.query,
 								row = local.i,
 								base = false,
-								joinAlias = variables.wheels.class.associations[local.include].joinAlias
+								joinAlias = local.joinAlias
 							);
 						}
 					}


### PR DESCRIPTION
Updated $queryRowToStruct to accept joinAlias and map columns correctly per association.
- Modified serializeQueryToArray to pass joinAlias when available.
- Ensures each nested association now receives only its relevant columns.