### PR TITLE
fix(auth): prevent session fixation on login

### DIFF
--- a/vendor/wheels/auth/SessionStrategy.cfc
+++ b/vendor/wheels/auth/SessionStrategy.cfc
@@ -101,7 +101,7 @@ component implements="wheels.auth.AuthStrategy" output="false" {
 		try {
 			sessionRotate();
 		} catch (any e) {
-			// Engine doesn't support sessionRotate — continue without rotation
+			writeLog(text="sessionRotate() unavailable: #e.message#", type="warning", file="wheels_auth");
 		}
 
 		$setSessionPrincipal(arguments.principal);

--- a/vendor/wheels/auth/SessionStrategy.cfc
+++ b/vendor/wheels/auth/SessionStrategy.cfc
@@ -97,6 +97,13 @@ component implements="wheels.auth.AuthStrategy" output="false" {
 	 * @principal Struct representing the authenticated identity (user id, roles, etc.).
 	 */
 	public void function login(required struct principal) {
+		// Regenerate session ID to prevent session fixation attacks
+		try {
+			sessionRotate();
+		} catch (any e) {
+			// Engine doesn't support sessionRotate — continue without rotation
+		}
+
 		$setSessionPrincipal(arguments.principal);
 
 		if (IsCustomFunction(variables.onLogin) || IsClosure(variables.onLogin)) {

--- a/vendor/wheels/tests/specs/auth/SessionStrategySpec.cfc
+++ b/vendor/wheels/tests/specs/auth/SessionStrategySpec.cfc
@@ -103,6 +103,14 @@ component extends="wheels.WheelsTest" {
 					expect(captured.principal.id).toBe(99);
 				});
 
+				it("does not error when sessionRotate is called during login", function() {
+					// sessionRotate() is wrapped in try/catch so login works
+					// even on engines that don't support it
+					strategy.login(principal = {id = 42});
+					expect(strategy.isLoggedIn()).toBeTrue();
+					expect(strategy.currentUser().id).toBe(42);
+				});
+
 				it("creates intermediate session structs for nested keys", function() {
 					strategy.login(principal = {id = 5});
 


### PR DESCRIPTION
## Summary
- Calls `sessionRotate()` before storing the principal in `SessionStrategy.login()` to prevent session fixation attacks
- Wrapped in try/catch so login continues gracefully on engines that don't support `sessionRotate()`
- Added test verifying login succeeds without error when sessionRotate is invoked

## Test plan
- [ ] Verify existing `SessionStrategySpec` tests still pass on Lucee and Adobe
- [ ] Verify the new "does not error when sessionRotate is called during login" test passes
- [ ] Confirm login flow works end-to-end on a running server

🤖 Generated with [Claude Code](https://claude.com/claude-code)