### PR TITLE
feat(tests): adds rocketunit package wildcard filter param

### DIFF
--- a/core/src/wheels/Test.cfc
+++ b/core/src/wheels/Test.cfc
@@ -700,6 +700,9 @@ component output="false" displayName="Test" extends="wheels.Global"{
 				if (StructKeyExists(arguments.options, "skip") && local.packageName contains arguments.options.skip) {
 					local.useTest = false;
 				}
+				if (StructKeyExists(arguments.options, "filter") && !FindNoCase(arguments.options.filter, local.packageName)) {
+					local.useTest = false;
+				}
 				if (local.useTest) {
 					QueryAddRow(local.rv);
 					QuerySetCell(local.rv, "package", local.packageName);


### PR DESCRIPTION
Enables filtering test cases by `filter` param.

Eg: `/wheels/packages/app?filter=util`

Will run tests on packages:
`utils.string`
`utils.number`
`futile`

This is an existing personal requirement, but I feel an in-intrusive and useful addition.