### PR TITLE
fix: catch IllegalArgumentException in $canonicalize for malformed percent-encoded sequences

### DIFF
--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -2343,9 +2343,17 @@ component output="false" {
 	 * Call CFML's canonicalize() function but set to blank string if the result is null (happens on Lucee 5).
 	 */
 	public string function $canonicalize(required string input) {
-		local.rv = Canonicalize(arguments.input, false, false);
-		if (IsNull(local.rv)) {
-			local.rv = "";
+		try {
+			local.rv = Canonicalize(arguments.input, false, false);
+			if (IsNull(local.rv)) {
+				local.rv = "";
+			}
+		} catch (any e) {
+			// Lucee's Canonicalize() delegates to Java's URLDecoder, which throws
+			// IllegalArgumentException for inputs containing malformed percent-encoded
+			// sequences (e.g. %% or a lone % not followed by two hex digits).
+			// Fall back to the raw input; it will still be HTML-encoded by the caller.
+			local.rv = arguments.input;
 		}
 		return local.rv;
 	}


### PR DESCRIPTION
## Problem

`$canonicalize()` in `Global.cfc` calls Lucee's built-in `Canonicalize()`, which delegates to Java's `URLDecoder.decode()`. Java's `URLDecoder` requires that any `%` in the input be followed by exactly two hexadecimal digits. When the input contains `%%` (or any lone `%` not followed by two hex digits), the decoder throws:

```
java.lang.IllegalArgumentException: URLDecoder: Illegal hex characters in escape (%) pattern - Error at index 0 in: "%%"
```

This crashes form rendering whenever CFWheels re-populates a field after a validation failure with a value containing such characters. **Passwords are a common real-world trigger** — a user entering `P%%ssword` or `100%%secure` will always hit this crash on form re-render.

## Call chain

```
passwordField() / textField() / any form helper
  → $attribute()                    [view/miscellaneous.cfc]
    → EncodeForHTMLAttribute(
        $canonicalize(arguments.value)
      )
      → Canonicalize("...%%...")    [Global.cfc]
        ← java.lang.IllegalArgumentException
```

## Fix

Wrap the `Canonicalize()` call in `try/catch` and fall back to the raw input on failure. The raw value is safe because the caller always passes it through `EncodeForHTMLAttribute()` immediately after. The existing Lucee 5 null-return guard is preserved inside the `try` block.

## Testing

- Submit any form with a field value containing `%%` and confirm no exception is thrown
- Confirm form re-renders correctly after a validation failure with such a value
- Confirm normal inputs (no malformed `%` sequences) behave identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)