### PR TITLE
feat: middleware pipeline (#1906)

### DIFF
--- a/.ai/wheels/middleware/middleware-pipeline.md
+++ b/.ai/wheels/middleware/middleware-pipeline.md
@@ -1,0 +1,133 @@
+# Middleware Pipeline
+
+## Architecture
+
+Middleware runs at the dispatch level in `Dispatch.cfc`, wrapping controller execution. The pipeline uses nested closures (onion model) — first registered = outermost layer.
+
+```
+Dispatch.$request()
+  → $buildMiddlewarePipeline()        # on $init(), from application.wheels.middleware
+  → $getRouteMiddleware(params)       # per-request, from matched route
+  → Pipeline.run(request, coreHandler)
+      → middleware[1].handle(request, next)
+          → middleware[2].handle(request, next)
+              → coreHandler(request)   # controller() + processAction()
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `vendor/wheels/middleware/MiddlewareInterface.cfc` | Contract: `handle(request, next)` |
+| `vendor/wheels/middleware/Pipeline.cfc` | Chains middleware via nested closures |
+| `vendor/wheels/middleware/RequestId.cfc` | Adds `X-Request-Id` header + `request.wheels.requestId` |
+| `vendor/wheels/middleware/Cors.cfc` | CORS headers + OPTIONS preflight |
+| `vendor/wheels/middleware/SecurityHeaders.cfc` | OWASP security headers |
+| `vendor/wheels/Dispatch.cfc` | `$buildMiddlewarePipeline()`, `$getRouteMiddleware()`, modified `$request()` |
+| `vendor/wheels/mapper/scoping.cfc` | `middleware` param on `scope()`, parent-child merging |
+| `vendor/wheels/mapper/matching.cfc` | Copies `middleware` from scope stack to matched route |
+| `vendor/wheels/events/onapplicationstart.cfc` | Initializes `application.$wheels.middleware = []` |
+
+## Pipeline.cfc Internals
+
+`Pipeline.run(request, coreHandler)` iterates middleware in reverse, wrapping each around the next handler:
+
+```cfm
+// Build chain from inside out
+local.next = arguments.coreHandler;
+for (local.i = ArrayLen(variables.middleware); local.i >= 1; local.i--) {
+    local.next = $wrapMiddleware(variables.middleware[local.i], local.next);
+}
+return local.next(arguments.request);
+```
+
+**CFML closure scoping gotcha:** `$wrapMiddleware` uses a shared `var ctx = {}` struct because closures in CFML have their own `local` scope. Writing `local.mw` inside a closure creates a new variable, not a reference to the enclosing function's `local.mw`.
+
+```cfm
+private any function $wrapMiddleware(required any mw, required any nextFn) {
+    var ctx = {mw = arguments.mw, nextFn = arguments.nextFn};
+    return function(required struct request) {
+        return ctx.mw.handle(request = arguments.request, next = ctx.nextFn);
+    };
+}
+```
+
+## Registration
+
+### Global (config/settings.cfm)
+
+```cfm
+set(middleware = [
+    new wheels.middleware.RequestId(),
+    new wheels.middleware.SecurityHeaders(),
+    new wheels.middleware.Cors(allowOrigins="https://myapp.com")
+]);
+```
+
+Accepts instances or string CFC paths (auto-instantiated with `init()`).
+
+### Route-scoped (config/routes.cfm)
+
+```cfm
+mapper()
+    .scope(path="/api", middleware=["app.middleware.ApiAuth"])
+        .resources("users")
+    .end()
+.end();
+```
+
+Route middleware runs after global middleware. Nested scopes inherit parent middleware.
+
+## Dispatch.cfc Integration
+
+In `$request()`, the controller dispatch is wrapped in a `coreHandler` closure:
+
+```cfm
+local.coreHandler = function(required struct request) {
+    local.ctrl = controller(name=request.params.controller, params=request.params);
+    local.ctrl.processAction();
+    if (local.ctrl.$performedRedirect()) {
+        $location(argumentCollection=local.ctrl.getRedirect());
+    }
+    local.ctrl.$flashClear();
+    return local.ctrl.response();
+};
+```
+
+If route-scoped middleware exists, a merged pipeline (global + route) is created per-request. Otherwise the pre-built global pipeline is used.
+
+## Request Context Struct
+
+The `request` struct passed through middleware contains:
+
+| Key | Description |
+|-----|-------------|
+| `params` | Merged URL/form/route params (same as controller `params`) |
+| `route` | The matched route struct from `request.wheels.currentRoute` |
+| `pathInfo` | Raw path info string |
+| `method` | HTTP method (GET, POST, etc.) |
+
+Middleware can add arbitrary keys (e.g., `request.currentUser`) for downstream access.
+
+## Built-in Middleware Reference
+
+### RequestId
+- No constructor args
+- Sets `request.wheels.requestId = CreateUUID()`
+- Adds `X-Request-Id` response header
+
+### Cors
+- `allowOrigins` (default `"*"`) — comma-delimited origins
+- `allowMethods` (default `"GET,POST,PUT,PATCH,DELETE,OPTIONS"`)
+- `allowHeaders` (default `"Content-Type,Authorization,X-Requested-With"`)
+- `allowCredentials` (default `false`)
+- `maxAge` (default `86400`) — preflight cache seconds
+- Short-circuits on OPTIONS with empty response
+
+### SecurityHeaders
+- `frameOptions` (default `"SAMEORIGIN"`)
+- `contentTypeOptions` (default `"nosniff"`)
+- `xssProtection` (default `"1; mode=block"`)
+- `referrerPolicy` (default `"strict-origin-when-cross-origin"`)
+- Set any to `""` to disable that header
+- Runs after `next()` (post-processing pattern)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,30 @@ model("User").findInBatches(batchSize=500, callback=function(users) {
 model("User").active().findEach(batchSize=500, callback=function(user) { /* ... */ });
 ```
 
+## Middleware Quick Reference
+
+Middleware runs at the dispatch level, before controller instantiation. Each implements `handle(request, next)`.
+
+```cfm
+// config/settings.cfm — global middleware (runs on every request)
+set(middleware = [
+    new wheels.middleware.RequestId(),
+    new wheels.middleware.SecurityHeaders(),
+    new wheels.middleware.Cors(allowOrigins="https://myapp.com")
+]);
+```
+
+```cfm
+// config/routes.cfm — route-scoped middleware
+mapper()
+    .scope(path="/api", middleware=["app.middleware.ApiAuth"])
+        .resources("users")
+    .end()
+.end();
+```
+
+Built-in: `wheels.middleware.RequestId`, `wheels.middleware.Cors`, `wheels.middleware.SecurityHeaders`. Custom middleware: implement `wheels.middleware.MiddlewareInterface`, place in `app/middleware/`.
+
 ## Routing Quick Reference
 
 ```cfm

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -132,6 +132,7 @@
 * [Sending Email](handling-requests-with-controllers/sending-email.md)
 * [Responding with Multiple Formats](handling-requests-with-controllers/responding-with-multiple-formats.md)
 * [Using the Flash](handling-requests-with-controllers/using-the-flash.md)
+* [Middleware](handling-requests-with-controllers/middleware.md)
 * [Using Filters](handling-requests-with-controllers/using-filters.md)
 * [Verification](handling-requests-with-controllers/verification.md)
 * [Event Handlers](handling-requests-with-controllers/event-handlers.md)

--- a/docs/src/handling-requests-with-controllers/middleware.md
+++ b/docs/src/handling-requests-with-controllers/middleware.md
@@ -1,0 +1,233 @@
+---
+description: Use middleware to process requests before they reach your controllers — add headers, enforce CORS, reject unauthorized requests, and more.
+---
+
+# Middleware
+
+Middleware lets you intercept and modify requests at the **dispatch level**, before a controller is even instantiated. This is different from [filters](using-filters.md), which run inside a specific controller.
+
+Use middleware when you need logic that applies globally or to groups of routes — things like request IDs, CORS headers, security headers, rate limiting, or authentication gates.
+
+## How It Works
+
+Each middleware implements a simple contract: receive a `request` struct and a `next` function, do your work, then call `next(request)` to pass control down the chain. The last step in the chain is the actual controller dispatch.
+
+```
+Request → RequestId → Cors → SecurityHeaders → Controller → Response
+                                                    ↑
+                                              next(request)
+```
+
+This is sometimes called the "onion model" — the first middleware registered is the outermost layer.
+
+## The Middleware Interface
+
+Every middleware component must implement `wheels.middleware.MiddlewareInterface`:
+
+```cfm
+// vendor/wheels/middleware/MiddlewareInterface.cfc
+interface {
+    public string function handle(required struct request, required any next);
+}
+```
+
+- **`request`** — A struct containing `params`, `route`, `pathInfo`, and `method`, plus any data added by prior middleware.
+- **`next`** — A closure. Call `next(request)` to continue to the next middleware (or the controller). Skip it to short-circuit the pipeline.
+- **Return value** — The response string.
+
+## Registering Global Middleware
+
+Register middleware in `config/settings.cfm`. They run on **every request** in the order listed:
+
+```cfm
+// config/settings.cfm
+set(
+    middleware = [
+        new wheels.middleware.RequestId(),
+        new wheels.middleware.SecurityHeaders(),
+        new wheels.middleware.Cors(allowOrigins="https://myapp.com")
+    ]
+);
+```
+
+You can pass component instances (as above) or CFC dot-paths as strings:
+
+```cfm
+set(middleware = ["wheels.middleware.RequestId", "app.middleware.RateLimiter"]);
+```
+
+String paths are instantiated automatically with a no-arg `init()`.
+
+## Route-Scoped Middleware
+
+Attach middleware to specific route groups using the `middleware` argument on `scope()`:
+
+```cfm
+// config/routes.cfm
+mapper()
+    .scope(path="/api", middleware=[new app.middleware.ApiAuth()])
+        .resources("users")
+        .resources("products")
+    .end()
+    .resources("pages")  // no ApiAuth middleware here
+.end();
+```
+
+Route-scoped middleware runs **after** global middleware. Scopes nest — child scopes inherit and append to parent middleware:
+
+```cfm
+mapper()
+    .scope(path="/api", middleware=["app.middleware.ApiAuth"])
+        .scope(path="/admin", middleware=["app.middleware.AdminOnly"])
+            .resources("settings")  // runs: global → ApiAuth → AdminOnly
+        .end()
+        .resources("users")         // runs: global → ApiAuth
+    .end()
+.end();
+```
+
+## Built-in Middleware
+
+Wheels ships with three middleware components you can use immediately.
+
+### RequestId
+
+Assigns a unique UUID to every request for tracing and debugging.
+
+- Sets `request.wheels.requestId`
+- Adds `X-Request-Id` response header
+
+```cfm
+set(middleware = [new wheels.middleware.RequestId()]);
+```
+
+### SecurityHeaders
+
+Adds OWASP-recommended security headers to every response.
+
+| Header | Default |
+|--------|---------|
+| `X-Frame-Options` | `SAMEORIGIN` |
+| `X-Content-Type-Options` | `nosniff` |
+| `X-XSS-Protection` | `1; mode=block` |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` |
+
+```cfm
+// Use defaults
+set(middleware = [new wheels.middleware.SecurityHeaders()]);
+
+// Customize
+set(middleware = [
+    new wheels.middleware.SecurityHeaders(
+        frameOptions = "DENY",
+        referrerPolicy = "no-referrer"
+    )
+]);
+```
+
+Set any parameter to an empty string to disable that header.
+
+### Cors
+
+Handles Cross-Origin Resource Sharing headers and OPTIONS preflight requests.
+
+```cfm
+set(middleware = [
+    new wheels.middleware.Cors(
+        allowOrigins = "https://myapp.com,https://admin.myapp.com",
+        allowMethods = "GET,POST,PUT,DELETE",
+        allowHeaders = "Content-Type,Authorization",
+        allowCredentials = true,
+        maxAge = 86400
+    )
+]);
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `allowOrigins` | `"*"` | Comma-delimited list of allowed origins |
+| `allowMethods` | `"GET,POST,PUT,PATCH,DELETE,OPTIONS"` | Allowed HTTP methods |
+| `allowHeaders` | `"Content-Type,Authorization,X-Requested-With"` | Allowed request headers |
+| `allowCredentials` | `false` | Whether to allow cookies/auth headers |
+| `maxAge` | `86400` | Preflight cache duration in seconds |
+
+For simple CORS needs, you may prefer the existing [CORS Requests](cors-requests.md) guide which covers header-only approaches.
+
+## Writing Custom Middleware
+
+Create a CFC that implements `wheels.middleware.MiddlewareInterface`:
+
+```cfm
+// app/middleware/RateLimiter.cfc
+component implements="wheels.middleware.MiddlewareInterface" output="false" {
+
+    public RateLimiter function init(numeric maxRequests = 100) {
+        variables.maxRequests = arguments.maxRequests;
+        return this;
+    }
+
+    public string function handle(required struct request, required any next) {
+        // Check rate limit (pseudo-code)
+        local.clientIp = cgi.remote_addr;
+        if ($isRateLimited(local.clientIp)) {
+            cfheader(statusCode="429", statusText="Too Many Requests");
+            return "Rate limit exceeded. Try again later.";
+        }
+
+        // Continue to next middleware / controller
+        return arguments.next(arguments.request);
+    }
+
+    private boolean function $isRateLimited(required string ip) {
+        // Your rate limiting logic here
+        return false;
+    }
+
+}
+```
+
+### Patterns
+
+**Enrich the request** — add data for downstream middleware or the controller:
+
+```cfm
+public string function handle(required struct request, required any next) {
+    arguments.request.currentUser = $lookupUser();
+    return arguments.next(arguments.request);
+}
+```
+
+**Short-circuit** — return a response without calling `next()`:
+
+```cfm
+public string function handle(required struct request, required any next) {
+    if (!$isAuthenticated(arguments.request)) {
+        cfheader(statusCode="401");
+        return "Unauthorized";
+    }
+    return arguments.next(arguments.request);
+}
+```
+
+**Post-process** — modify the response after the controller runs:
+
+```cfm
+public string function handle(required struct request, required any next) {
+    local.startTick = GetTickCount();
+    local.response = arguments.next(arguments.request);
+    local.elapsed = GetTickCount() - local.startTick;
+    cfheader(name="X-Response-Time", value="#local.elapsed#ms");
+    return local.response;
+}
+```
+
+## Middleware vs. Filters
+
+| | Middleware | Filters |
+|---|---|---|
+| **Runs at** | Dispatch level (before controller) | Controller level (inside controller) |
+| **Scope** | Global or route group | Single controller |
+| **Access to** | Request struct, response string | Controller instance, `params`, views |
+| **Best for** | Cross-cutting concerns (auth, headers, logging) | Controller-specific logic (load record, check permissions) |
+
+Both can coexist. A typical setup might use middleware for security headers and request IDs globally, then filters for loading specific records inside individual controllers.

--- a/tests/specs/middleware/MiddlewarePipelineSpec.cfc
+++ b/tests/specs/middleware/MiddlewarePipelineSpec.cfc
@@ -1,0 +1,145 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("Middleware Pipeline", function() {
+
+			describe("Pipeline.init()", function() {
+
+				it("creates an empty pipeline with no middleware", function() {
+					var pipeline = new wheels.middleware.Pipeline();
+					expect(pipeline.getMiddleware()).toBeArray();
+					expect(ArrayLen(pipeline.getMiddleware())).toBe(0);
+				});
+
+				it("accepts an array of middleware instances", function() {
+					var mw = new wheels.middleware.RequestId();
+					var pipeline = new wheels.middleware.Pipeline(middleware = [mw]);
+					expect(ArrayLen(pipeline.getMiddleware())).toBe(1);
+				});
+
+			});
+
+			describe("Pipeline.run()", function() {
+
+				it("calls the core handler when no middleware is registered", function() {
+					var pipeline = new wheels.middleware.Pipeline();
+					var shared = {called = false};
+					var handler = function(required struct request) {
+						shared.called = true;
+						return "core response";
+					};
+					var result = pipeline.run(request = {}, coreHandler = handler);
+					expect(result).toBe("core response");
+					expect(shared.called).toBeTrue();
+				});
+
+				it("passes request through a single middleware to core handler", function() {
+					var shared = {order = []};
+					var mw = new tests.specs.middleware._helpers.TrackingMiddleware(id = "A", tracker = shared);
+					var pipeline = new wheels.middleware.Pipeline(middleware = [mw]);
+					var handler = function(required struct request) {
+						ArrayAppend(shared.order, "core");
+						return "done";
+					};
+					var result = pipeline.run(request = {}, coreHandler = handler);
+					expect(shared.order[1]).toBe("before:A");
+					expect(shared.order[2]).toBe("core");
+					expect(shared.order[3]).toBe("after:A");
+					expect(result).toBe("done");
+				});
+
+				it("executes multiple middleware in correct order", function() {
+					var shared = {order = []};
+					var mwA = new tests.specs.middleware._helpers.TrackingMiddleware(id = "A", tracker = shared);
+					var mwB = new tests.specs.middleware._helpers.TrackingMiddleware(id = "B", tracker = shared);
+					var pipeline = new wheels.middleware.Pipeline(middleware = [mwA, mwB]);
+					var handler = function(required struct request) {
+						ArrayAppend(shared.order, "core");
+						return "done";
+					};
+					pipeline.run(request = {}, coreHandler = handler);
+					// A wraps B wraps core: before:A, before:B, core, after:B, after:A
+					expect(shared.order[1]).toBe("before:A");
+					expect(shared.order[2]).toBe("before:B");
+					expect(shared.order[3]).toBe("core");
+					expect(shared.order[4]).toBe("after:B");
+					expect(shared.order[5]).toBe("after:A");
+				});
+
+				it("allows middleware to short-circuit the pipeline", function() {
+					var shared = {order = []};
+					var blocker = new tests.specs.middleware._helpers.BlockingMiddleware(tracker = shared);
+					var mwB = new tests.specs.middleware._helpers.TrackingMiddleware(id = "B", tracker = shared);
+					var pipeline = new wheels.middleware.Pipeline(middleware = [blocker, mwB]);
+					var handler = function(required struct request) {
+						ArrayAppend(shared.order, "core");
+						return "should not reach";
+					};
+					var result = pipeline.run(request = {}, coreHandler = handler);
+					expect(result).toBe("blocked");
+					expect(ArrayLen(shared.order)).toBe(1);
+					expect(shared.order[1]).toBe("blocked");
+				});
+
+				it("passes request data through the middleware chain", function() {
+					var enricher = new tests.specs.middleware._helpers.EnrichingMiddleware();
+					var pipeline = new wheels.middleware.Pipeline(middleware = [enricher]);
+					var shared = {capturedRequest = {}};
+					var handler = function(required struct request) {
+						shared.capturedRequest = arguments.request;
+						return "done";
+					};
+					pipeline.run(request = {}, coreHandler = handler);
+					expect(StructKeyExists(shared.capturedRequest, "enriched")).toBeTrue();
+					expect(shared.capturedRequest.enriched).toBeTrue();
+				});
+
+			});
+
+			describe("Built-in Middleware", function() {
+
+				it("RequestId sets request.wheels.requestId", function() {
+					var mw = new wheels.middleware.RequestId();
+					var pipeline = new wheels.middleware.Pipeline(middleware = [mw]);
+					var handler = function(required struct request) {
+						return "ok";
+					};
+					pipeline.run(request = {}, coreHandler = handler);
+					expect(StructKeyExists(request.wheels, "requestId")).toBeTrue();
+					expect(Len(request.wheels.requestId)).toBeGT(0);
+				});
+
+				it("SecurityHeaders can be instantiated with defaults", function() {
+					var mw = new wheels.middleware.SecurityHeaders();
+					expect(mw).toBeInstanceOf("wheels.middleware.SecurityHeaders");
+				});
+
+				it("SecurityHeaders can be instantiated with custom options", function() {
+					var mw = new wheels.middleware.SecurityHeaders(
+						frameOptions = "DENY",
+						referrerPolicy = "no-referrer"
+					);
+					expect(mw).toBeInstanceOf("wheels.middleware.SecurityHeaders");
+				});
+
+				it("Cors can be instantiated with defaults", function() {
+					var mw = new wheels.middleware.Cors();
+					expect(mw).toBeInstanceOf("wheels.middleware.Cors");
+				});
+
+				it("Cors can be instantiated with custom origins", function() {
+					var mw = new wheels.middleware.Cors(
+						allowOrigins = "https://example.com,https://app.example.com",
+						allowCredentials = true
+					);
+					expect(mw).toBeInstanceOf("wheels.middleware.Cors");
+				});
+
+			});
+
+		});
+
+	}
+
+}

--- a/tests/specs/middleware/_helpers/BlockingMiddleware.cfc
+++ b/tests/specs/middleware/_helpers/BlockingMiddleware.cfc
@@ -1,0 +1,16 @@
+/**
+ * Test middleware that short-circuits the pipeline (never calls next).
+ */
+component implements="wheels.middleware.MiddlewareInterface" output="false" {
+
+	public BlockingMiddleware function init(required struct tracker) {
+		variables.tracker = arguments.tracker;
+		return this;
+	}
+
+	public string function handle(required struct request, required any next) {
+		ArrayAppend(variables.tracker.order, "blocked");
+		return "blocked";
+	}
+
+}

--- a/tests/specs/middleware/_helpers/EnrichingMiddleware.cfc
+++ b/tests/specs/middleware/_helpers/EnrichingMiddleware.cfc
@@ -1,0 +1,15 @@
+/**
+ * Test middleware that adds data to the request struct.
+ */
+component implements="wheels.middleware.MiddlewareInterface" output="false" {
+
+	public EnrichingMiddleware function init() {
+		return this;
+	}
+
+	public string function handle(required struct request, required any next) {
+		arguments.request.enriched = true;
+		return arguments.next(arguments.request);
+	}
+
+}

--- a/tests/specs/middleware/_helpers/TrackingMiddleware.cfc
+++ b/tests/specs/middleware/_helpers/TrackingMiddleware.cfc
@@ -1,0 +1,19 @@
+/**
+ * Test middleware that records before/after execution order.
+ */
+component implements="wheels.middleware.MiddlewareInterface" output="false" {
+
+	public TrackingMiddleware function init(required string id, required struct tracker) {
+		variables.id = arguments.id;
+		variables.tracker = arguments.tracker;
+		return this;
+	}
+
+	public string function handle(required struct request, required any next) {
+		ArrayAppend(variables.tracker.order, "before:#variables.id#");
+		local.response = arguments.next(arguments.request);
+		ArrayAppend(variables.tracker.order, "after:#variables.id#");
+		return local.response;
+	}
+
+}

--- a/vendor/wheels/Dispatch.cfc
+++ b/vendor/wheels/Dispatch.cfc
@@ -5,7 +5,35 @@ component output="false" extends="wheels.Global"{
 	 * Returns itself (the Dispatch object).
 	 */
 	public any function $init() {
+		// Initialize the middleware pipeline from application settings.
+		variables.$middlewarePipeline = $buildMiddlewarePipeline();
 		return this;
+	}
+
+	/**
+	 * Build the middleware pipeline from application.wheels.middleware (array of component instances or paths).
+	 */
+	private any function $buildMiddlewarePipeline() {
+		local.middlewareInstances = [];
+		if (StructKeyExists(application, "$wheels") && StructKeyExists(application.$wheels, "middleware")) {
+			local.configured = application.$wheels.middleware;
+		} else if (StructKeyExists(application, "wheels") && StructKeyExists(application.wheels, "middleware")) {
+			local.configured = application.wheels.middleware;
+		} else {
+			local.configured = [];
+		}
+
+		for (local.item in local.configured) {
+			if (IsSimpleValue(local.item)) {
+				// It's a CFC path — instantiate it.
+				ArrayAppend(local.middlewareInstances, CreateObject("component", local.item).init());
+			} else {
+				// Already an instance.
+				ArrayAppend(local.middlewareInstances, local.item);
+			}
+		}
+
+		return new wheels.middleware.Pipeline(middleware = local.middlewareInstances);
 	}
 
 	/**
@@ -262,20 +290,66 @@ component output="false" extends="wheels.Global"{
 				return "";
 			}
 		} else {
-			// Create the requested controller and call the action on it.
-			local.controller = controller(name = local.params.controller, params = local.params);
-			local.controller.processAction();
+			// Build the request context for middleware.
+			local.requestContext = {
+				params = local.params,
+				route = StructKeyExists(request.wheels, "currentRoute") ? request.wheels.currentRoute : {},
+				pathInfo = arguments.pathInfo,
+				method = $getRequestMethod()
+			};
 
-			// If there is a delayed redirect pending we execute it here thus halting the rest of the request.
-			if (local.controller.$performedRedirect()) {
-				$location(argumentCollection = local.controller.getRedirect());
+			// The core handler that middleware wraps around.
+			local.coreHandler = function(required struct request) {
+				local.ctrl = controller(name = arguments.request.params.controller, params = arguments.request.params);
+				local.ctrl.processAction();
+
+				if (local.ctrl.$performedRedirect()) {
+					$location(argumentCollection = local.ctrl.getRedirect());
+				}
+
+				local.ctrl.$flashClear();
+				return local.ctrl.response();
+			};
+
+			// Merge global + route-scoped middleware and run through the pipeline.
+			local.routeMiddleware = $getRouteMiddleware(local.params);
+			if (ArrayLen(local.routeMiddleware)) {
+				local.allMiddleware = [];
+				ArrayAppend(local.allMiddleware, variables.$middlewarePipeline.getMiddleware(), true);
+				ArrayAppend(local.allMiddleware, local.routeMiddleware, true);
+				local.pipeline = new wheels.middleware.Pipeline(middleware = local.allMiddleware);
+				return local.pipeline.run(request = local.requestContext, coreHandler = local.coreHandler);
 			}
 
-			// Clear out the flash (note that this is not done for redirects since the processing does not get here).
-			local.controller.$flashClear();
-
-			return local.controller.response();
+			return variables.$middlewarePipeline.run(request = local.requestContext, coreHandler = local.coreHandler);
 		}
+	}
+
+	/**
+	 * Resolve route-scoped middleware from the matched route's `middleware` property.
+	 * Returns an array of instantiated middleware components.
+	 */
+	private array function $getRouteMiddleware(required struct params) {
+		local.instances = [];
+		// The matched route is stored on request.wheels.currentRoute during $findMatchingRoute.
+		if (!StructKeyExists(request.wheels, "currentRoute") || !StructKeyExists(request.wheels.currentRoute, "middleware")) {
+			return local.instances;
+		}
+
+		local.routeMiddleware = request.wheels.currentRoute.middleware;
+		if (IsSimpleValue(local.routeMiddleware)) {
+			local.routeMiddleware = ListToArray(local.routeMiddleware);
+		}
+
+		for (local.item in local.routeMiddleware) {
+			if (IsSimpleValue(local.item)) {
+				ArrayAppend(local.instances, CreateObject("component", local.item).init());
+			} else {
+				ArrayAppend(local.instances, local.item);
+			}
+		}
+
+		return local.instances;
 	}
 
 	/**
@@ -289,6 +363,10 @@ component output="false" extends="wheels.Global"{
 	) {
 		local.path = $getPathFromRequest(pathInfo = arguments.pathInfo, scriptName = arguments.scriptName);
 		local.route = $findMatchingRoute(path = local.path);
+
+		// Store the matched route so middleware and other components can inspect it.
+		request.wheels.currentRoute = local.route;
+
 		return $createParams(
 			path = local.path,
 			route = local.route,

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -88,6 +88,7 @@ component {
 		application.$wheels.nonExistingObjectFiles = "";
 		application.$wheels.directoryFiles = {};
 		application.$wheels.routes = [];
+		application.$wheels.middleware = [];
 		application.$wheels.resourceControllerNaming = "plural";
 		application.$wheels.namedRoutePositions = {};
 		application.$wheels.mixins = {};

--- a/vendor/wheels/mapper/matching.cfc
+++ b/vendor/wheels/mapper/matching.cfc
@@ -361,6 +361,11 @@ component {
 			StructAppend(arguments.constraints, variables.scopeStack[1].constraints, false);
 		}
 
+		// Inherit middleware from scope stack.
+		if (!StructKeyExists(arguments, "middleware") && StructKeyExists(variables.scopeStack[1], "middleware")) {
+			arguments.middleware = variables.scopeStack[1].middleware;
+		}
+
 		// Add shallow path to pattern.
 		// Or, add scoped path to pattern.
 		if ($shallow()) {

--- a/vendor/wheels/mapper/scoping.cfc
+++ b/vendor/wheels/mapper/scoping.cfc
@@ -23,6 +23,7 @@ component {
 		string shallowPath,
 		string shallowName,
 		struct constraints,
+		any middleware,
 		string $call = "scope"
 	) {
 		// Set shallow path and prefix if not in a resource.
@@ -59,6 +60,21 @@ component {
 		// Copy existing constraints if they were previously set.
 		if (StructKeyExists(variables.scopeStack[1], "constraints") && StructKeyExists(arguments, "constraints")) {
 			StructAppend(arguments.constraints, variables.scopeStack[1].constraints, false);
+		}
+
+		// Merge middleware from parent scope with current scope.
+		if (StructKeyExists(arguments, "middleware") || StructKeyExists(variables.scopeStack[1], "middleware")) {
+			local.parentMiddleware = StructKeyExists(variables.scopeStack[1], "middleware") ? variables.scopeStack[1].middleware : [];
+			local.currentMiddleware = StructKeyExists(arguments, "middleware") ? arguments.middleware : [];
+			if (IsSimpleValue(local.currentMiddleware)) {
+				local.currentMiddleware = ListToArray(local.currentMiddleware);
+			}
+			if (IsSimpleValue(local.parentMiddleware)) {
+				local.parentMiddleware = ListToArray(local.parentMiddleware);
+			}
+			arguments.middleware = [];
+			ArrayAppend(arguments.middleware, local.parentMiddleware, true);
+			ArrayAppend(arguments.middleware, local.currentMiddleware, true);
 		}
 
 		// Put scope arguments on the stack.

--- a/vendor/wheels/middleware/Cors.cfc
+++ b/vendor/wheels/middleware/Cors.cfc
@@ -1,0 +1,87 @@
+/**
+ * Handles Cross-Origin Resource Sharing (CORS) headers.
+ * Responds to preflight OPTIONS requests and sets appropriate CORS headers on all responses.
+ *
+ * [section: Middleware]
+ * [category: Built-in]
+ */
+component implements="wheels.middleware.MiddlewareInterface" output="false" {
+
+	/**
+	 * Creates the CORS middleware with configurable options.
+	 *
+	 * @allowOrigins Comma-delimited list of allowed origins. Use "*" for any origin.
+	 * @allowMethods Comma-delimited list of allowed HTTP methods.
+	 * @allowHeaders Comma-delimited list of allowed request headers.
+	 * @allowCredentials Whether to allow credentials (cookies, auth headers).
+	 * @maxAge Preflight cache duration in seconds.
+	 */
+	public Cors function init(
+		string allowOrigins = "*",
+		string allowMethods = "GET,POST,PUT,PATCH,DELETE,OPTIONS",
+		string allowHeaders = "Content-Type,Authorization,X-Requested-With",
+		boolean allowCredentials = false,
+		numeric maxAge = 86400
+	) {
+		variables.allowOrigins = arguments.allowOrigins;
+		variables.allowMethods = arguments.allowMethods;
+		variables.allowHeaders = arguments.allowHeaders;
+		variables.allowCredentials = arguments.allowCredentials;
+		variables.maxAge = arguments.maxAge;
+		return this;
+	}
+
+	public string function handle(required struct request, required any next) {
+		// Determine the request origin.
+		local.origin = "";
+		if (StructKeyExists(request, "cgi") && StructKeyExists(request.cgi, "http_origin")) {
+			local.origin = request.cgi.http_origin;
+		} else {
+			try {
+				local.origin = cgi.http_origin;
+			} catch (any e) {
+			}
+		}
+
+		// Set CORS headers.
+		local.allowOrigin = variables.allowOrigins;
+		if (variables.allowOrigins != "*" && Len(local.origin)) {
+			// Only reflect the origin if it's in the allowed list.
+			if (ListFindNoCase(variables.allowOrigins, local.origin)) {
+				local.allowOrigin = local.origin;
+			} else {
+				local.allowOrigin = "";
+			}
+		}
+
+		if (Len(local.allowOrigin)) {
+			try {
+				cfheader(name = "Access-Control-Allow-Origin", value = local.allowOrigin);
+				cfheader(name = "Access-Control-Allow-Methods", value = variables.allowMethods);
+				cfheader(name = "Access-Control-Allow-Headers", value = variables.allowHeaders);
+				if (variables.allowCredentials) {
+					cfheader(name = "Access-Control-Allow-Credentials", value = "true");
+				}
+			} catch (any e) {
+			}
+		}
+
+		// Handle preflight OPTIONS request — return empty response immediately.
+		local.requestMethod = "GET";
+		try {
+			local.requestMethod = cgi.request_method;
+		} catch (any e) {
+		}
+
+		if (local.requestMethod == "OPTIONS") {
+			try {
+				cfheader(name = "Access-Control-Max-Age", value = variables.maxAge);
+			} catch (any e) {
+			}
+			return "";
+		}
+
+		return arguments.next(arguments.request);
+	}
+
+}

--- a/vendor/wheels/middleware/MiddlewareInterface.cfc
+++ b/vendor/wheels/middleware/MiddlewareInterface.cfc
@@ -1,0 +1,19 @@
+/**
+ * Interface that all middleware components must implement.
+ * Middleware runs at the dispatch level, before controller instantiation.
+ *
+ * [section: Middleware]
+ * [category: Core]
+ */
+interface {
+
+	/**
+	 * Handle the incoming request.
+	 *
+	 * @request Struct containing route params, CGI info, and any data added by prior middleware.
+	 * @next Closure that calls the next middleware in the pipeline. Invoke as `next(request)`.
+	 * @return The response string from the controller (or from a short-circuiting middleware).
+	 */
+	public string function handle(required struct request, required any next);
+
+}

--- a/vendor/wheels/middleware/Pipeline.cfc
+++ b/vendor/wheels/middleware/Pipeline.cfc
@@ -1,0 +1,59 @@
+/**
+ * Chains middleware components into a pipeline using nested closures.
+ * Each middleware calls `next(request)` to pass control to the next one.
+ * The final closure in the chain executes the actual controller dispatch.
+ *
+ * [section: Middleware]
+ * [category: Core]
+ */
+component output="false" {
+
+	/**
+	 * Creates a new middleware pipeline.
+	 *
+	 * @middleware Array of middleware component instances (each implements MiddlewareInterface).
+	 */
+	public Pipeline function init(array middleware = []) {
+		variables.middleware = arguments.middleware;
+		return this;
+	}
+
+	/**
+	 * Run the pipeline, wrapping the given core handler with all registered middleware.
+	 *
+	 * @request Struct containing route params and request context.
+	 * @coreHandler Closure that performs the actual controller dispatch. Signature: `function(request)`.
+	 * @return The response string.
+	 */
+	public string function run(required struct request, required any coreHandler) {
+		// Build the chain from inside out: start with the core handler,
+		// then wrap each middleware around it in reverse order.
+		local.next = arguments.coreHandler;
+
+		// Iterate in reverse so the first middleware in the array runs first.
+		for (local.i = ArrayLen(variables.middleware); local.i >= 1; local.i--) {
+			local.next = $wrapMiddleware(variables.middleware[local.i], local.next);
+		}
+
+		return local.next(arguments.request);
+	}
+
+	/**
+	 * Returns the current middleware stack (for inspection/testing).
+	 */
+	public array function getMiddleware() {
+		return variables.middleware;
+	}
+
+	/**
+	 * Create a closure that invokes a single middleware's handle() with the given next function.
+	 * Uses a shared struct to avoid CFML closure scoping issues (closures have their own local scope).
+	 */
+	private any function $wrapMiddleware(required any mw, required any nextFn) {
+		var ctx = {mw = arguments.mw, nextFn = arguments.nextFn};
+		return function(required struct request) {
+			return ctx.mw.handle(request = arguments.request, next = ctx.nextFn);
+		};
+	}
+
+}

--- a/vendor/wheels/middleware/RequestId.cfc
+++ b/vendor/wheels/middleware/RequestId.cfc
@@ -1,0 +1,28 @@
+/**
+ * Adds a unique request ID to every request for tracing and debugging.
+ * Sets `request.wheels.requestId` and adds an `X-Request-Id` response header.
+ *
+ * [section: Middleware]
+ * [category: Built-in]
+ */
+component implements="wheels.middleware.MiddlewareInterface" output="false" {
+
+	public string function handle(required struct request, required any next) {
+		// Generate a unique request ID.
+		local.requestId = CreateUUID();
+		request.wheels.requestId = local.requestId;
+
+		// Call the next middleware / controller dispatch.
+		local.response = arguments.next(arguments.request);
+
+		// Set response header (safe to call even if headers already sent).
+		try {
+			cfheader(name = "X-Request-Id", value = local.requestId);
+		} catch (any e) {
+			// Headers may already be flushed — silently ignore.
+		}
+
+		return local.response;
+	}
+
+}

--- a/vendor/wheels/middleware/SecurityHeaders.cfc
+++ b/vendor/wheels/middleware/SecurityHeaders.cfc
@@ -1,0 +1,56 @@
+/**
+ * Adds common security headers to every response.
+ * Covers OWASP recommended headers for clickjacking, XSS, MIME sniffing, and referrer leakage.
+ *
+ * [section: Middleware]
+ * [category: Built-in]
+ */
+component implements="wheels.middleware.MiddlewareInterface" output="false" {
+
+	/**
+	 * Creates the SecurityHeaders middleware with configurable options.
+	 *
+	 * @frameOptions X-Frame-Options value. Set to empty string to disable.
+	 * @contentTypeOptions X-Content-Type-Options value.
+	 * @xssProtection X-XSS-Protection value.
+	 * @referrerPolicy Referrer-Policy value.
+	 */
+	public SecurityHeaders function init(
+		string frameOptions = "SAMEORIGIN",
+		string contentTypeOptions = "nosniff",
+		string xssProtection = "1; mode=block",
+		string referrerPolicy = "strict-origin-when-cross-origin"
+	) {
+		variables.headers = {};
+		if (Len(arguments.frameOptions)) {
+			variables.headers["X-Frame-Options"] = arguments.frameOptions;
+		}
+		if (Len(arguments.contentTypeOptions)) {
+			variables.headers["X-Content-Type-Options"] = arguments.contentTypeOptions;
+		}
+		if (Len(arguments.xssProtection)) {
+			variables.headers["X-XSS-Protection"] = arguments.xssProtection;
+		}
+		if (Len(arguments.referrerPolicy)) {
+			variables.headers["Referrer-Policy"] = arguments.referrerPolicy;
+		}
+		return this;
+	}
+
+	public string function handle(required struct request, required any next) {
+		// Execute the rest of the pipeline first.
+		local.response = arguments.next(arguments.request);
+
+		// Apply security headers.
+		try {
+			for (local.name in variables.headers) {
+				cfheader(name = local.name, value = variables.headers[local.name]);
+			}
+		} catch (any e) {
+			// Headers may already be flushed.
+		}
+
+		return local.response;
+	}
+
+}


### PR DESCRIPTION
## Summary

- Adds dispatch-level middleware pipeline with `handle(request, next)` contract
- Global middleware via `set(middleware=[...])` in `config/settings.cfm`
- Route-scoped middleware via `middleware` parameter on routes/scopes/groups
- Ships 3 built-in middleware: `RequestId`, `Cors`, `SecurityHeaders`
- 12 TestBox BDD specs covering pipeline ordering, short-circuiting, request enrichment, and built-in middleware

## Design

Middleware runs **before controller instantiation** at the dispatch level, complementing (not replacing) the existing controller-scoped `filters()` system. The pipeline uses nested closures — each middleware calls `next(request)` to continue, or returns early to short-circuit.

```cfm
// config/settings.cfm — register global middleware
set(middleware = [
    new wheels.middleware.RequestId(),
    new wheels.middleware.SecurityHeaders(),
    new wheels.middleware.Cors(allowOrigins="https://myapp.com")
]);

// config/routes.cfm — route-scoped middleware
mapper()
    .scope(path="api", middleware=["app.middleware.ApiAuth"])
        .resources("users")
    .end()
.end();
```

## Files Changed

| File | Change |
|------|--------|
| `vendor/wheels/middleware/MiddlewareInterface.cfc` | New — interface contract |
| `vendor/wheels/middleware/Pipeline.cfc` | New — closure-based chain executor |
| `vendor/wheels/middleware/RequestId.cfc` | New — adds X-Request-Id header |
| `vendor/wheels/middleware/Cors.cfc` | New — CORS headers + OPTIONS preflight |
| `vendor/wheels/middleware/SecurityHeaders.cfc` | New — OWASP security headers |
| `vendor/wheels/Dispatch.cfc` | Modified — wraps controller dispatch in pipeline |
| `vendor/wheels/events/onapplicationstart.cfc` | Modified — initializes `middleware` setting |
| `vendor/wheels/mapper/matching.cfc` | Modified — inherits middleware from scope stack |
| `vendor/wheels/mapper/scoping.cfc` | Modified — adds `middleware` param, merges from parent scopes |
| `tests/specs/middleware/` | New — 12 TestBox BDD specs + 3 test helper middleware |

## Backwards Compatibility

- Existing `filters()` in controllers work unchanged
- No middleware runs by default (`application.wheels.middleware` starts as empty array)
- Route definitions without `middleware` parameter are unaffected

## Test Plan

- [x] 12/12 middleware pipeline specs pass
- [x] 68/68 total specs pass (no regressions)
- [ ] CI matrix (Lucee 5/6/7, Adobe 2018-2025, BoxLang)

Closes #1906

🤖 Generated with [Claude Code](https://claude.com/claude-code)