### PR TITLE
fix: detect and run gap migrations in migrateTo()

### DIFF
--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -28,13 +28,23 @@ component output="false" extends="wheels.Global"{
 		local.rv = "";
 		local.currentVersion = getCurrentMigrationVersion();
 		local.appKey = $appKey();
-		if (local.currentVersion == arguments.version) {
+
+		// Load migrations early to detect unapplied "gap" migrations before short-circuiting
+		local.migrations = getAvailableMigrations();
+		local.hasPendingMigrations = false;
+		for (local.m in local.migrations) {
+			if (local.m.status != "migrated" && local.m.version <= arguments.version) {
+				local.hasPendingMigrations = true;
+				break;
+			}
+		}
+
+		if (local.currentVersion == arguments.version && !local.hasPendingMigrations) {
 			local.rv = "Database is currently at version #arguments.version#. No migration required.#Chr(13)#";
 		} else {
 			if (!DirectoryExists(this.paths.sql) && application[local.appKey].writeMigratorSQLFiles) {
 				DirectoryCreate(this.paths.sql);
 			}
-			local.migrations = getAvailableMigrations();
 			if (local.currentVersion > arguments.version && arguments.missingMigFlag == false) {
 				local.rv = "Migrating from #local.currentVersion# down to #arguments.version#.#Chr(13)#";
 				for (local.i = ArrayLen(local.migrations); local.i >= 1; local.i--) {
@@ -249,6 +259,9 @@ component output="false" extends="wheels.Global"{
 				ArrayAppend(local.rv, local.migration);
 			}
 		};
+		ArraySort(local.rv, function(a, b) {
+			return Compare(a.version, b.version);
+		});
 		return local.rv;
 	}
 


### PR DESCRIPTION
## Summary

- **Bug**: `migrateTo()` short-circuits with "No migration required" when `currentVersion == targetVersion`, even if there are unapplied migrations with timestamps *before* the current version. This happens when PRs merge out of order (PR B with migration `20260310` merges before PR A with `20260308`).
- **Fix**: Move `getAvailableMigrations()` before the short-circuit check, scan for pending gap migrations, and only skip if there are truly none.
- **Bonus**: Add explicit `ArraySort` by version in `getAvailableMigrations()` to guarantee sort order across all CFML engines (previously relied on `DirectoryList` filename sort).

## Reproduction

1. Have migrations `001`, `002`, `003` applied (current version = `003`)
2. Add migration `002a` (timestamp between `002` and `003`) — simulating a late-merged PR
3. Run `migrateToLatest()` → **Before fix**: "No migration required". **After fix**: runs `002a`

## Test plan

- [ ] Gap migration detected and run when `currentVersion == targetVersion`
- [ ] Normal case (no gaps) still returns "No migration required"
- [ ] Fresh DB runs all migrations in order
- [ ] Down migration path unchanged
- [ ] Multiple gap migrations all run in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)