### PR TITLE
Replace broken installation link with anchor to Quick Start

### DIFF
--- a/examples/starter-app/README.md
+++ b/examples/starter-app/README.md
@@ -8,7 +8,7 @@ This repository contains a **user management and authentication web application*
 
 ## Installation
 
-See [Installation](https://github.com/wheels-dev/Wheels-example-app/wiki/Installation)
+See the [Quick Start](#quick-start) section below for setup instructions.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary

- Replaces the broken external wiki link in `examples/starter-app/README.md` with an anchor to the Quick Start section already in the same file

The Installation section linked to `wheels-dev/Wheels-example-app` (doesn't exist) — PR #1861 proposed fixing it to `wheels-dev/cfwheels-example-app`, but that wiki covers setup for the old CFWheels 2.x app, not this Wheels 3.0 starter app. Since this README already has a detailed Quick Start section with prerequisites, environment config, and database setup, linking there is the cleaner fix.

Closes #1861

🤖 Generated with [Claude Code](https://claude.com/claude-code)