### PR TITLE
feat: (W-002) Navbar in Wheels debug panel breaks when controller action...

### DIFF
--- a/vendor/wheels/public/layout/_header_simple.cfm
+++ b/vendor/wheels/public/layout/_header_simple.cfm
@@ -73,7 +73,7 @@ Static simple version of the header/navigation for output on error screens
 	</script>
 </head>
 <body>
-<div class="ui pointing fluid nine item menu stackable" style="margin-bottom:0;">
+<div class="ui pointing fluid eight item menu stackable" style="margin-bottom:0;">
 	<a href="/" class="item">
 		<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="150px" height="18px" viewBox="0 0 153 18" version="1.1">
 			<g id="surface1">
@@ -85,7 +85,18 @@ Static simple version of the header/navigation for output on error screens
 	</a>
 	<a class="item" href="/wheels/info"><svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 512 512"><path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/></svg>&nbsp; Info</a>
 	<a class="item" href="/wheels/routes"><svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 512 512"><path d="M403.8 34.4c12-5 25.7-2.2 34.9 6.9l64 64c6 6 9.4 14.1 9.4 22.6s-3.4 16.6-9.4 22.6l-64 64c-9.2 9.2-22.9 11.9-34.9 6.9s-19.8-16.6-19.8-29.6V160H352c-10.1 0-19.6 4.7-25.6 12.8L284 229.3 244 176l31.2-41.6C293.3 110.2 321.8 96 352 96h32V64c0-12.9 7.8-24.6 19.8-29.6z"/></svg>&nbsp; Routes</a>
+	<a class="item" href="/wheels/api"><svg xmlns="http://www.w3.org/2000/svg" height="16" width="12" viewBox="0 0 384 512"><path d="M64 0C28.7 0 0 28.7 0 64V448c0 35.3 28.7 64 64 64H320c35.3 0 64-28.7 64-64V160H256c-17.7 0-32-14.3-32-32V0H64zM256 0V128H384L256 0zM112 256H272c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16s7.2-16 16-16zm0 64H272c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16s7.2-16 16-16zm0 64H272c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16s7.2-16 16-16z"/></svg>&nbsp; API</a>
+	<a class="item" href="/wheels/guides"><svg xmlns="http://www.w3.org/2000/svg" height="16" width="12" viewBox="0 0 384 512"><path d="M64 0C28.7 0 0 28.7 0 64V448c0 35.3 28.7 64 64 64H320c35.3 0 64-28.7 64-64V160H256c-17.7 0-32-14.3-32-32V0H64zM256 0V128H384L256 0zM112 256H272c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16s7.2-16 16-16zm0 64H272c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16s7.2-16 16-16zm0 64H272c8.8 0 16 7.2 16 16s-7.2 16-16 16H112c-8.8 0-16-7.2-16-16s7.2-16 16-16z"/></svg>&nbsp; Guides</a>
+	<a class="item" href="/wheels/core/tests"><svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 512 512"><path d="M152.1 38.2c9.9 8.9 10.7 24 1.8 33.9l-72 80c-4.4 4.9-10.6 7.8-17.2 7.9s-12.9-2.4-17.6-7L7 113C-2.3 103.6-2.3 88.4 7 79s24.6-9.4 33.9 0l22.1 22.1 55.1-61.2c8.9-9.9 24-10.7 33.9-1.8zm0 160c9.9 8.9 10.7 24 1.8 33.9l-72 80c-4.4 4.9-10.6 7.8-17.2 7.9s-12.9-2.4-17.6-7L7 273c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l22.1 22.1 55.1-61.2c8.9-9.9 24-10.7 33.9-1.8zM224 96c0-17.7 14.3-32 32-32H480c17.7 0 32 14.3 32 32s-14.3 32-32 32H256c-17.7 0-32-14.3-32-32zm0 160c0-17.7 14.3-32 32-32H480c17.7 0 32 14.3 32 32s-14.3 32-32 32H256c-17.7 0-32-14.3-32-32zM160 416c0-17.7 14.3-32 32-32H480c17.7 0 32 14.3 32 32s-14.3 32-32 32H192c-17.7 0-32-14.3-32-32zM48 368a48 48 0 1 1 0 96 48 48 0 1 1 0-96z"/></svg>&nbsp; Tests</a>
+	<cfif StructKeyExists(application, "wheels") AND StructKeyExists(application.wheels, "enableMigratorComponent") AND application.wheels.enableMigratorComponent>
 	<a class="item" href="/wheels/migrator"><svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 448 512"><path d="M448 80v48c0 44.2-100.3 80-224 80S0 172.2 0 128V80C0 35.8 100.3 0 224 0S448 35.8 448 80z"/></svg>&nbsp; Migrator</a>
+	</cfif>
+	<cfif StructKeyExists(application, "wheels") AND StructKeyExists(application.wheels, "enablePackagesComponent") AND application.wheels.enablePackagesComponent>
+	<a class="item" href="/wheels/packages"><svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 512 512"><path d="M234.5 5.7c13.9-5.3 29.7-5.3 43.6 0l192 73.7C493.6 89.5 512 112.3 512 138.4V373.6c0 26.1-18.4 48.9-42 59l-192 73.7c-13.9 5.3-29.7 5.3-43.6 0l-192-73.7C18.4 422.5 0 399.7 0 373.6V138.4c0-26.1 18.4-48.9 42-59l192-73.7zM256 66L82 133l174 67 174-67L256 66zM32 373.6c0 8.7 6.1 16.3 14 19.7l192 73.7V274L46 200v173.6zM274 467l192-73.7c7.9-3 14-11 14-19.7V200L274 274V467z"/></svg>&nbsp; Packages</a>
+	</cfif>
+	<cfif StructKeyExists(application, "wheels") AND StructKeyExists(application.wheels, "enablePluginsComponent") AND application.wheels.enablePluginsComponent>
+	<a class="item" href="/wheels/plugins"><svg xmlns="http://www.w3.org/2000/svg" height="14" width="10" viewBox="0 0 384 512"><path d="M96 0C78.3 0 64 14.3 64 32v96h64V32c0-17.7-14.3-32-32-32zM288 0c-17.7 0-32 14.3-32 32v96h64V32c0-17.7-14.3-32-32-32zM32 160c-17.7 0-32 14.3-32 32s14.3 32 32 32v32c0 77.4 55 142 128 156.8V480c0 17.7 14.3 32 32 32s32-14.3 32-32V412.8C297 398 352 333.4 352 256V224c17.7 0 32-14.3 32-32s-14.3-32-32-32H32z"/></svg>&nbsp; Plugins</a>
+	</cfif>
 </div>
 <div class="container ui" style="margin-top:2em;">
 </cfoutput>


### PR DESCRIPTION
## Navbar in Wheels debug panel breaks when controller action throws "view not found" error Issue #1998

When a controller action is executed without a corresponding view, Wheels correctly throws an error indicating that the view does not exist. But when this error occurs, the debug navbar becomes partially broken and only shows Logo, Info, Routes, Migrator. All other tabs disappear. The debug navbar should remain intact and display all standard tabs even when an error occurs. See: https://github.com/wheels-dev/wheels/issues/1998

**Task:** W-002
**Path:** development
**Cost:** $0.00
**Files changed:** 0

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 13 lines changed

---
*Created by [Grove](https://grove.cloud)*