### PR TITLE
security: use hash-based comparison for reload password

### DIFF
--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -127,7 +127,7 @@ component {
 			&& StructKeyExists(application.$wheels, "reloadPassword")
 			&& (
 				!Len(application.$wheels.reloadPassword)
-				|| (StructKeyExists(URL, "password") && URL.password == application.$wheels.reloadPassword)
+				|| (StructKeyExists(URL, "password") && Compare(Hash(URL.password, "SHA-256"), Hash(application.$wheels.reloadPassword, "SHA-256")) == 0)
 			)
 		) {
 			application.$wheels.environment = URL.reload;

--- a/vendor/wheels/public/views/consoleeval.cfm
+++ b/vendor/wheels/public/views/consoleeval.cfm
@@ -48,7 +48,7 @@ if (!len(trim(local.expression))) {
 if (
 	structKeyExists(application.wheels, "reloadPassword")
 	&& len(application.wheels.reloadPassword)
-	&& local.password != application.wheels.reloadPassword
+	&& Compare(Hash(local.password, "SHA-256"), Hash(application.wheels.reloadPassword, "SHA-256")) != 0
 ) {
 	writeOutput(serializeJSON({
 		success: false,

--- a/vendor/wheels/tests/specs/events/reloadPasswordSpec.cfc
+++ b/vendor/wheels/tests/specs/events/reloadPasswordSpec.cfc
@@ -1,0 +1,50 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("Reload password hash comparison", () => {
+
+			it("accepts correct password via hash comparison", () => {
+				local.storedPassword = "mySecretPassword123";
+				local.suppliedPassword = "mySecretPassword123";
+				local.result = Compare(
+					Hash(local.suppliedPassword, "SHA-256"),
+					Hash(local.storedPassword, "SHA-256")
+				);
+				expect(local.result).toBe(0);
+			});
+
+			it("rejects incorrect password via hash comparison", () => {
+				local.storedPassword = "mySecretPassword123";
+				local.suppliedPassword = "wrongPassword";
+				local.result = Compare(
+					Hash(local.suppliedPassword, "SHA-256"),
+					Hash(local.storedPassword, "SHA-256")
+				);
+				expect(local.result).notToBe(0);
+			});
+
+			it("rejects empty password when stored password is set", () => {
+				local.storedPassword = "mySecretPassword123";
+				local.suppliedPassword = "";
+				local.result = Compare(
+					Hash(local.suppliedPassword, "SHA-256"),
+					Hash(local.storedPassword, "SHA-256")
+				);
+				expect(local.result).notToBe(0);
+			});
+
+			it("is case-sensitive for passwords", () => {
+				local.storedPassword = "MyPassword";
+				local.suppliedPassword = "mypassword";
+				local.result = Compare(
+					Hash(local.suppliedPassword, "SHA-256"),
+					Hash(local.storedPassword, "SHA-256")
+				);
+				expect(local.result).notToBe(0);
+			});
+
+
+		});
+	}
+}


### PR DESCRIPTION
## Summary
- Replace plaintext `==` / `!=` comparison of the reload password with `Compare(Hash(SHA-256))` in both `onapplicationstart.cfc` and `consoleeval.cfm`
- Hashing both sides at comparison time prevents timing attacks while maintaining full backward compatibility (developers still set `set(reloadPassword="mypassword")` in config)
- Add TestBox BDD specs validating correct/incorrect/empty/case-sensitive password behavior

## Test plan
- [ ] CI passes on Lucee + Adobe engines
- [ ] Reload with correct password still triggers environment switch
- [ ] Reload with wrong password is rejected
- [ ] Console eval with correct/wrong password behaves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)