### PR TITLE
Add route model binding (#1909)

### DIFF
--- a/.ai/wheels/core-concepts/routing/route-model-binding.md
+++ b/.ai/wheels/core-concepts/routing/route-model-binding.md
@@ -1,0 +1,35 @@
+# Route Model Binding
+
+Auto-resolves model instances from `params.key` during dispatch.
+
+## Enable
+
+```cfm
+// Per-route
+.resources(name="users", binding=true)
+
+// Global
+set(routeModelBinding=true);
+
+// Explicit model name
+.resources(name="writers", binding="Author")
+```
+
+## Behavior
+
+- Convention: controller `posts` → model `Post` → `params.post`
+- Calls `model("Post").findByKey(params.key)`
+- Throws `Wheels.RecordNotFound` if record not found (renders 404)
+- Silently skips if model class doesn't exist
+- Skips routes without `params.key` (index, create)
+- `params.key` is preserved alongside the resolved model
+- Per-route `binding=false` overrides global `true`
+
+## Setting
+
+`routeModelBinding` — default: `false`
+
+## Where in dispatch
+
+Runs in `$createParams()` after `$deobfuscateParams`, before `$createNestedParamStruct`.
+Method: `$resolveRouteModelBinding(params, route)` in `Dispatch.cfc`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 ## [Unreleased]
 
 ### Added
+- Route model binding with `binding=true` on resource routes or `set(routeModelBinding=true)` globally to auto-resolve model instances from route key parameters
 - Chainable query builder with `where()`, `orWhere()`, `whereNull()`, `whereBetween()`, `whereIn()`, `orderBy()`, `limit()`, and more for injection-safe fluent queries
 - Enum support with `enum()` for named property values, auto-generated `is*()` checkers, auto-scopes, and inclusion validation
 - Query scopes with `scope()` for reusable, composable query fragments in models

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -133,6 +133,7 @@
 * [Responding with Multiple Formats](handling-requests-with-controllers/responding-with-multiple-formats.md)
 * [Using the Flash](handling-requests-with-controllers/using-the-flash.md)
 * [Middleware](handling-requests-with-controllers/middleware.md)
+* [Route Model Binding](handling-requests-with-controllers/route-model-binding.md)
 * [Using Filters](handling-requests-with-controllers/using-filters.md)
 * [Verification](handling-requests-with-controllers/verification.md)
 * [Event Handlers](handling-requests-with-controllers/event-handlers.md)

--- a/docs/src/handling-requests-with-controllers/route-model-binding.md
+++ b/docs/src/handling-requests-with-controllers/route-model-binding.md
@@ -1,0 +1,134 @@
+# Route Model Binding
+
+Route model binding automatically resolves model instances from route `key` parameters during dispatch, before your controller action runs. Instead of manually looking up records in every action, Wheels does it for you.
+
+## The Problem
+
+Without route model binding, every controller action that works with a specific record starts with the same boilerplate:
+
+```cfm
+// app/controllers/Users.cfc
+function show() {
+    user = model("User").findByKey(params.key);
+    if (IsBoolean(user) && !user) {
+        redirectTo(route="users");
+    }
+}
+
+function edit() {
+    user = model("User").findByKey(params.key);
+    if (IsBoolean(user) && !user) {
+        redirectTo(route="users");
+    }
+}
+```
+
+## The Solution
+
+With route model binding enabled, the resolved model instance is automatically available in `params`:
+
+```cfm
+// config/routes.cfm
+mapper()
+    .resources(name="users", binding=true)
+.end();
+
+// app/controllers/Users.cfc
+function show() {
+    // params.user is already a User model instance!
+    // If the record doesn't exist, a 404 is automatically returned.
+    user = params.user;
+}
+```
+
+## Enabling Route Model Binding
+
+### Per-Route (Recommended)
+
+Add `binding=true` to individual resource declarations:
+
+```cfm
+// config/routes.cfm
+mapper()
+    .resources(name="users", binding=true)
+    .resources(name="posts", binding=true)
+    .resources("comments")  // no binding on this resource
+.end();
+```
+
+### Globally
+
+Enable for all resource routes at once:
+
+```cfm
+// config/settings.cfm
+set(routeModelBinding=true);
+```
+
+Per-route `binding=false` can override the global setting:
+
+```cfm
+set(routeModelBinding=true);
+
+// In routes.cfm — comments won't have binding even though global is on
+mapper()
+    .resources("users")                         // binding enabled (global)
+    .resources(name="comments", binding=false)   // binding disabled (per-route)
+.end();
+```
+
+## How It Works
+
+1. **Convention:** The controller name is singularized and capitalized to derive the model name. `posts` controller → `Post` model.
+2. **Lookup:** `model("Post").findByKey(params.key)` is called automatically.
+3. **Storage:** The resolved instance is stored in `params` under the singular name: `params.post`.
+4. **404 Handling:** If no record is found, Wheels throws `Wheels.RecordNotFound` which renders a 404 page.
+5. **No key, no binding:** Actions without a `key` parameter (like `index` and `create`) are unaffected.
+
+## Explicit Model Name
+
+If your controller name doesn't match your model name, specify the model explicitly:
+
+```cfm
+// "writers" controller, but the model is "Author"
+mapper()
+    .resources(name="writers", binding="Author")
+.end();
+
+// In the controller, the resolved model uses the model name:
+// params.author (not params.writer)
+```
+
+## Scoped Binding
+
+Binding inherits through route scopes, so you can enable it for an entire API namespace:
+
+```cfm
+mapper()
+    .scope(path="/api", binding=true)
+        .resources("users")    // binding enabled
+        .resources("posts")    // binding enabled
+    .end()
+.end();
+```
+
+## Error Handling
+
+When a record is not found, Wheels throws a `Wheels.RecordNotFound` error. In development mode, you'll see a detailed error page. In production, this renders your 404 page.
+
+If binding is enabled on a route whose controller doesn't correspond to a model (e.g., a `settings` controller with no `Setting` model), binding is silently skipped — no error is thrown.
+
+## What's in params?
+
+| Scenario | `params.key` | `params.<model>` |
+|----------|-------------|------------------|
+| Binding enabled, record found | `"42"` (preserved) | Model instance |
+| Binding enabled, no key param | N/A | Not set |
+| Binding disabled | `"42"` (preserved) | Not set |
+| No matching model class | `"42"` (preserved) | Not set |
+
+## Limitations
+
+- **Single resource only:** Nested parent resources are not automatically resolved. `/users/5/posts/3` resolves `Post` from `params.key` but does not resolve `User` from `params.userKey`.
+- **Primary key only:** Binding uses `findByKey()`. Slug-based or custom lookups should use a before filter.
+- **Soft deletes:** Uses default `findByKey()` behavior, which excludes soft-deleted records.

--- a/tests/specs/dispatch/RouteModelBindingSpec.cfc
+++ b/tests/specs/dispatch/RouteModelBindingSpec.cfc
@@ -1,0 +1,208 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("Route Model Binding", function() {
+
+			beforeEach(function() {
+				// Store original setting so we can restore it.
+				_originalBinding = application.$wheels.routeModelBinding;
+				// Default to off for isolation.
+				application.$wheels.routeModelBinding = false;
+
+				// Get a reference to the Dispatch object for calling internal methods.
+				_dispatch = application.wheels.dispatch;
+			});
+
+			afterEach(function() {
+				application.$wheels.routeModelBinding = _originalBinding;
+			});
+
+			describe("when binding is enabled on a route", function() {
+
+				it("resolves a model instance into params", function() {
+					// Find an existing post to use as test data.
+					var post = model("Post").findOne(order="id");
+					if (IsBoolean(post) && !post) {
+						// Skip if no test data — create one.
+						post = model("Post").create(
+							authorId = 1,
+							title = "Binding Test",
+							body = "Test body",
+							views = 0
+						);
+					}
+
+					var params = {controller = "posts", action = "show", key = post.key()};
+					var route = {binding = true};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).toHaveKey("post");
+					expect(result.post.key()).toBe(post.key());
+					// Original key param should be preserved.
+					expect(result.key).toBe(post.key());
+				});
+
+				it("throws RecordNotFound when record does not exist", function() {
+					var params = {controller = "posts", action = "show", key = "999999"};
+					var route = {binding = true};
+
+					expect(function() {
+						_dispatch.$resolveRouteModelBinding(params = params, route = route);
+					}).toThrow("Wheels.RecordNotFound");
+				});
+
+			});
+
+			describe("when binding is disabled", function() {
+
+				it("does not resolve models when disabled by default", function() {
+					var params = {controller = "posts", action = "show", key = "1"};
+					var route = {};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).notToHaveKey("post");
+				});
+
+				it("does not resolve models when per-route binding is false even if global is true", function() {
+					application.$wheels.routeModelBinding = true;
+
+					var params = {controller = "posts", action = "show", key = "1"};
+					var route = {binding = false};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).notToHaveKey("post");
+				});
+
+			});
+
+			describe("with explicit model name", function() {
+
+				it("uses the specified model name instead of deriving from controller", function() {
+					var author = model("Author").findOne(order="id");
+					if (IsBoolean(author) && !author) {
+						author = model("Author").create(firstName = "Test", lastName = "Author");
+					}
+
+					var params = {controller = "writers", action = "show", key = author.key()};
+					var route = {binding = "Author"};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).toHaveKey("author");
+					expect(result.author.key()).toBe(author.key());
+				});
+
+			});
+
+			describe("controller resolution", function() {
+
+				it("derives model from route.controller when params.controller is not set", function() {
+					var post = model("Post").findOne(order="id");
+					if (IsBoolean(post) && !post) {
+						post = model("Post").create(
+							authorId = 1,
+							title = "Route Controller Test",
+							body = "Test body",
+							views = 0
+						);
+					}
+
+					// Simulates a resource route where controller is on the route struct, not in params.
+					var params = {key = post.key()};
+					var route = {binding = true, controller = "posts"};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).toHaveKey("post");
+					expect(result.post.key()).toBe(post.key());
+				});
+
+			});
+
+			describe("edge cases", function() {
+
+				it("skips binding when no key param is present", function() {
+					var params = {controller = "posts", action = "index"};
+					var route = {binding = true};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).notToHaveKey("post");
+				});
+
+				it("skips silently when model class does not exist", function() {
+					var params = {controller = "nonexistentThings", action = "show", key = "1"};
+					var route = {binding = true};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).notToHaveKey("nonexistentThing");
+				});
+
+				it("resolves models when global setting is enabled and no per-route binding", function() {
+					application.$wheels.routeModelBinding = true;
+
+					var post = model("Post").findOne(order="id");
+					if (IsBoolean(post) && !post) {
+						post = model("Post").create(
+							authorId = 1,
+							title = "Global Binding Test",
+							body = "Test body",
+							views = 0
+						);
+					}
+
+					var params = {controller = "posts", action = "show", key = post.key()};
+					var route = {};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).toHaveKey("post");
+					expect(result.post.key()).toBe(post.key());
+				});
+
+			});
+
+			describe("route-level integration", function() {
+
+				it("produces routes with binding property when binding=true on resources", function() {
+					// Create a temporary mapper to test route generation.
+					var testRoutes = [];
+					var mapper = application.wheels.mapper;
+					var originalRoutes = Duplicate(application.wheels.routes);
+
+					// Clear routes and add a test resource with binding.
+					application.wheels.routes = [];
+					mapper.draw(restful = true, methods = true);
+						mapper.resources(name = "posts", binding = true);
+					mapper.end();
+
+					var routes = application.wheels.routes;
+
+					// Check that the show route has binding property.
+					var showRoute = {};
+					for (var route in routes) {
+						if (StructKeyExists(route, "action") && route.action == "show") {
+							showRoute = route;
+							break;
+						}
+					}
+
+					expect(showRoute).toHaveKey("binding");
+					expect(showRoute.binding).toBeTrue();
+
+					// Restore original routes.
+					application.wheels.routes = originalRoutes;
+				});
+
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/Dispatch.cfc
+++ b/vendor/wheels/Dispatch.cfc
@@ -50,6 +50,7 @@ component output="false" extends="wheels.Global"{
 		local.rv = $parseJsonBody(params = local.rv);
 		local.rv = $mergeRoutePattern(params = local.rv, route = arguments.route, path = arguments.path);
 		local.rv = $deobfuscateParams(params = local.rv);
+		local.rv = $resolveRouteModelBinding(params = local.rv, route = arguments.route);
 		local.rv = $translateBlankCheckBoxSubmissions(params = local.rv);
 		local.rv = $translateDatePartSubmissions(params = local.rv);
 		local.rv = $createNestedParamStruct(params = local.rv);
@@ -462,6 +463,71 @@ component output="false" extends="wheels.Global"{
 				}
 			}
 		}
+		return local.rv;
+	}
+
+	/**
+	 * Resolves a model instance from params.key when route model binding is enabled.
+	 * The resolved model is stored in params under the singularized controller name (e.g., params.user).
+	 * Throws Wheels.RecordNotFound if the record doesn't exist. Silently skips if the model class doesn't exist.
+	 */
+	public struct function $resolveRouteModelBinding(required struct params, required struct route) {
+		local.rv = arguments.params;
+
+		// Determine if binding is enabled: route-level takes precedence, then global setting.
+		local.binding = false;
+		if (StructKeyExists(arguments.route, "binding")) {
+			local.binding = arguments.route.binding;
+		} else if ($get("routeModelBinding")) {
+			local.binding = true;
+		}
+
+		// Skip if disabled or no key parameter exists.
+		if (IsBoolean(local.binding) && !local.binding) {
+			return local.rv;
+		}
+		if (!StructKeyExists(local.rv, "key")) {
+			return local.rv;
+		}
+
+		// Derive the model name.
+		if (IsSimpleValue(local.binding) && !IsBoolean(local.binding) && Len(local.binding)) {
+			// Explicit model name override (e.g., binding="BlogPost").
+			local.modelName = local.binding;
+		} else {
+			// Convention: singularize + capitalize controller name.
+			// Check params first, then fall back to route struct (controller may not be in params yet).
+			if (StructKeyExists(local.rv, "controller")) {
+				local.controllerName = local.rv.controller;
+			} else if (StructKeyExists(arguments.route, "controller")) {
+				local.controllerName = arguments.route.controller;
+			} else {
+				return local.rv;
+			}
+			local.modelName = capitalize(singularize(local.controllerName));
+		}
+
+		// Attempt to resolve the model instance.
+		try {
+			local.instance = model(local.modelName).findByKey(local.rv.key);
+		} catch (any e) {
+			// Model class doesn't exist — silently skip (don't break non-model routes).
+			return local.rv;
+		}
+
+		// If no record was found, throw a 404.
+		if (IsBoolean(local.instance) && !local.instance) {
+			$throwErrorOrShow404Page(
+				type = "Wheels.RecordNotFound",
+				message = "#local.modelName# record not found.",
+				extendedInfo = "A #local.modelName# record with key `#EncodeForHTML(local.rv.key)#` could not be found."
+			);
+		}
+
+		// Store the resolved model in params under the singular name.
+		local.paramKey = LCase(Left(local.modelName, 1)) & Mid(local.modelName, 2, Len(local.modelName) - 1);
+		local.rv[local.paramKey] = local.instance;
+
 		return local.rv;
 	}
 

--- a/vendor/wheels/events/init/orm.cfm
+++ b/vendor/wheels/events/init/orm.cfm
@@ -20,6 +20,7 @@
 		};
 		application.$wheels.tableNamePrefix = "";
 		application.$wheels.obfuscateURLs = false;
+		application.$wheels.routeModelBinding = false;
 		application.$wheels.reloadPassword = "";
 		application.$wheels.redirectAfterReload = false;
 		application.$wheels.softDeleteProperty = "deletedAt";

--- a/vendor/wheels/mapper/matching.cfc
+++ b/vendor/wheels/mapper/matching.cfc
@@ -366,6 +366,11 @@ component {
 			arguments.middleware = variables.scopeStack[1].middleware;
 		}
 
+		// Inherit binding from scope stack.
+		if (!StructKeyExists(arguments, "binding") && StructKeyExists(variables.scopeStack[1], "binding")) {
+			arguments.binding = variables.scopeStack[1].binding;
+		}
+
 		// Add shallow path to pattern.
 		// Or, add scoped path to pattern.
 		if ($shallow()) {

--- a/vendor/wheels/mapper/resources.cfc
+++ b/vendor/wheels/mapper/resources.cfc
@@ -33,6 +33,7 @@ component {
 		string shallowName,
 		struct constraints,
 		any callback,
+		any binding,
 		string $call = "resource",
 		boolean $plural = false,
 		boolean mapFormat = variables.mapFormat
@@ -164,6 +165,11 @@ component {
 			local.args.mapFormat = arguments.mapFormat;
 		}
 
+		// Pass along binding preference.
+		if (StructKeyExists(arguments, "binding")) {
+			local.args.binding = arguments.binding;
+		}
+
 		// Scope the resource.
 		scope($call = arguments.$call, argumentCollection = local.args);
 
@@ -214,6 +220,7 @@ component {
 		string shallowName,
 		struct constraints,
 		any callback,
+		any binding,
 		boolean mapFormat = variables.mapFormat
 	) {
 		return resource(argumentCollection = arguments, $plural = true, $call = "resources");

--- a/vendor/wheels/mapper/scoping.cfc
+++ b/vendor/wheels/mapper/scoping.cfc
@@ -24,6 +24,7 @@ component {
 		string shallowName,
 		struct constraints,
 		any middleware,
+		any binding,
 		string $call = "scope"
 	) {
 		// Set shallow path and prefix if not in a resource.


### PR DESCRIPTION
## Summary
- Auto-resolve model instances from route `key` params during dispatch, eliminating repetitive `findByKey` + 404 boilerplate in controllers
- Enable per-route with `binding=true` on `resources()` or globally with `set(routeModelBinding=true)`
- Supports explicit model name override (`binding="BlogPost"`), silently skips non-model routes, throws `Wheels.RecordNotFound` for missing records

## Changes
- **Default setting** (`orm.cfm`): `routeModelBinding = false`
- **Mapper** (`resources.cfc`, `scoping.cfc`, `matching.cfc`): `binding` param flows through scope stack to individual routes
- **Dispatch** (`Dispatch.cfc`): `$resolveRouteModelBinding()` runs after `$deobfuscateParams`, before `$createNestedParamStruct`
- **Tests**: 9 TestBox BDD specs covering happy path, 404, disabled, override, explicit model, edge cases, route integration
- **Docs**: Full user guide + AI reference

Closes #1909

## Test plan
- [ ] Run `tests/specs/dispatch/RouteModelBindingSpec.cfc` — all 9 tests pass
- [ ] Run full test suite — no regressions
- [ ] Manual: configure `binding=true` on a resource route, hit with valid key (model in params), invalid key (404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)