### PR TITLE
fix(security): add SameSite attribute to CSRF cookie

### DIFF
--- a/vendor/wheels/controller/csrf.cfc
+++ b/vendor/wheels/controller/csrf.cfc
@@ -232,6 +232,9 @@ component {
 			preserveCase = application.wheels.csrfCookiePreserveCase,
 			secure = application.wheels.csrfCookieSecure
 		};
+		if (Len(application.wheels.csrfCookieSameSite)) {
+			local.cookieStruct.sameSite = application.wheels.csrfCookieSameSite;
+		}
 		if (Len(application.wheels.csrfCookieDomain)) {
 			local.cookieStruct.domain = application.wheels.csrfCookieDomain;
 		}

--- a/vendor/wheels/events/init/security.cfm
+++ b/vendor/wheels/events/init/security.cfm
@@ -11,6 +11,7 @@
 		application.$wheels.csrfCookiePath = "/";
 		application.$wheels.csrfCookiePreserveCase = "";
 		application.$wheels.csrfCookieSecure = true;
+		application.$wheels.csrfCookieSameSite = "Lax";
 
 		// CORS (Cross-Origin Resource Sharing) settings.
 		application.$wheels.allowCorsRequests = false;

--- a/vendor/wheels/tests/specs/events/SecurityDefaultsSpec.cfc
+++ b/vendor/wheels/tests/specs/events/SecurityDefaultsSpec.cfc
@@ -15,6 +15,33 @@ component extends="wheels.WheelsTest" {
 				expect(application.wheels.csrfCookieSecure).toBe(true);
 			});
 
+			it("defaults csrfCookieSameSite to Lax", function() {
+				expect(application.wheels.csrfCookieSameSite).toBe("Lax");
+			});
+
+		});
+
+		describe("CSRF cookie attribute collection", function() {
+
+			it("includes sameSite attribute when csrfCookieSameSite is set", function() {
+				var _controller = application.wo.controller("dummy");
+				var attrs = _controller.$csrfCookieAttributeCollection("testvalue");
+				expect(StructKeyExists(attrs, "sameSite")).toBeTrue();
+				expect(attrs.sameSite).toBe("Lax");
+			});
+
+			it("omits sameSite attribute when csrfCookieSameSite is empty", function() {
+				var originalValue = application.wheels.csrfCookieSameSite;
+				application.wheels.csrfCookieSameSite = "";
+				try {
+					var _controller = application.wo.controller("dummy");
+					var attrs = _controller.$csrfCookieAttributeCollection("testvalue");
+					expect(StructKeyExists(attrs, "sameSite")).toBeFalse();
+				} finally {
+					application.wheels.csrfCookieSameSite = originalValue;
+				}
+			});
+
 		});
 
 	}


### PR DESCRIPTION
## Summary
- Adds `SameSite=Lax` attribute to the CSRF protection cookie, preventing cross-site POST requests
- New `csrfCookieSameSite` setting (default: `"Lax"`) — configurable, set to empty string to omit
- Tests verify the attribute is included/omitted based on configuration

## Test plan
- [ ] Verify `SecurityDefaultsSpec` passes on Lucee 6 + SQLite
- [ ] Verify CSRF cookie includes `SameSite=Lax` in browser dev tools
- [ ] Verify setting `csrfCookieSameSite = ""` omits the attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)