### PR TITLE
refactor: rename application.wirebox to application.wheelsdi

### DIFF
--- a/cli/src/models/PluginService.cfc
+++ b/cli/src/models/PluginService.cfc
@@ -263,7 +263,7 @@ component {
      */
     private function isWheelsPlugin(moduleName) {
         // Exclude the core framework and common non-plugin dependencies
-        if (listFindNoCase("wheels-core,wirebox,testbox,cfformat", arguments.moduleName)) {
+        if (listFindNoCase("wheels-core,testbox,cfformat", arguments.moduleName)) {
             return false;
         }
         

--- a/design_docs/scratchpad/AI-CONTEXT.md
+++ b/design_docs/scratchpad/AI-CONTEXT.md
@@ -8,9 +8,9 @@ This file provides structured context about the Wheels framework architecture fo
 1. Request arrives at /public/index.cfm
    ↓
 2. Application.cfc initializes
-   - Sets up mappings (/app, /vendor, /wheels, /wirebox, /testbox)
+   - Sets up mappings (/app, /vendor, /wheels, /testbox)
    - Loads environment configuration
-   - Creates WireBox injector
+   - Creates Wheels DI injector
    ↓
 3. onRequestStart() executes
    - Checks for reload parameter

--- a/docs/src/command-line-tools/commands/generate/app.md
+++ b/docs/src/command-line-tools/commands/generate/app.md
@@ -186,8 +186,7 @@ myapp/
 ├── tests/
 └── vendor/                 # Framework files
     ├── testbox/
-    ├── wheels/
-    └── wirebox/
+    └── wheels/
 ```
 
 ## Configuration Files

--- a/docs/src/command-line-tools/commands/test/test-run.md
+++ b/docs/src/command-line-tools/commands/test/test-run.md
@@ -155,7 +155,7 @@ component extends="wheels.Testbox" {
 
             beforeEach(function() {
                 // Reset test data
-                application.wirebox.getInstance("User").deleteAll();
+                application.wheelsdi.getInstance("User").deleteAll();
             });
 
             it("validates required fields", function() {

--- a/docs/src/database-interaction-through-models/using-sqlite.md
+++ b/docs/src/database-interaction-through-models/using-sqlite.md
@@ -67,7 +67,6 @@ Download the SQLite module for Boxlang from [ForgeBox](https://forgebox.io/view/
 {
   "dependencies" : {
     "wheels-core":"3.1.0-SNAPSHOT",
-    "wirebox":"^7",
     "testbox":"^6",
     "bx-compat-cfml":"^1.27.0+35",
     "bx-csrf":"^1.2.0+3",

--- a/examples/starter-app/public/Application.cfc
+++ b/examples/starter-app/public/Application.cfc
@@ -97,7 +97,7 @@ component output="false" {
 		application.wo = injector.getInstance("global");
 		initArgs.path="wheels";
 		initArgs.filename="onapplicationstart";
-		application.wirebox.getInstance(name = "wheels.events.onapplicationstart", initArguments = initArgs).$init(this);
+		application.wheelsdi.getInstance(name = "wheels.events.onapplicationstart", initArguments = initArgs).$init(this);
 	}
 
 	public void function onApplicationEnd( struct ApplicationScope ) {

--- a/examples/tweet/public/Application.cfc
+++ b/examples/tweet/public/Application.cfc
@@ -97,7 +97,7 @@ component output="false" {
 		application.wo = injector.getInstance("global");
 		initArgs.path="wheels";
 		initArgs.filename="onapplicationstart";
-		application.wirebox.getInstance(name = "wheels.events.onapplicationstart", initArguments = initArgs).$init(this);
+		application.wheelsdi.getInstance(name = "wheels.events.onapplicationstart", initArguments = initArgs).$init(this);
 	}
 
 	public void function onApplicationEnd( struct ApplicationScope ) {

--- a/public/Application.cfc
+++ b/public/Application.cfc
@@ -97,7 +97,7 @@ component output="false" {
 		application.wo = injector.getInstance("global");
 		initArgs.path="wheels";
 		initArgs.filename="onapplicationstart";
-		application.wirebox.getInstance(name = "wheels.events.onapplicationstart", initArguments = initArgs).$init(this);
+		application.wheelsdi.getInstance(name = "wheels.events.onapplicationstart", initArguments = initArgs).$init(this);
 	}
 
 	public void function onApplicationEnd( struct ApplicationScope ) {

--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -661,10 +661,10 @@ component output="false" {
 		local.component = ListChangeDelims(arguments.path, ".", "/") & "." & ListChangeDelims(arguments.fileName, ".", "/");
 		local.argumentCollection = arguments;
 		if(local.method EQ 'init'){
-			local.rv = application.wirebox.getInstance(name = "#local.component#", initArguments = local.argumentCollection);
+			local.rv = application.wheelsdi.getInstance(name = "#local.component#", initArguments = local.argumentCollection);
 		}
 		else{
-			local.instance = application.wirebox.getInstance(name = "#local.component#");
+			local.instance = application.wheelsdi.getInstance(name = "#local.component#");
       local.rv = invoke(local.instance, local.method, local.argumentCollection);
 		}
 		return local.rv;

--- a/vendor/wheels/Injector.cfc
+++ b/vendor/wheels/Injector.cfc
@@ -1,12 +1,12 @@
 /**
  * Lightweight dependency injection container for Wheels.
  *
- * Replaces WireBox with only the features Wheels actually uses:
+ * Provides only the DI features Wheels actually uses:
  * - map(name).to(componentPath) fluent bindings
  * - getInstance(name, initArguments) resolution
  * - onDIcomplete() lifecycle callback
  *
- * Self-registers at application.wirebox for backward compatibility.
+ * Self-registers at application.wheelsdi for framework-wide access.
  */
 component {
 
@@ -28,8 +28,8 @@ component {
 		// Track the current mapping being built (for fluent API)
 		variables.currentMapping = "";
 
-		// Register self at application.wirebox for backward compatibility
-		application.wirebox = this;
+		// Register self at application.wheelsdi for framework-wide access
+		application.wheelsdi = this;
 
 		// Load bindings configuration
 		local.binder = createObject("component", arguments.binderPath);

--- a/vendor/wheels/Test.cfc
+++ b/vendor/wheels/Test.cfc
@@ -506,7 +506,7 @@ component output="false" displayName="Test" extends="wheels.Global"{
 		local.i = 0;
 		for (local.row in local.packages) {
 			local.i++;
-			local.instance = application.wirebox.getInstance(name = "#local.row.package#");
+			local.instance = application.wheelsdi.getInstance(name = "#local.row.package#");
 			// is there a better way to check for existence of a function?
 			// if the beforeall method is present, run it once only per request
 			if (StructKeyExists(local.instance, "beforeAll") && local.i eq 1) {

--- a/vendor/wheels/events/onerror/wheelserror.cfm
+++ b/vendor/wheels/events/onerror/wheelserror.cfm
@@ -43,7 +43,7 @@
 				Classification uses path segments (not base path math) for reliability.
 				Framework: vendor/wheels/, index.cfm & Application.cfc in public/
 				Plugin: plugins/
-				Library: any other vendor/ path (testbox, wirebox, coldbox, etc.)
+				Library: any other vendor/ path (testbox, coldbox, etc.)
 				App: app/, config/, public/, tests/, and anything else
 			--->
 			<cfset local.frameType = "app">

--- a/vendor/wheels/tests/model/validations/conditional_validations.cfc
+++ b/vendor/wheels/tests/model/validations/conditional_validations.cfc
@@ -1,7 +1,7 @@
 component extends="wheels.tests.Test" {
 
 	function setup() {
-		user = application.wirebox.getInstance( "wheels.tests._assets.models.Model" ).$initModelClass(
+		user = application.wheelsdi.getInstance( "wheels.tests._assets.models.Model" ).$initModelClass(
 			name = "c_o_r_e_Users",
 			path = get("modelPath")
 		);

--- a/vendor/wheels/tests/plugins/injection.cfc
+++ b/vendor/wheels/tests/plugins/injection.cfc
@@ -18,7 +18,7 @@ component extends="wheels.tests.Test" {
 		_params = {controller = "test", action = "index"};
 		c = controller("test", _params);
 		d = $createObjectFromRoot(path = "wheels", fileName = "Dispatch", method = "$init");
-		t = application.wirebox.getInstance("wheels.Test");
+		t = application.wheelsdi.getInstance("wheels.Test");
 	}
 
 	function teardown() {

--- a/vendor/wheels/tests/view/forms/checkbox.cfc
+++ b/vendor/wheels/tests/view/forms/checkbox.cfc
@@ -1,7 +1,7 @@
 component extends="wheels.tests.Test" {
 
 	function setup() {
-		_controller = application.wirebox.getInstance("wheels.tests._assets.controllers.ControllerWithModel");
+		_controller = application.wheelsdi.getInstance("wheels.tests._assets.controllers.ControllerWithModel");
 		args = {};
 		args.objectName = "user";
 		args.label = false;

--- a/vendor/wheels/tests/view/forms/yearSelect.cfc
+++ b/vendor/wheels/tests/view/forms/yearSelect.cfc
@@ -1,7 +1,7 @@
 component extends="wheels.tests.Test" {
 
 	function setup() {
-		_controller = application.wirebox.getInstance("wheels.tests._assets.controllers.ControllerWithModel");
+		_controller = application.wheelsdi.getInstance("wheels.tests._assets.controllers.ControllerWithModel");
 		args = {};
 		args.objectName = "user";
 		args.property = "birthday";

--- a/vendor/wheels/tests/view/miscellaneous/getobject.cfc
+++ b/vendor/wheels/tests/view/miscellaneous/getobject.cfc
@@ -1,7 +1,7 @@
 component extends="wheels.tests.Test" {
 
 	function setup(){
-		_controller = application.wirebox.getInstance( "wheels.Controller" );
+		_controller = application.wheelsdi.getInstance( "wheels.Controller" );
 	}
 
 	function test_getting_object_from_request_scope() {

--- a/vendor/wheels/tests_testbox/specs/model/validationsSpec.cfc
+++ b/vendor/wheels/tests_testbox/specs/model/validationsSpec.cfc
@@ -113,7 +113,7 @@ component extends="wheels.Testbox" {
 		describe("Tests conditional validations", () => {
 
 			beforeEach(() => {
-				user = application.wirebox.getInstance("wheels.tests._assets.models.Model").$initModelClass(
+				user = application.wheelsdi.getInstance("wheels.tests._assets.models.Model").$initModelClass(
 					name = "c_o_r_e_Users",
 					path = g.get("modelPath")
 				)

--- a/vendor/wheels/tests_testbox/specs/view/formsSpec.cfc
+++ b/vendor/wheels/tests_testbox/specs/view/formsSpec.cfc
@@ -1171,7 +1171,7 @@ component extends="wheels.Testbox" {
 		describe("Tests that yearSelect", () => {
 
 			beforeEach(() => {
-				_controller = application.wirebox.getInstance("wheels.tests._assets.controllers.ControllerWithModel")
+				_controller = application.wheelsdi.getInstance("wheels.tests._assets.controllers.ControllerWithModel")
 				args = {}
 				args.objectName = "user"
 				args.property = "birthday"

--- a/vendor/wheels/tests_testbox/specs/view/miscellaneousSpec.cfc
+++ b/vendor/wheels/tests_testbox/specs/view/miscellaneousSpec.cfc
@@ -1,7 +1,7 @@
 component extends="wheels.Testbox" {
 
 	function beforeAll(){
-		miscellaneous = application.wirebox.getInstance( "wheels.Controller" );
+		miscellaneous = application.wheelsdi.getInstance( "wheels.Controller" );
 	};
 
 	function run() {


### PR DESCRIPTION
The internal DI layer replaced WireBox but kept the wirebox namespace
for backward compatibility. This renames it to wheelsdi to avoid
confusion with the external Ortus WireBox library.

Changes across 20 files:
- Core: Injector.cfc registers as application.wheelsdi
- Framework: Global.cfc, Test.cfc use application.wheelsdi
- App: All Application.cfc files updated
- Tests: All test files using getInstance() updated
- Docs: Removed stale wirebox vendor/dependency references
- CLI PluginService: Removed wirebox from exclusion list

Note: CLI commands under cli/src/commands/ still reference
application.wirebox — those are CommandBox's WireBox DI, not Wheels'.

https://claude.ai/code/session_015J5kLiyH5yx9PUyKG6RuRm