### PR TITLE
Fix release workflow box.json path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
 
           # Check that source version in box.json is clean (no -SNAPSHOT suffix).
           # The workflow injects -SNAPSHOT for develop builds automatically.
-          BASE_VERSION=$(jq -r '.version' templates/base/src/box.json)
+          BASE_VERSION=$(jq -r '.version' box.json)
           if echo "$BASE_VERSION" | grep -qi "snapshot"; then
             echo "ERROR: Version in box.json contains -SNAPSHOT suffix ($BASE_VERSION)"
             echo "Source files should have clean versions (e.g., 3.1.0)."


### PR DESCRIPTION
## Summary
- Fix `release.yml` line 78: update `templates/base/src/box.json` to `box.json` to match the post-flattening directory structure

Closes #1957

## Test plan
- [ ] Verify the release workflow's version-check step reads from root `box.json`
- [ ] Confirm no other workflow files reference the old `templates/base/src/` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)