### PR TITLE
Add PR template and Definition of Done

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Related Issue
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Enhancement to existing feature
+- [ ] Documentation update
+- [ ] Refactoring
+
+## Feature Completeness Checklist
+
+<!-- All items must be checked for new features and enhancements -->
+
+- [ ] **Tests** -- Unit tests covering happy path, edge cases, and error conditions
+- [ ] **Framework Docs** -- New or updated page in `docs/src/` with `SUMMARY.md` entry
+- [ ] **AI Reference Docs** -- New or updated file in `.ai/wheels/` directory
+- [ ] **CLAUDE.md** -- Updated if the feature changes model/controller/view conventions
+- [ ] **CHANGELOG.md** -- Entry under `[Unreleased]` section
+- [ ] **Test runner passes** -- All existing tests still pass (`/wheels/tests/core?format=json`)
+
+## Test Plan
+
+<!-- How to verify this PR works -->
+
+## Screenshots / Output
+
+<!-- If applicable -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,19 @@ We welcome PRs of all sizes — from typo fixes to major features. To make revie
 * Use meaningful variable and function names
 * Add comments for complex logic
 
+**Definition of Done:**
+
+A feature or enhancement is not complete until all of the following are satisfied:
+
+* **Tests** -- Unit tests covering happy path, edge cases, and error conditions in `vendor/wheels/tests/`
+* **Framework Docs** -- New or updated page in `docs/src/` with a corresponding entry in `docs/src/SUMMARY.md`
+* **AI Reference Docs** -- New or updated file in `.ai/wheels/` so AI assistants have accurate context
+* **CLAUDE.md** -- Updated if the feature changes model, controller, or view conventions
+* **CHANGELOG.md** -- Entry under the `[Unreleased]` section
+* **Test runner passes** -- All existing tests still pass (`/wheels/tests/core?format=json`)
+
+Bug-fix PRs require tests and a CHANGELOG entry at minimum. Documentation-only PRs are exempt from the test requirement.
+
 If you're making a **breaking change** or working on **core functionality**, it's best to open an Issue first to discuss the approach.
 
 **Fork-and-Pull Workflow:**


### PR DESCRIPTION
## Summary

Adds a GitHub pull request template with a feature completeness checklist and updates CONTRIBUTING.md with a "Definition of Done" section.

## Related Issue

Part of Phase 1 modernization effort.

## Type of Change

- [x] Documentation update

## Test Plan

- [x] PR template renders correctly on new PR creation
- [x] CONTRIBUTING.md reads correctly with new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)