### PR TITLE
Remove Railo compatibility workaround from $initializeMixins

### DIFF
--- a/vendor/wheels/Plugins.cfc
+++ b/vendor/wheels/Plugins.cfc
@@ -300,15 +300,9 @@ component output="false" extends="wheels.Global"{
 			}
 			if (StructKeyExists(application[$wheels.appKey].mixins, $wheels.className)) {
 				if (!StructKeyExists(variablesScope, "core")) {
-					if (application[$wheels.appKey].serverName == "Railo") {
-						// this is to work around a railo bug (https://jira.jboss.org/browse/RAILO-936)
-						// NB, fixed in Railo 3.2.0, so assume this is fixed in all lucee versions
-						variablesScope.core = Duplicate(variablesScope);
-					} else {
-						variablesScope.core = {};
-						StructAppend(variablesScope.core, variablesScope);
-						StructDelete(variablesScope.core, "$wheels");
-					}
+					variablesScope.core = {};
+					StructAppend(variablesScope.core, variablesScope);
+					StructDelete(variablesScope.core, "$wheels");
 				}
 				StructAppend(variablesScope, application[$wheels.appKey].mixins[$wheels.className], true);
 


### PR DESCRIPTION
## Summary
- Remove dead Railo-specific `Duplicate()` workaround in `Plugins.cfc` `$initializeMixins` function
- The workaround was for [RAILO-936](https://jira.jboss.org/browse/RAILO-936), fixed in Railo 3.2 (~2012)
- Simplify to always use the modern `StructAppend` code path, which is the only path executed on Lucee and Adobe CF

Closes #1975

## Test plan
- [ ] Existing plugin/mixin tests pass (no behavioral change — the Railo branch was never reached on supported engines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)