### PR TITLE
feat: add CockroachDB database adapter

### DIFF
--- a/core/src/wheels/Model.cfc
+++ b/core/src/wheels/Model.cfc
@@ -390,6 +390,9 @@ component output="false" displayName="Model" extends="wheels.Global"{
 		} else if (FindNoCase("MySQL", local.info.driver_name) || FindNoCase("MariaDB", local.info.driver_name)) {
 			local.adapterNamespace = "MySQL";
 			local.adapterName = "MySQLModel";
+		} else if (FindNoCase("CockroachDB", local.info.database_productname)) {
+			local.adapterNamespace = "CockroachDB";
+			local.adapterName = "CockroachDBModel";
 		} else if (FindNoCase("PostgreSQL", local.info.driver_name)) {
 			local.adapterNamespace = "PostgreSQL";
 			local.adapterName = "PostgreSQLModel";
@@ -406,7 +409,7 @@ component output="false" displayName="Model" extends="wheels.Global"{
 			Throw(
 				type = "Wheels.DatabaseNotSupported",
 				message = "#local.info.database_productname# is not supported by Wheels.",
-				extendedInfo = "Use SQL Server, MySQL, MariaDB, PostgreSQL, Oracle, SQLite or H2."
+				extendedInfo = "Use SQL Server, MySQL, MariaDB, PostgreSQL, CockroachDB, Oracle, SQLite or H2."
 			);
 		}
 		$set(adapterName = local.adapterName);

--- a/core/src/wheels/databaseAdapters/CockroachDB/CockroachDBMigrator.cfc
+++ b/core/src/wheels/databaseAdapters/CockroachDB/CockroachDBMigrator.cfc
@@ -1,0 +1,10 @@
+component extends="wheels.databaseAdapters.PostgreSQL.PostgreSQLMigrator" {
+
+	/**
+	 * name of database adapter
+	 */
+	public string function adapterName() {
+		return "CockroachDB";
+	}
+
+}

--- a/core/src/wheels/databaseAdapters/CockroachDB/CockroachDBModel.cfc
+++ b/core/src/wheels/databaseAdapters/CockroachDB/CockroachDBModel.cfc
@@ -1,0 +1,25 @@
+component extends="wheels.databaseAdapters.PostgreSQL.PostgreSQLModel" output=false {
+
+	/**
+	 * Map database types to the ones used in CFML.
+	 * CockroachDB requires cf_sql_boolean for boolean columns instead of cf_sql_bit,
+	 * as it enforces strict type checking and rejects boolean-to-bit/integer comparisons.
+	 */
+	public string function $getType(required string type, string scale, string details) {
+		switch (arguments.type) {
+			case "bool":
+			case "boolean":
+				local.rv = "cf_sql_boolean";
+				break;
+			case "bit":
+			case "varbit":
+				local.rv = "cf_sql_bit";
+				break;
+			default:
+				local.rv = super.$getType(argumentCollection = arguments);
+				break;
+		}
+		return local.rv;
+	}
+
+}

--- a/core/src/wheels/migrator/Base.cfc
+++ b/core/src/wheels/migrator/Base.cfc
@@ -30,6 +30,8 @@ component extends="wheels.Global"{
 			local.adapterName = "MicrosoftSQLServer";
 		} else if (local.info.driver_name Contains "MySQL") {
 			local.adapterName = "MySQL";
+		} else if (local.info.database_productname Contains "CockroachDB") {
+			local.adapterName = "CockroachDB";
 		} else if (local.info.driver_name Contains "PostgreSQL") {
 			local.adapterName = "PostgreSQL";
 			// NB: using mySQL adapter for H2 as the cli defaults to this for development

--- a/core/src/wheels/migrator/Migration.cfc
+++ b/core/src/wheels/migrator/Migration.cfc
@@ -6,7 +6,7 @@ component extends="Base" {
 			Throw(
 				type = "wheels.model.migrate.DatabaseNotSupported",
 				message = "#dbType# is not supported by Wheels.",
-				extendedInfo = "Use SQL Server, MySQL, MariaDB, PostgreSQL, Oracle, SQLite or H2."
+				extendedInfo = "Use SQL Server, MySQL, MariaDB, PostgreSQL, CockroachDB, Oracle, SQLite or H2."
 			);
 		} else {
 			this.adapter = CreateObject("component", "wheels.databaseAdapters.#dbType#.#dbType#Migrator");


### PR DESCRIPTION
## Summary

- Adds a dedicated CockroachDB database adapter that extends the PostgreSQL adapter
- CockroachDB uses the PostgreSQL wire protocol but enforces strict type checking — the PostgreSQL adapter maps `boolean` columns to `cf_sql_bit`, which causes `unsupported comparison operator: <boolean> = <integer>` errors on CockroachDB
- The CockroachDB adapter overrides `$getType()` to map `bool`/`boolean` to `cf_sql_boolean`, which the JDBC driver correctly sends as a native boolean parameter
- Detection uses `database_productname` (which CockroachDB reports as "CockroachDB") before the PostgreSQL `driver_name` check, since CockroachDB uses the standard PostgreSQL JDBC driver

## Changes

- **New:** `databaseAdapters/CockroachDB/CockroachDBModel.cfc` — extends PostgreSQLModel, overrides boolean type mapping
- **New:** `databaseAdapters/CockroachDB/CockroachDBMigrator.cfc` — extends PostgreSQLMigrator
- **Modified:** `Model.cfc` — adds CockroachDB detection before PostgreSQL check
- **Modified:** `migrator/Base.cfc` — adds CockroachDB detection for migrations
- **Modified:** `migrator/Migration.cfc` — updates supported database list in error message

## Test plan

- [ ] Verify CockroachDB is detected correctly when using the PostgreSQL JDBC driver (`database_productname` = "CockroachDB")
- [ ] Verify boolean columns use `cf_sql_boolean` parameter type, resolving strict type comparison errors
- [ ] Verify existing PostgreSQL databases continue to use the PostgreSQL adapter unchanged
- [ ] Verify migrations work with CockroachDB via the extended migrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)