### PR TITLE
feat(middleware): add CSP, HSTS, and Permissions-Policy to SecurityHeaders

### DIFF
--- a/vendor/wheels/middleware/SecurityHeaders.cfc
+++ b/vendor/wheels/middleware/SecurityHeaders.cfc
@@ -1,6 +1,7 @@
 /**
  * Adds common security headers to every response.
- * Covers OWASP recommended headers for clickjacking, XSS, MIME sniffing, and referrer leakage.
+ * Covers OWASP recommended headers for clickjacking, XSS, MIME sniffing, referrer leakage,
+ * content security policy, transport security, and browser feature permissions.
  *
  * [section: Middleware]
  * [category: Built-in]
@@ -14,12 +15,18 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	 * @contentTypeOptions X-Content-Type-Options value.
 	 * @xssProtection X-XSS-Protection value.
 	 * @referrerPolicy Referrer-Policy value.
+	 * @contentSecurityPolicy Content-Security-Policy value. Empty by default (opt-in) because a restrictive policy can break apps with inline scripts/styles.
+	 * @strictTransportSecurity Strict-Transport-Security value. Empty by default (opt-in) because it requires HTTPS to be configured.
+	 * @permissionsPolicy Permissions-Policy value. Empty by default (opt-in) because it is app-specific.
 	 */
 	public SecurityHeaders function init(
 		string frameOptions = "SAMEORIGIN",
 		string contentTypeOptions = "nosniff",
 		string xssProtection = "1; mode=block",
-		string referrerPolicy = "strict-origin-when-cross-origin"
+		string referrerPolicy = "strict-origin-when-cross-origin",
+		string contentSecurityPolicy = "",
+		string strictTransportSecurity = "",
+		string permissionsPolicy = ""
 	) {
 		variables.headers = {};
 		if (Len(arguments.frameOptions)) {
@@ -34,7 +41,20 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		if (Len(arguments.referrerPolicy)) {
 			variables.headers["Referrer-Policy"] = arguments.referrerPolicy;
 		}
+		if (Len(arguments.contentSecurityPolicy)) {
+			variables.headers["Content-Security-Policy"] = arguments.contentSecurityPolicy;
+		}
+		if (Len(arguments.strictTransportSecurity)) {
+			variables.headers["Strict-Transport-Security"] = arguments.strictTransportSecurity;
+		}
+		if (Len(arguments.permissionsPolicy)) {
+			variables.headers["Permissions-Policy"] = arguments.permissionsPolicy;
+		}
 		return this;
+	}
+
+	public struct function $headers() {
+		return variables.headers;
 	}
 
 	public string function handle(required struct request, required any next) {

--- a/vendor/wheels/tests/specs/middleware/SecurityHeadersSpec.cfc
+++ b/vendor/wheels/tests/specs/middleware/SecurityHeadersSpec.cfc
@@ -1,0 +1,165 @@
+/**
+ * Tests for SecurityHeaders middleware including CSP, HSTS, and Permissions-Policy.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("SecurityHeaders middleware", function() {
+
+			beforeEach(function() {
+				variables.nextHandler = function(required struct request) {
+					return "ok";
+				};
+				variables.reqCtx = {cgi = {}};
+			});
+
+			describe("default headers", function() {
+
+				it("sets four default security headers", function() {
+					local.mw = new wheels.middleware.SecurityHeaders();
+					expect(local.mw.$headers()).toHaveKey("X-Frame-Options");
+					expect(local.mw.$headers()).toHaveKey("X-Content-Type-Options");
+					expect(local.mw.$headers()).toHaveKey("X-XSS-Protection");
+					expect(local.mw.$headers()).toHaveKey("Referrer-Policy");
+				});
+
+				it("does not set CSP by default", function() {
+					local.mw = new wheels.middleware.SecurityHeaders();
+					expect(local.mw.$headers()).notToHaveKey("Content-Security-Policy");
+				});
+
+				it("does not set HSTS by default", function() {
+					local.mw = new wheels.middleware.SecurityHeaders();
+					expect(local.mw.$headers()).notToHaveKey("Strict-Transport-Security");
+				});
+
+				it("does not set Permissions-Policy by default", function() {
+					local.mw = new wheels.middleware.SecurityHeaders();
+					expect(local.mw.$headers()).notToHaveKey("Permissions-Policy");
+				});
+
+			});
+
+			describe("Content-Security-Policy", function() {
+
+				it("sets CSP header when provided", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						contentSecurityPolicy = "default-src 'self'"
+					);
+					expect(local.mw.$headers()).toHaveKey("Content-Security-Policy");
+					expect(local.mw.$headers()["Content-Security-Policy"]).toBe("default-src 'self'");
+				});
+
+				it("supports complex CSP directives", function() {
+					local.policy = "default-src 'self'; script-src 'self' https://cdn.example.com; style-src 'self' 'unsafe-inline'";
+					local.mw = new wheels.middleware.SecurityHeaders(
+						contentSecurityPolicy = local.policy
+					);
+					expect(local.mw.$headers()["Content-Security-Policy"]).toBe(local.policy);
+				});
+
+				it("does not set CSP header when empty string", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						contentSecurityPolicy = ""
+					);
+					expect(local.mw.$headers()).notToHaveKey("Content-Security-Policy");
+				});
+
+			});
+
+			describe("Strict-Transport-Security", function() {
+
+				it("sets HSTS header when provided", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						strictTransportSecurity = "max-age=31536000; includeSubDomains"
+					);
+					expect(local.mw.$headers()).toHaveKey("Strict-Transport-Security");
+					expect(local.mw.$headers()["Strict-Transport-Security"]).toBe("max-age=31536000; includeSubDomains");
+				});
+
+				it("supports HSTS with preload", function() {
+					local.value = "max-age=63072000; includeSubDomains; preload";
+					local.mw = new wheels.middleware.SecurityHeaders(
+						strictTransportSecurity = local.value
+					);
+					expect(local.mw.$headers()["Strict-Transport-Security"]).toBe(local.value);
+				});
+
+				it("does not set HSTS header when empty string", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						strictTransportSecurity = ""
+					);
+					expect(local.mw.$headers()).notToHaveKey("Strict-Transport-Security");
+				});
+
+			});
+
+			describe("Permissions-Policy", function() {
+
+				it("sets Permissions-Policy header when provided", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						permissionsPolicy = "camera=(), microphone=(), geolocation=()"
+					);
+					expect(local.mw.$headers()).toHaveKey("Permissions-Policy");
+					expect(local.mw.$headers()["Permissions-Policy"]).toBe("camera=(), microphone=(), geolocation=()");
+				});
+
+				it("does not set Permissions-Policy header when empty string", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						permissionsPolicy = ""
+					);
+					expect(local.mw.$headers()).notToHaveKey("Permissions-Policy");
+				});
+
+			});
+
+			describe("disabling headers", function() {
+
+				it("omits X-Frame-Options when set to empty string", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(frameOptions = "");
+					expect(local.mw.$headers()).notToHaveKey("X-Frame-Options");
+				});
+
+				it("allows overriding default header values", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						frameOptions = "DENY",
+						referrerPolicy = "no-referrer"
+					);
+					expect(local.mw.$headers()["X-Frame-Options"]).toBe("DENY");
+					expect(local.mw.$headers()["Referrer-Policy"]).toBe("no-referrer");
+				});
+
+			});
+
+			describe("handle()", function() {
+
+				it("calls next handler and returns its result", function() {
+					local.mw = new wheels.middleware.SecurityHeaders();
+					local.result = local.mw.handle(
+						request = variables.reqCtx,
+						next = variables.nextHandler
+					);
+					expect(local.result).toBe("ok");
+				});
+
+				it("calls next handler even with all new headers configured", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						contentSecurityPolicy = "default-src 'self'",
+						strictTransportSecurity = "max-age=31536000",
+						permissionsPolicy = "camera=()"
+					);
+					local.result = local.mw.handle(
+						request = variables.reqCtx,
+						next = variables.nextHandler
+					);
+					expect(local.result).toBe("ok");
+				});
+
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add three opt-in security headers to `SecurityHeaders` middleware: `Content-Security-Policy`, `Strict-Transport-Security`, and `Permissions-Policy`
- All default to empty string (opt-in) to avoid breaking existing apps — CSP can break inline scripts, HSTS requires HTTPS, Permissions-Policy is app-specific
- Add `$headers()` accessor for test inspection of configured headers

## Test plan
- [ ] New `SecurityHeadersSpec.cfc` covers all three new headers (set when provided, omitted when empty)
- [ ] Tests cover default header presence, disabling headers, overriding values, and handle() passthrough
- [ ] CI matrix validates compilation across all engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)