### PR TITLE
Add env() helper for cross-scope environment variable access

### DIFF
--- a/public/Application.cfc
+++ b/public/Application.cfc
@@ -91,6 +91,7 @@ component output="false" {
 	include "../config/app.cfm";
 
 	function onApplicationStart() {
+		application.env = duplicate(this.env);
 		injector = new wheels.Injector("wheels.Bindings");
 
 		/* wheels/global object */

--- a/tests/specs/functional/EnvHelperSpec.cfc
+++ b/tests/specs/functional/EnvHelperSpec.cfc
@@ -1,0 +1,52 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("env()", () => {
+
+			afterEach(() => {
+				// Clean up any test keys we added
+				StructDelete(application, "env");
+			})
+
+			it("returns value from application.env when present", () => {
+				application.env = {TEST_KEY: "from_dotenv"};
+				expect(env("TEST_KEY")).toBe("from_dotenv");
+			})
+
+			it("returns default when key is not found anywhere", () => {
+				application.env = {};
+				expect(env("NONEXISTENT_KEY_12345")).toBe("");
+			})
+
+			it("returns custom default when key is not found", () => {
+				application.env = {};
+				expect(env("NONEXISTENT_KEY_12345", "custom_default")).toBe("custom_default");
+			})
+
+			it("prefers application.env over system environment", () => {
+				// If a key exists in both, application.env should win
+				application.env = {PATH: "app_path_override"};
+				expect(env("PATH")).toBe("app_path_override");
+			})
+
+			it("falls back to server.system.environment", () => {
+				// PATH should exist in system environment on all platforms
+				application.env = {};
+				local.result = env("PATH");
+				expect(local.result).notToBe("");
+			})
+
+		})
+
+		describe("application.env population", () => {
+
+			it("application.env is populated from Application.cfc this.env", () => {
+				expect(StructKeyExists(application, "env")).toBeTrue();
+				expect(IsStruct(application.env)).toBeTrue();
+			})
+
+		})
+
+	}
+}

--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -409,6 +409,29 @@ component output="false" {
 	}
 
 	/**
+	 * Returns the value of an environment variable. Checks application.env (loaded from .env files) first, then falls back to system environment variables (server.system.environment). Returns the default if the variable is not found in either location.
+	 *
+	 * [section: Configuration]
+	 * [category: Miscellaneous Functions]
+	 *
+	 * @name The environment variable name to look up.
+	 * @default Value to return if the variable is not found.
+	 */
+	public any function env(required string name, any default="") {
+		if (StructKeyExists(application, "env") && StructKeyExists(application.env, arguments.name)) {
+			return application.env[arguments.name];
+		}
+		if (
+			StructKeyExists(server, "system")
+			&& StructKeyExists(server.system, "environment")
+			&& StructKeyExists(server.system.environment, arguments.name)
+		) {
+			return server.system.environment[arguments.name];
+		}
+		return arguments.default;
+	}
+
+	/**
 	 * Use to configure a global setting or set a default for a function.
 	 *
 	 * [section: Configuration]


### PR DESCRIPTION
## Summary
- Copies `this.env` → `application.env` in `onApplicationStart()` so `.env` values are available outside `Application.cfc`
- Adds `env(name, default)` helper to `Global.cfc` — callable from controllers, models, and views
- Lookup order: `application.env` (from `.env` files) → `server.system.environment` (system env vars) → default value

### Access patterns after this change
| Context | How to access |
|---------|--------------|
| `config/app.cfm` | `this.env.VAR` (unchanged — included inline in Application.cfc) |
| `config/settings.cfm` | `application.env.VAR` (new) |
| Controllers/models/views | `env("VAR")` or `env("VAR", "fallback")` (new) |

## Test plan
- [ ] `env()` returns value from `application.env` when present
- [ ] `env()` returns custom default when key not found
- [ ] `env()` falls back to `server.system.environment` (e.g., `PATH`)
- [ ] `env()` prefers `application.env` over system env
- [ ] `application.env` is populated at app start

Closes #1783

🤖 Generated with [Claude Code](https://claude.com/claude-code)