### PR TITLE
ci: allow auto-label job to fail gracefully on fork PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,8 @@ jobs:
   label:
     name: Auto-Label PR
     runs-on: ubuntu-latest
+    # Fork PRs get a read-only GITHUB_TOKEN so labeling will fail — don't block CI
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Fork PRs get a read-only `GITHUB_TOKEN`, causing the Auto-Label job to fail with `Resource not accessible by integration`
- Adds `continue-on-error: true` so this cosmetic job doesn't block CI for external contributors
- Triggered by #2006 (fork PR from @mlibbe)

## Test plan
- [ ] Verify this PR's own Auto-Label check shows as pass (or soft-fail) rather than hard failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)