### PR TITLE
fix: escape single quotes in $quoteValue() to prevent SQL injection

### DIFF
--- a/vendor/wheels/databaseAdapters/Base.cfc
+++ b/vendor/wheels/databaseAdapters/Base.cfc
@@ -478,7 +478,7 @@ component output=false extends="wheels.Global"{
 			arguments.type = $getValidationType(arguments.sqlType);
 		}
 		if (!ListFindNoCase("integer,float,boolean", arguments.type) || !Len(arguments.str)) {
-			local.rv = "'#arguments.str#'";
+			local.rv = "'#Replace(arguments.str, "'", "''", "all")#'";
 		} else {
 			local.rv = arguments.str;
 		}

--- a/vendor/wheels/tests/specs/database/QuoteValueSpec.cfc
+++ b/vendor/wheels/tests/specs/database/QuoteValueSpec.cfc
@@ -1,0 +1,51 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("$quoteValue()", () => {
+
+			beforeEach(() => {
+				adapter = CreateObject("component", "wheels.databaseAdapters.H2.H2Model");
+			});
+
+			it("wraps string values in single quotes", () => {
+				expect(adapter.$quoteValue(str="hello")).toBe("'hello'");
+			});
+
+			it("returns numeric values unquoted for integer type", () => {
+				expect(adapter.$quoteValue(str="42", type="integer")).toBe("42");
+			});
+
+			it("returns numeric values unquoted for float type", () => {
+				expect(adapter.$quoteValue(str="3.14", type="float")).toBe("3.14");
+			});
+
+			it("returns numeric values unquoted for boolean type", () => {
+				expect(adapter.$quoteValue(str="1", type="boolean")).toBe("1");
+			});
+
+			it("quotes empty strings even for numeric types", () => {
+				expect(adapter.$quoteValue(str="", type="integer")).toBe("''");
+			});
+
+			it("escapes single quotes to prevent SQL injection", () => {
+				expect(adapter.$quoteValue(str="test' OR '1'='1")).toBe("'test'' OR ''1''=''1'");
+			});
+
+			it("escapes multiple single quotes in a value", () => {
+				expect(adapter.$quoteValue(str="it's a 'test'")).toBe("'it''s a ''test'''");
+			});
+
+			it("handles strings with no single quotes unchanged", () => {
+				expect(adapter.$quoteValue(str="normal value")).toBe("'normal value'");
+			});
+
+			it("handles a single quote character", () => {
+				expect(adapter.$quoteValue(str="'")).toBe("''''");
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/database/QuoteValueSpec.cfc
+++ b/vendor/wheels/tests/specs/database/QuoteValueSpec.cfc
@@ -5,7 +5,7 @@ component extends="wheels.WheelsTest" {
 		describe("$quoteValue()", () => {
 
 			beforeEach(() => {
-				adapter = CreateObject("component", "wheels.databaseAdapters.H2.H2Model");
+				adapter = CreateObject("component", "wheels.databaseAdapters.SQLite.SQLiteModel");
 			});
 
 			it("wraps string values in single quotes", () => {


### PR DESCRIPTION
## Summary
- **Critical SQL injection fix** in `$quoteValue()` (`vendor/wheels/databaseAdapters/Base.cfc`)
- The function wrapped string values in single quotes without escaping embedded quotes, allowing payloads like `test' OR '1'='1` to break out of the quoted context
- Fix: `Replace(arguments.str, "'", "''", "all")` before wrapping in quotes — standard SQL single-quote escaping
- Added `QuoteValueSpec.cfc` with 9 test cases covering injection payloads, edge cases, and numeric passthrough

## Test plan
- [ ] CI passes across all engines (Lucee 5/6/7, Adobe 2018/2021/2023/2025, BoxLang) with SQLite
- [ ] Verify `$quoteValue("test' OR '1'='1")` returns `'test'' OR ''1''=''1'` (escaped)
- [ ] Verify numeric types still pass through unquoted
- [ ] Verify empty strings are still quoted (not passed through as numeric)

🤖 Generated with [Claude Code](https://claude.com/claude-code)