### PR TITLE
Inline debug CSS instead of injecting into HTML head

### DIFF
--- a/core/src/wheels/events/onrequestend/debug.cfm
+++ b/core/src/wheels/events/onrequestend/debug.cfm
@@ -86,8 +86,8 @@
 		margin-right:5px;
 		}</style>
 </cfsavecontent>
-<cfset $htmlhead(text = local.css)>
 <cfoutput>
+	#local.css#
 	<div id="wheels-debug-area">
 		<cfif $get("enablePublicComponent")>
 			<table>


### PR DESCRIPTION
The debug footer is rendered during onRequestEnd, after the <head> tag has already been written. Injecting CSS via cfhtmlhead relied on engine-specific behavior and does not work in BoxLang.

Inlining the <style> block ensures consistent behavior across Adobe ColdFusion, Lucee, and BoxLang.