### PR TITLE
docs: add common testing gotchas

### DIFF
--- a/.ai/wheels/testing/unit-testing.md
+++ b/.ai/wheels/testing/unit-testing.md
@@ -1,0 +1,200 @@
+# Unit & Integration Testing in Wheels
+
+## Two Test Frameworks
+
+Wheels has two test frameworks. **All new tests must use TestBox.**
+
+| | TestBox (current) | RocketUnit (legacy) |
+|---|---|---|
+| **Syntax** | `describe`/`it`/`expect` (BDD) | `test_methodName()` + `assert()` |
+| **Base class** | `wheels.WheelsTest` | `wheels.tests.Test` |
+| **Location** | `tests/specs/` | `vendor/wheels/tests/` |
+| **Runner URL** | `/wheels/app/tests` | `/wheels/tests/core` |
+| **Status** | Active, all new tests | Legacy, backwards-compat only |
+
+## TestBox Test Structure
+
+### File Layout
+
+```
+tests/
+  _assets/
+    models/         <- Test-only model CFCs (not app models)
+      Model.cfc     <- Base model (extends wheels.Model)
+      Author.cfc    <- Test model with table() override
+      Post.cfc
+  specs/
+    models/          <- Model specs
+      BatchProcessingSpec.cfc
+      QueryBuilderSpec.cfc
+    controllers/     <- Controller specs
+    functional/      <- End-to-end specs
+  populate.cfm       <- Creates/seeds test tables (runs before every test suite)
+  runner.cfm         <- TestBox runner (web entry point)
+```
+
+### Writing a Spec
+
+```cfm
+component extends="wheels.WheelsTest" {
+    function run() {
+        describe("Feature Name", () => {
+
+            it("does something specific", () => {
+                var result = model("author").findAll();
+                expect(result.recordcount).toBeGT(0);
+            });
+
+            it("returns a model object", () => {
+                var obj = model("author").findOne(order="id");
+                expect(IsObject(obj)).toBeTrue();
+                expect(obj.firstName).toBe("Per");
+            });
+
+        });
+    }
+}
+```
+
+### Key Points
+
+- **Extend `wheels.WheelsTest`** — this injects all `application.wo` methods (like `model()`) into the test scope automatically.
+- **Use `function run()`** — TestBox calls this to discover specs. Not `init()`, not `config()`.
+- **Arrow functions work** — `() => {}` is fine for `describe`/`it`/`beforeEach`.
+
+## Test Models
+
+Test models live in `tests/_assets/models/` and extend the local `Model.cfc` (which extends `wheels.Model`). They use `table()` to map to test tables created by `populate.cfm`.
+
+```cfm
+// tests/_assets/models/Author.cfc
+component extends="Model" {
+    function config() {
+        table("c_o_r_e_authors");
+        hasMany("posts");
+    }
+}
+```
+
+The test environment sets `modelPath` to `tests/_assets/models/` so `model("author")` resolves to your test model, not an app model.
+
+## Test Data (populate.cfm)
+
+`tests/populate.cfm` runs before every test suite invocation. It creates tables and seeds data.
+
+**Always use DROP + CREATE, never IF NOT EXISTS:**
+
+```cfm
+<!--- DROP first — IF NOT EXISTS misses schema changes --->
+<cftry>
+    <cfquery datasource="#application.wheels.dataSourceName#">
+        DROP TABLE IF EXISTS c_o_r_e_posts
+    </cfquery>
+    <cfcatch></cfcatch>
+</cftry>
+
+<!--- Then CREATE --->
+<cfquery datasource="#application.wheels.dataSourceName#">
+CREATE TABLE c_o_r_e_posts (
+    id #local.identityColumnType#,
+    title varchar(250) NOT NULL,
+    ...
+    PRIMARY KEY(id)
+) #local.storageEngine#
+</cfquery>
+```
+
+**Why not IF NOT EXISTS?** If you add a column (like `status`) to a table that already exists from a previous test run, IF NOT EXISTS skips the CREATE and the column is missing. DROP + CREATE guarantees a clean schema every time.
+
+## Running Tests
+
+### Via URL (most reliable)
+
+```
+# All specs in a directory
+/wheels/app/tests?format=json&directory=tests.specs.models
+
+# Single spec bundle
+/wheels/app/tests?format=json&bundles=tests.specs.models.BatchProcessingSpec
+
+# HTML output (for browser)
+/wheels/app/tests?format=html&directory=tests.specs.models
+
+# Force model cache reload (needed after adding new model CFCs)
+/wheels/app/tests?format=json&directory=tests.specs.models&reload=true
+```
+
+### Via curl + node (for CLI parsing)
+
+```bash
+curl -sL "http://localhost:60006/wheels/app/tests?format=json&directory=tests.specs.models&reload=true" \
+  > /tmp/testbox_results.json && node -e "
+const j = JSON.parse(require('fs').readFileSync('/tmp/testbox_results.json', 'utf8'));
+console.log('Passed:', j.totalPass, '| Failed:', j.totalFail, '| Errors:', j.totalError);
+for (const b of j.bundleStats) {
+  console.log('\n' + b.name + ' (' + b.totalPass + '/' + b.totalSpecs + ')');
+  function printSuite(s, indent) {
+    for (const sp of (s.specStats || [])) {
+      if (sp.status !== 'Passed') console.log(indent + '[FAIL] ' + sp.name + ': ' + sp.failMessage);
+    }
+    for (const ns of (s.suiteStats || [])) printSuite(ns, indent + '  ');
+  }
+  for (const s of b.suiteStats) printSuite(s, '  ');
+}
+"
+```
+
+**Why node instead of jq?** The Wheels TestBox JSON response contains unquoted `true`/`false` booleans that break strict JSON parsers. Node's `JSON.parse` handles them.
+
+## Common Gotchas
+
+### 1. CFML Closure Scoping
+
+Closures in CFML have their own `local` scope. You **cannot** read/write outer `local` variables from inside a closure.
+
+```cfm
+// WRONG — `local.count` inside the closure is a DIFFERENT variable
+var count = 0;
+model("author").findEach(callback = function(author) {
+    count++; // This modifies the closure's local.count, not the outer one
+});
+expect(count).toBe(10); // FAILS — count is still 0
+
+// RIGHT — use a shared struct (structs are passed by reference)
+var result = {count: 0};
+model("author").findEach(callback = function(author) {
+    result.count++; // Modifies the shared struct
+});
+expect(result.count).toBe(10); // PASSES
+```
+
+### 2. Model Cache After Adding New CFCs
+
+After adding a new model CFC to `tests/_assets/models/`, the first test run may fail with errors like `table 'authorscopeds' not found` — Wheels is using default table name conventions because it hasn't loaded your `config()` yet.
+
+**Fix:** Add `&reload=true` to the test runner URL to clear the model cache.
+
+### 3. Table Naming in Test Models
+
+Always call `table()` in your test model's `config()` to map to the test table name. Without it, Wheels pluralizes the model name (e.g., `AuthorScoped` -> `authorscopeds`).
+
+```cfm
+component extends="Model" {
+    function config() {
+        table("c_o_r_e_authors"); // Explicit table name
+    }
+}
+```
+
+### 4. Drop Order for Foreign Keys
+
+Drop child tables before parent tables in `populate.cfm`:
+
+```cfm
+DROP TABLE IF EXISTS c_o_r_e_posts   <!--- child (has authorid FK) --->
+DROP TABLE IF EXISTS c_o_r_e_authors <!--- parent --->
+```
+
+### 5. Pre-existing Test Failures
+
+The `vendor/wheels/tests/` RocketUnit suite has some pre-existing failures (e.g., in `model.errors`). Don't chase these — they're known issues in the legacy suite. Focus on making your TestBox specs green.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,11 +276,14 @@ Helpers: `linkTo(route="user", key=user.id, text="View")`, `urlFor(route="users"
 
 ## Testing Quick Reference
 
+**All new tests use TestBox BDD syntax.** RocketUnit (`test_` prefix, `assert()`) is legacy only — never use it for new tests.
+
 ```cfm
+// tests/specs/models/MyFeatureSpec.cfc
 component extends="wheels.WheelsTest" {
     function run() {
-        describe("User", function() {
-            it("validates presence of name", function() {
+        describe("My Feature", () => {
+            it("validates presence of name", () => {
                 var user = model("User").new();
                 expect(user.valid()).toBeFalse();
             });
@@ -289,7 +292,13 @@ component extends="wheels.WheelsTest" {
 }
 ```
 
-Tests live in `tests/models/`, `tests/controllers/`, `tests/integration/`. Run with MCP `wheels_test()` or CLI `wheels test run`.
+- **Specs**: `tests/specs/models/`, `tests/specs/controllers/`, `tests/specs/functional/`
+- **Test models**: `tests/_assets/models/` (use `table()` to map to test tables)
+- **Test data**: `tests/populate.cfm` (DROP + CREATE tables, seed data)
+- **Runner URL**: `/wheels/app/tests?format=json&directory=tests.specs.models`
+- **Force reload**: append `&reload=true` after adding new model CFCs
+- **Closure gotcha**: CFML closures can't access outer `local` vars — use shared structs (`var result = {count: 0}`)
+- Run with MCP `wheels_test()` or CLI `wheels test run`
 
 ## Background Jobs Quick Reference
 
@@ -356,6 +365,7 @@ Deeper documentation lives in `.ai/` — Claude will search it automatically whe
 - `.ai/wheels/controllers/` — filters, rendering, security
 - `.ai/wheels/views/` — layouts, partials, form helpers, link helpers
 - `.ai/wheels/database/` — migration column types, queries, advanced operations
+- `.ai/wheels/testing/` — unit testing with TestBox, test infrastructure, common gotchas
 - `.ai/wheels/configuration/` — routing, environments, settings
 
 ## MCP Server

--- a/docs/src/working-with-wheels/testing-your-application.md
+++ b/docs/src/working-with-wheels/testing-your-application.md
@@ -724,6 +724,96 @@ Your test suite should provide comprehensive coverage for:
 
 For detailed guidance on what to test and testing strategies, see the [TestBox Testing Code Coverage documentation](https://testbox.ortusbooks.com/v6.x/digging-deeper/introduction).
 
+## Common Gotchas
+
+### CFML Closure Scoping
+
+Closures in CFML have their own `local` scope. You **cannot** read or write outer `local` variables from inside a closure — assignments create a new variable in the closure's scope instead.
+
+```cfm
+// WRONG — count inside the closure is a different variable
+var count = 0;
+model("User").findEach(callback = function(user) {
+    count++; // Modifies the closure's own local.count, not the outer one
+});
+expect(count).toBe(10); // FAILS — count is still 0
+
+// RIGHT — use a shared struct (structs are passed by reference)
+var result = {count: 0};
+model("User").findEach(callback = function(user) {
+    result.count++; // Modifies the shared struct
+});
+expect(result.count).toBe(10); // PASSES
+```
+
+This applies to any test that passes a closure to a Wheels method (`findEach`, `findInBatches`, callbacks, etc.).
+
+### Model Cache Requires Reload After Adding New Models
+
+When you add a new model CFC to `tests/_assets/models/`, the first test run may fail with errors like `table 'authorscopeds' not found`. This happens because Wheels caches model metadata and hasn't loaded your new model's `config()` method yet — so it falls back to convention-based table naming.
+
+**Fix:** Append `&reload=true` to the test runner URL to clear the model cache:
+
+```
+http://localhost:8080/wheels/app/tests?format=json&directory=tests.specs.models&reload=true
+```
+
+You only need to do this once after adding or renaming model CFCs. Subsequent runs without `&reload=true` will work fine.
+
+### Use DROP + CREATE in populate.cfm, Not IF NOT EXISTS
+
+When setting up test tables in `populate.cfm`, always drop and recreate tables rather than using `CREATE TABLE IF NOT EXISTS`:
+
+```cfm
+<!--- WRONG — if the table exists from a previous run with a different schema,
+      IF NOT EXISTS skips the CREATE and your new columns are missing --->
+<cfquery datasource="#application.wheels.dataSourceName#">
+    CREATE TABLE IF NOT EXISTS my_test_table (...)
+</cfquery>
+
+<!--- RIGHT — DROP first guarantees a clean schema every time --->
+<cftry>
+    <cfquery datasource="#application.wheels.dataSourceName#">
+        DROP TABLE IF EXISTS my_test_table
+    </cfquery>
+    <cfcatch></cfcatch>
+</cftry>
+<cfquery datasource="#application.wheels.dataSourceName#">
+    CREATE TABLE my_test_table (...)
+</cfquery>
+```
+
+**Why?** If you add a column to a test table (e.g., adding a `status` column for enum tests), `IF NOT EXISTS` silently skips the `CREATE` when the table already exists from a previous test run — and the new column is missing. DROP + CREATE ensures the schema matches your current test requirements.
+
+{% hint style="warning" %}
+When dropping tables, drop child tables (with foreign keys) before parent tables to avoid constraint errors.
+{% endhint %}
+
+### Test Model CFCs Must Override the Table Name
+
+Test models in `tests/_assets/models/` should always call `table()` in their `config()` to explicitly set the table name. Without it, Wheels pluralizes the component name using conventions — which often produces unexpected results for compound names.
+
+```cfm
+// Without table() override, Wheels would look for a table called "authorscopeds"
+component extends="Model" {
+    function config() {
+        table("c_o_r_e_authors"); // Explicit table name
+        scope(name="active", where="active = 1");
+    }
+}
+```
+
+### TestBox JSON Output Contains Non-Standard Booleans
+
+When parsing TestBox JSON results programmatically (e.g., in CI/CD scripts), be aware that the Wheels TestBox runner may produce JSON with unquoted `true`/`false` boolean values, which can cause strict JSON parsers to fail.
+
+**Workaround:** Use Node.js `JSON.parse()` instead of tools like `jq` for parsing test results:
+
+```bash
+curl -sL "http://localhost:8080/wheels/app/tests?format=json" > results.json
+node -e "const j = JSON.parse(require('fs').readFileSync('results.json','utf8')); console.log('Passed:', j.totalPass, '| Failed:', j.totalFail)"
+```
+
 ## Best Practices
 
 For comprehensive testing best practices and advanced techniques, refer to the [TestBox Testing documentation](https://testbox.ortusbooks.com/v6.x/digging-deeper/life-cycle-methods).


### PR DESCRIPTION
## Summary

- Add "Common Gotchas" section to `docs/src/working-with-wheels/testing-your-application.md` covering 5 pitfalls discovered during Phase 1 feature testing
- Update CLAUDE.md testing section with accurate paths and key warnings
- Create `.ai/wheels/testing/unit-testing.md` AI reference doc for TestBox test infrastructure

## Gotchas Documented

1. **CFML closure scoping** — closures can't access outer `local` vars; use shared structs
2. **Model cache reload** — `&reload=true` needed after adding new model CFCs
3. **DROP+CREATE vs IF NOT EXISTS** — stale tables miss schema changes in populate.cfm
4. **Test model table naming** — always call `table()` to avoid convention surprises
5. **TestBox JSON parsing** — non-standard booleans break strict parsers; use Node.js

## Test plan

- [x] No code changes, documentation only
- [x] Verified all gotchas against live test environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)