### PR TITLE
fix: escape single quotes in enum scope WHERE clauses

### DIFF
--- a/vendor/wheels/model/properties.cfc
+++ b/vendor/wheels/model/properties.cfc
@@ -816,6 +816,15 @@ component {
 		required string property,
 		required any values
 	) {
+		// Validate property name: alphanumeric and underscore only (prevents SQL injection via property name)
+		if (!ReFind("^[a-zA-Z_][a-zA-Z0-9_]*$", arguments.property)) {
+			Throw(
+				type = "Wheels.InvalidPropertyName",
+				message = "The property name `#arguments.property#` is invalid.",
+				extendedInfo = "Property names must contain only letters, numbers, and underscores, and must start with a letter or underscore."
+			);
+		}
+
 		if (!StructKeyExists(variables.wheels.class, "enums")) {
 			variables.wheels.class.enums = {};
 		}
@@ -850,8 +859,10 @@ component {
 		}
 		for (local.name in ListToArray(local.enumDef.names)) {
 			local.storedValue = local.enumDef.values[local.name];
+			// Escape single quotes to prevent SQL injection in generated WHERE clauses
+			local.escapedValue = Replace(local.storedValue, "'", "''", "all");
 			local.scopeDef = {};
-			local.scopeDef.where = "#arguments.property# = '#local.storedValue#'";
+			local.scopeDef.where = "#arguments.property# = '#local.escapedValue#'";
 			variables.wheels.class.scopes[local.name] = local.scopeDef;
 		}
 	}

--- a/vendor/wheels/tests/specs/model/enumScopeEscapingSpec.cfc
+++ b/vendor/wheels/tests/specs/model/enumScopeEscapingSpec.cfc
@@ -1,0 +1,101 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("Tests that enum scope WHERE clauses", () => {
+
+			beforeEach(() => {
+				g.$clearModelInitializationCache()
+			})
+
+			afterEach(() => {
+				g.$clearModelInitializationCache()
+			})
+
+			it("generates correct WHERE for simple string values", () => {
+				var m = g.model("post")
+				m.enum(property="status", values="draft,published,archived")
+				var scopes = m.scopeInfo()
+
+				expect(scopes).toHaveKey("draft")
+				expect(scopes.draft).toHaveKey("where")
+				expect(scopes.draft.where).toBe("status = 'draft'")
+
+				expect(scopes).toHaveKey("published")
+				expect(scopes.published.where).toBe("status = 'published'")
+
+				expect(scopes).toHaveKey("archived")
+				expect(scopes.archived.where).toBe("status = 'archived'")
+			})
+
+			it("generates correct WHERE for struct-mapped values", () => {
+				var m = g.model("post")
+				m.enum(property="priority", values={low: 0, medium: 1, high: 2})
+				var scopes = m.scopeInfo()
+
+				expect(scopes).toHaveKey("low")
+				expect(scopes.low.where).toBe("priority = '0'")
+
+				expect(scopes).toHaveKey("high")
+				expect(scopes.high.where).toBe("priority = '2'")
+			})
+
+			it("escapes single quotes in enum stored values", () => {
+				var m = g.model("post")
+				m.enum(property="status", values={it_s_fine: "it's fine", normal: "normal"})
+				var scopes = m.scopeInfo()
+
+				expect(scopes).toHaveKey("it_s_fine")
+				expect(scopes.it_s_fine.where).toBe("status = 'it''s fine'")
+
+				expect(scopes).toHaveKey("normal")
+				expect(scopes.normal.where).toBe("status = 'normal'")
+			})
+
+			it("escapes multiple single quotes in enum stored values", () => {
+				var m = g.model("post")
+				m.enum(property="status", values={tricky: "it''s a ''test''"})
+				var scopes = m.scopeInfo()
+
+				expect(scopes).toHaveKey("tricky")
+				expect(scopes.tricky.where).toBe("status = 'it''''s a ''''test'''''")
+			})
+
+			it("handles enum values containing SQL keywords safely", () => {
+				var m = g.model("post")
+				m.enum(property="status", values={dangerous: "'; DROP TABLE users; --"})
+				var scopes = m.scopeInfo()
+
+				expect(scopes).toHaveKey("dangerous")
+				expect(scopes.dangerous.where).toBe("status = '''; DROP TABLE users; --'")
+			})
+
+			it("rejects property names with invalid characters", () => {
+				var m = g.model("post")
+
+				expect(function() {
+					m.enum(property="status; DROP TABLE", values="draft")
+				}).toThrow("Wheels.InvalidPropertyName")
+			})
+
+			it("rejects property names starting with a number", () => {
+				var m = g.model("post")
+
+				expect(function() {
+					m.enum(property="1status", values="draft")
+				}).toThrow("Wheels.InvalidPropertyName")
+			})
+
+			it("allows property names with underscores", () => {
+				var m = g.model("post")
+				m.enum(property="_my_status", values="draft,published")
+				var scopes = m.scopeInfo()
+
+				expect(scopes).toHaveKey("draft")
+				expect(scopes.draft.where).toBe("_my_status = 'draft'")
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Escape single quotes in enum stored values by doubling them (`'` -> `''`) before interpolating into generated WHERE clauses, preventing SQL injection via malicious enum values.
- Validate enum property names against `^[a-zA-Z_][a-zA-Z0-9_]*$` pattern, throwing `Wheels.InvalidPropertyName` if invalid.
- Add `enumScopeEscapingSpec.cfc` with 8 specs covering normal values, struct-mapped values, single quote escaping, SQL keyword injection, and property name validation.

## Test plan
- [ ] CI passes on Lucee + SQLite (quick suite)
- [ ] New specs in `vendor/wheels/tests/specs/model/enumScopeEscapingSpec.cfc` all pass
- [ ] Existing enum tests in `introspectionSpec.cfc` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)