### PR TITLE
Fix CockroachDB primary key: use unique_rowid() instead of SERIAL

### DIFF
--- a/vendor/wheels/databaseAdapters/CockroachDB/CockroachDBMigrator.cfc
+++ b/vendor/wheels/databaseAdapters/CockroachDB/CockroachDBMigrator.cfc
@@ -7,4 +7,16 @@ component extends="wheels.databaseAdapters.PostgreSQL.PostgreSQLMigrator" {
 		return "CockroachDB";
 	}
 
+	/**
+	 * generates sql for primary key options
+	 * CockroachDB does not support SERIAL; use INT DEFAULT unique_rowid() instead
+	 */
+	public string function addPrimaryKeyOptions(required string sql, struct options = {}) {
+		if (StructKeyExists(arguments.options, "autoIncrement") && arguments.options.autoIncrement) {
+			arguments.sql = ReplaceNoCase(arguments.sql, "INTEGER", "INT DEFAULT unique_rowid()", "all");
+		}
+		arguments.sql = arguments.sql & " PRIMARY KEY";
+		return arguments.sql;
+	}
+
 }


### PR DESCRIPTION
## Summary
- CockroachDBMigrator inherits PostgreSQL's `addPrimaryKeyOptions()` which replaces `INTEGER` with `SERIAL` -- a type CockroachDB does not support
- Adds an override in `CockroachDBMigrator.cfc` that uses `INT DEFAULT unique_rowid()` instead, which is CockroachDB's idiomatic auto-generated primary key pattern

Fixes #1970

## Test plan
- [ ] Run migrations against a CockroachDB instance and verify `CREATE TABLE` statements use `INT DEFAULT unique_rowid() PRIMARY KEY` instead of `SERIAL PRIMARY KEY`
- [ ] Verify PostgreSQL migrations are unaffected (still use `SERIAL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)