### PR TITLE
security: validate QueryBuilder property names and operators against SQL injection

### DIFF
--- a/vendor/wheels/model/query/QueryBuilder.cfc
+++ b/vendor/wheels/model/query/QueryBuilder.cfc
@@ -83,6 +83,7 @@ component output="false" {
 	 * @property The property name to check for NULL.
 	 */
 	public any function whereNull(required string property) {
+		$validatePropertyName(arguments.property);
 		ArrayAppend(variables.whereClauses, {type = "AND", clause = "#arguments.property# IS NULL"});
 		return this;
 	}
@@ -93,6 +94,7 @@ component output="false" {
 	 * @property The property name to check for NOT NULL.
 	 */
 	public any function whereNotNull(required string property) {
+		$validatePropertyName(arguments.property);
 		ArrayAppend(variables.whereClauses, {type = "AND", clause = "#arguments.property# IS NOT NULL"});
 		return this;
 	}
@@ -105,6 +107,7 @@ component output="false" {
 	 * @high The upper bound value.
 	 */
 	public any function whereBetween(required string property, required any low, required any high) {
+		$validatePropertyName(arguments.property);
 		local.lowQuoted = $quoteValue(arguments.property, arguments.low);
 		local.highQuoted = $quoteValue(arguments.property, arguments.high);
 		ArrayAppend(variables.whereClauses, {type = "AND", clause = "#arguments.property# BETWEEN #local.lowQuoted# AND #local.highQuoted#"});
@@ -118,6 +121,7 @@ component output="false" {
 	 * @values A list or array of values to match against.
 	 */
 	public any function whereIn(required string property, required any values) {
+		$validatePropertyName(arguments.property);
 		local.valueList = $quoteValueList(arguments.property, arguments.values);
 		ArrayAppend(variables.whereClauses, {type = "AND", clause = "#arguments.property# IN (#local.valueList#)"});
 		return this;
@@ -130,6 +134,7 @@ component output="false" {
 	 * @values A list or array of values to exclude.
 	 */
 	public any function whereNotIn(required string property, required any values) {
+		$validatePropertyName(arguments.property);
 		local.valueList = $quoteValueList(arguments.property, arguments.values);
 		ArrayAppend(variables.whereClauses, {type = "AND", clause = "#arguments.property# NOT IN (#local.valueList#)"});
 		return this;
@@ -142,6 +147,8 @@ component output="false" {
 	 * @direction The sort direction: "ASC" or "DESC". Defaults to "ASC".
 	 */
 	public any function orderBy(required string property, string direction = "ASC") {
+		$validatePropertyName(arguments.property);
+		$validateDirection(arguments.direction);
 		ArrayAppend(variables.orderClauses, "#arguments.property# #arguments.direction#");
 		return this;
 	}
@@ -390,9 +397,58 @@ component output="false" {
 	// ----- Private Helpers -----
 
 	/**
+	 * Validate that a property name is safe to interpolate into SQL.
+	 * Allows alphanumeric identifiers with underscores, and optional table.column dot notation.
+	 * Throws Wheels.InvalidPropertyName if the name contains unsafe characters.
+	 *
+	 * @property The property name to validate.
+	 */
+	private void function $validatePropertyName(required string property) {
+		if (!Len(arguments.property) || !ReFind("^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?$", arguments.property)) {
+			Throw(
+				type = "Wheels.InvalidPropertyName",
+				message = "The property name `#HTMLEditFormat(arguments.property)#` contains invalid characters.",
+				extendedInfo = "Property names may only contain letters, numbers, and underscores, with an optional table prefix using dot notation (e.g., `users.id`)."
+			);
+		}
+	}
+
+	/**
+	 * Validate that an ORDER BY direction is safe.
+	 *
+	 * @direction The sort direction to validate.
+	 */
+	private void function $validateDirection(required string direction) {
+		if (!ReFind("^(?i)(ASC|DESC)$", arguments.direction)) {
+			Throw(
+				type = "Wheels.InvalidSortDirection",
+				message = "The sort direction `#HTMLEditFormat(arguments.direction)#` is invalid.",
+				extendedInfo = "Sort direction must be either ASC or DESC."
+			);
+		}
+	}
+
+	/**
+	 * Validate that a comparison operator is safe to interpolate into SQL.
+	 *
+	 * @operator The operator to validate.
+	 */
+	private void function $validateOperator(required string operator) {
+		if (!ReFind("^(=|!=|<>|<|>|<=|>=|LIKE|NOT LIKE|IS|IS NOT)$", UCase(Trim(arguments.operator)))) {
+			Throw(
+				type = "Wheels.InvalidOperator",
+				message = "The operator `#HTMLEditFormat(arguments.operator)#` is not allowed.",
+				extendedInfo = "Allowed operators: =, !=, <>, <, >, <=, >=, LIKE, NOT LIKE, IS, IS NOT."
+			);
+		}
+	}
+
+	/**
 	 * Build a single condition clause with proper value quoting.
 	 */
 	private string function $buildCondition(required string property, required string operator, required any value) {
+		$validatePropertyName(arguments.property);
+		$validateOperator(arguments.operator);
 		local.quotedValue = $quoteValue(arguments.property, arguments.value);
 		return "#arguments.property# #arguments.operator# #local.quotedValue#";
 	}

--- a/vendor/wheels/tests/specs/QueryBuilderSpec.cfc
+++ b/vendor/wheels/tests/specs/QueryBuilderSpec.cfc
@@ -1,0 +1,272 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("QueryBuilder Property Name Validation", function() {
+
+			beforeEach(function() {
+				// Create a QueryBuilder with a real model reference so $quoteValue works
+				modelRef = model("post");
+				qb = new wheels.model.query.QueryBuilder(modelReference = modelRef);
+			});
+
+			describe("valid property names", function() {
+
+				it("accepts simple property names", function() {
+					expect(function() {
+						qb.whereNull("status");
+					}).notToThrow();
+				});
+
+				it("accepts property names with underscores", function() {
+					expect(function() {
+						qb.whereNotNull("first_name");
+					}).notToThrow();
+				});
+
+				it("accepts property names starting with underscore", function() {
+					expect(function() {
+						qb.whereNull("_internal");
+					}).notToThrow();
+				});
+
+				it("accepts dot notation for table.column", function() {
+					expect(function() {
+						qb.whereNull("users.id");
+					}).notToThrow();
+				});
+
+				it("accepts dot notation with underscores", function() {
+					expect(function() {
+						qb.whereNull("user_accounts.first_name");
+					}).notToThrow();
+				});
+
+				it("accepts property names with numbers", function() {
+					expect(function() {
+						qb.whereNull("address2");
+					}).notToThrow();
+				});
+
+			});
+
+			describe("invalid property names are rejected", function() {
+
+				it("rejects SQL injection with semicolon and DROP", function() {
+					expect(function() {
+						qb.whereNull("id; DROP TABLE users");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("rejects property names with parentheses", function() {
+					expect(function() {
+						qb.whereNull("COUNT(id)");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("rejects property names with single quotes", function() {
+					expect(function() {
+						qb.whereNull("name' OR '1'='1");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("rejects property names with double quotes", function() {
+					expect(function() {
+						qb.whereNull('name" OR "1"="1');
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("rejects empty strings", function() {
+					expect(function() {
+						qb.whereNull("");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("rejects property names with spaces", function() {
+					expect(function() {
+						qb.whereNull("first name");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("rejects property names with hyphens", function() {
+					expect(function() {
+						qb.whereNull("first-name");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("rejects property names starting with a number", function() {
+					expect(function() {
+						qb.whereNull("1column");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("rejects multiple dots", function() {
+					expect(function() {
+						qb.whereNull("schema.table.column");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("rejects trailing dot", function() {
+					expect(function() {
+						qb.whereNull("table.");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("rejects leading dot", function() {
+					expect(function() {
+						qb.whereNull(".column");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("rejects SQL comment injection", function() {
+					expect(function() {
+						qb.whereNull("id--");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+			});
+
+			describe("validation applies to all affected methods", function() {
+
+				it("validates whereNotNull property", function() {
+					expect(function() {
+						qb.whereNotNull("id; DROP TABLE users");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("validates whereBetween property", function() {
+					expect(function() {
+						qb.whereBetween(property="id; DROP TABLE users", low=1, high=10);
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("validates whereIn property", function() {
+					expect(function() {
+						qb.whereIn(property="id; DROP TABLE users", values="1,2,3");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("validates whereNotIn property", function() {
+					expect(function() {
+						qb.whereNotIn(property="id; DROP TABLE users", values="1,2,3");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("validates orderBy property", function() {
+					expect(function() {
+						qb.orderBy("id; DROP TABLE users");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("validates where() two-argument form property", function() {
+					expect(function() {
+						qb.where("id; DROP TABLE users", "active");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("validates where() three-argument form property", function() {
+					expect(function() {
+						qb.where("id; DROP TABLE users", "=", "active");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("validates orWhere() two-argument form property", function() {
+					expect(function() {
+						qb.orWhere("id; DROP TABLE users", "active");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+				it("validates orWhere() three-argument form property", function() {
+					expect(function() {
+						qb.orWhere("id; DROP TABLE users", "=", "active");
+					}).toThrow("Wheels.InvalidPropertyName");
+				});
+
+			});
+
+			describe("orderBy direction validation", function() {
+
+				it("accepts ASC", function() {
+					expect(function() {
+						qb.orderBy(property="name", direction="ASC");
+					}).notToThrow();
+				});
+
+				it("accepts DESC", function() {
+					expect(function() {
+						qb.orderBy(property="name", direction="DESC");
+					}).notToThrow();
+				});
+
+				it("accepts lowercase asc", function() {
+					expect(function() {
+						qb.orderBy(property="name", direction="asc");
+					}).notToThrow();
+				});
+
+				it("rejects SQL injection in direction", function() {
+					expect(function() {
+						qb.orderBy(property="name", direction="ASC; DROP TABLE users");
+					}).toThrow("Wheels.InvalidSortDirection");
+				});
+
+			});
+
+			describe("operator validation", function() {
+
+				it("accepts standard comparison operators", function() {
+					var operators = ["=", "!=", "<>", "<", ">", "<=", ">="];
+					for (var op in operators) {
+						expect(function() {
+							qb.where("status", op, "active");
+						}).notToThrow();
+					}
+				});
+
+				it("accepts LIKE operator", function() {
+					expect(function() {
+						qb.where("name", "LIKE", "%test%");
+					}).notToThrow();
+				});
+
+				it("accepts NOT LIKE operator", function() {
+					expect(function() {
+						qb.where("name", "NOT LIKE", "%test%");
+					}).notToThrow();
+				});
+
+				it("rejects SQL injection in operator", function() {
+					expect(function() {
+						qb.where("status", "= 1; DROP TABLE users --", "active");
+					}).toThrow("Wheels.InvalidOperator");
+				});
+
+				it("rejects arbitrary strings as operators", function() {
+					expect(function() {
+						qb.where("status", "UNION SELECT", "active");
+					}).toThrow("Wheels.InvalidOperator");
+				});
+
+			});
+
+			describe("raw where passthrough is not affected", function() {
+
+				it("allows single-argument raw SQL in where()", function() {
+					expect(function() {
+						qb.where("status = 'active' OR role = 'admin'");
+					}).notToThrow();
+				});
+
+				it("allows single-argument raw SQL in orWhere()", function() {
+					expect(function() {
+						qb.orWhere("status = 'active' OR role = 'admin'");
+					}).notToThrow();
+				});
+
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `$validatePropertyName()` to reject SQL injection in property arguments across `whereNull`, `whereNotNull`, `whereBetween`, `whereIn`, `whereNotIn`, `orderBy`, and `$buildCondition`
- Adds `$validateOperator()` to restrict operators to a safe allowlist (`=`, `!=`, `<>`, `<`, `>`, `<=`, `>=`, `LIKE`, `NOT LIKE`, `IS`, `IS NOT`)
- Adds `$validateDirection()` to restrict ORDER BY direction to `ASC`/`DESC`
- Raw single-argument `where()` passthrough intentionally unchanged (power-user feature)

## Test plan
- [ ] 30+ new TestBox BDD specs in `QueryBuilderSpec.cfc` covering valid names, injection attempts, all affected methods, direction/operator validation
- [ ] CI passes on Lucee + Adobe engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)