### PR TITLE
fix: base template build fails on vendor/.keep gitignore negation

### DIFF
--- a/tools/build/base/.gitignore
+++ b/tools/build/base/.gitignore
@@ -1,3 +1,2 @@
-/vendor/**
-!/vendor/.keep
+/vendor/*/
 /db/**


### PR DESCRIPTION
## Summary
- The `Build & Publish Release` step fails with `Can't copy file .../vendor/.keep` because CommandBox's Globber doesn't handle `/vendor/**` + `!/vendor/.keep` negation correctly — the parent directory is never created in the temp staging area
- Replace with `/vendor/*/` which ignores subdirectories while keeping top-level files like `.keep`, avoiding the negation pattern entirely

## Test plan
- [ ] CI build step passes without the `vendor/.keep` copy error

🤖 Generated with [Claude Code](https://claude.com/claude-code)