### PR TITLE
fix(security): prevent path traversal in guideImage endpoint

### DIFF
--- a/vendor/wheels/Public.cfc
+++ b/vendor/wheels/Public.cfc
@@ -204,26 +204,39 @@ component output="false" displayName="Internal GUI" extends="wheels.Global" {
 
 	function guideImage() {
 		var file = StructKeyExists(request.wheels.params, "file") ? request.wheels.params.file : "";
-		var assetPath = expandPath("/wheels/docs/src/.gitbook/assets/" & file);
 
-		if (fileExists(assetPath)) {
-			var ext = lcase(listLast(file, "."));
-			var mime = "application/octet-stream";
-			switch (ext) {
-				case "png": mime = "image/png"; break;
-				case "jpg":
-				case "jpeg": mime = "image/jpeg"; break;
-				case "gif": mime = "image/gif"; break;
-				case "svg": mime = "image/svg+xml"; break;
-				case "webp": mime = "image/webp"; break;
-			}
-			cfheader(name="Content-Type", value=mime);
-			cffile(action="readBinary", file=assetPath, variable="imgData");
-			cfcontent(type=mime, variable=imgData);
-		} else {
+		file = getFileFromPath(file);
+		if (!len(file) || find("..", file) || reFind("[/\\]", file)) {
 			cfheader(statusCode=404);
 			writeOutput("Image not found");
+			return;
 		}
+
+		var assetsDir = expandPath("/wheels/docs/src/.gitbook/assets/");
+		var assetPath = assetsDir & file;
+
+		// Java canonical path for cross-engine compat (getCanonicalPath is Lucee-only)
+		var canonicalAssets = createObject("java", "java.io.File").init(assetsDir).getCanonicalPath();
+		var canonicalPath = createObject("java", "java.io.File").init(assetPath).getCanonicalPath();
+		if (!fileExists(assetPath) || left(canonicalPath, len(canonicalAssets)) != canonicalAssets) {
+			cfheader(statusCode=404);
+			writeOutput("Image not found");
+			return;
+		}
+
+		var ext = lcase(listLast(file, "."));
+		var mime = "application/octet-stream";
+		switch (ext) {
+			case "png": mime = "image/png"; break;
+			case "jpg":
+			case "jpeg": mime = "image/jpeg"; break;
+			case "gif": mime = "image/gif"; break;
+			case "svg": mime = "image/svg+xml"; break;
+			case "webp": mime = "image/webp"; break;
+		}
+		cfheader(name="Content-Type", value=mime);
+		cffile(action="readBinary", file=assetPath, variable="imgData");
+		cfcontent(type=mime, variable=imgData);
 	}
 
 	function mcp() {

--- a/vendor/wheels/Public.cfc
+++ b/vendor/wheels/Public.cfc
@@ -215,10 +215,15 @@ component output="false" displayName="Internal GUI" extends="wheels.Global" {
 		var assetsDir = expandPath("/wheels/docs/src/.gitbook/assets/");
 		var assetPath = assetsDir & file;
 
-		// Java canonical path for cross-engine compat (getCanonicalPath is Lucee-only)
-		var canonicalAssets = createObject("java", "java.io.File").init(assetsDir).getCanonicalPath();
-		var canonicalPath = createObject("java", "java.io.File").init(assetPath).getCanonicalPath();
-		if (!fileExists(assetPath) || left(canonicalPath, len(canonicalAssets)) != canonicalAssets) {
+		try {
+			var canonicalAssets = createObject("java", "java.io.File").init(assetsDir).getCanonicalPath();
+			var canonicalPath = createObject("java", "java.io.File").init(assetPath).getCanonicalPath();
+		} catch (any e) {
+			cfheader(statusCode=404);
+			writeOutput("Image not found");
+			return;
+		}
+		if (!fileExists(assetPath) || CompareNoCase(left(canonicalPath, len(canonicalAssets)), canonicalAssets) != 0) {
 			cfheader(statusCode=404);
 			writeOutput("Image not found");
 			return;

--- a/vendor/wheels/tests/specs/security/PathTraversalSpec.cfc
+++ b/vendor/wheels/tests/specs/security/PathTraversalSpec.cfc
@@ -1,0 +1,57 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("guideImage path traversal prevention", () => {
+
+			it("strips directory components from file parameter", () => {
+				var file = "../../etc/passwd"
+				var sanitized = getFileFromPath(file)
+				expect(sanitized).toBe("passwd")
+			})
+
+			it("strips backslash directory components", () => {
+				var file = "..\..\windows\system32\config\sam"
+				var sanitized = getFileFromPath(file)
+				expect(sanitized).notToInclude("..")
+			})
+
+			it("allows a simple filename with no path components", () => {
+				var file = "screenshot.png"
+				var sanitized = getFileFromPath(file)
+				expect(sanitized).toBe("screenshot.png")
+				expect(find("..", sanitized)).toBe(0)
+				expect(reFind("[/\\]", sanitized)).toBe(0)
+			})
+
+			it("rejects path traversal with forward slashes", () => {
+				var file = "../../../etc/passwd"
+				var sanitized = getFileFromPath(file)
+				expect(sanitized).notToInclude("/")
+				expect(sanitized).notToInclude("..")
+			})
+
+			it("validates canonical path stays within assets directory", () => {
+				var assetsDir = expandPath("/wheels/docs/src/.gitbook/assets/")
+				var canonicalAssets = createObject("java", "java.io.File").init(assetsDir).getCanonicalPath()
+
+				var traversalPath = assetsDir & "../../Public.cfc"
+				var canonicalTraversal = createObject("java", "java.io.File").init(traversalPath).getCanonicalPath()
+
+				expect(left(canonicalTraversal, len(canonicalAssets))).notToBe(canonicalAssets)
+			})
+
+			it("validates canonical path for a legitimate file stays within assets directory", () => {
+				var assetsDir = expandPath("/wheels/docs/src/.gitbook/assets/")
+				var canonicalAssets = createObject("java", "java.io.File").init(assetsDir).getCanonicalPath()
+
+				var normalPath = assetsDir & "test.png"
+				var canonicalNormal = createObject("java", "java.io.File").init(normalPath).getCanonicalPath()
+
+				expect(left(canonicalNormal, len(canonicalAssets))).toBe(canonicalAssets)
+			})
+		})
+	}
+}

--- a/vendor/wheels/tests/specs/security/PathTraversalSpec.cfc
+++ b/vendor/wheels/tests/specs/security/PathTraversalSpec.cfc
@@ -2,56 +2,57 @@ component extends="wheels.WheelsTest" {
 
 	function run() {
 
-		g = application.wo
-
 		describe("guideImage path traversal prevention", () => {
 
 			it("strips directory components from file parameter", () => {
-				var file = "../../etc/passwd"
-				var sanitized = getFileFromPath(file)
-				expect(sanitized).toBe("passwd")
-			})
+				var file = "../../etc/passwd";
+				var sanitized = getFileFromPath(file);
+				expect(sanitized).toBe("passwd");
+			});
 
 			it("strips backslash directory components", () => {
-				var file = "..\..\windows\system32\config\sam"
-				var sanitized = getFileFromPath(file)
-				expect(sanitized).notToInclude("..")
-			})
+				var file = "..\..\windows\system32\config\sam";
+				var sanitized = getFileFromPath(file);
+				expect(sanitized).notToInclude("..");
+			});
 
 			it("allows a simple filename with no path components", () => {
-				var file = "screenshot.png"
-				var sanitized = getFileFromPath(file)
-				expect(sanitized).toBe("screenshot.png")
-				expect(find("..", sanitized)).toBe(0)
-				expect(reFind("[/\\]", sanitized)).toBe(0)
-			})
+				var file = "screenshot.png";
+				var sanitized = getFileFromPath(file);
+				expect(sanitized).toBe("screenshot.png");
+				expect(find("..", sanitized)).toBe(0);
+				expect(reFind("[/\\]", sanitized)).toBe(0);
+			});
 
 			it("rejects path traversal with forward slashes", () => {
-				var file = "../../../etc/passwd"
-				var sanitized = getFileFromPath(file)
-				expect(sanitized).notToInclude("/")
-				expect(sanitized).notToInclude("..")
-			})
+				var file = "../../../etc/passwd";
+				var sanitized = getFileFromPath(file);
+				expect(sanitized).notToInclude("/");
+				expect(sanitized).notToInclude("..");
+			});
 
 			it("validates canonical path stays within assets directory", () => {
-				var assetsDir = expandPath("/wheels/docs/src/.gitbook/assets/")
-				var canonicalAssets = createObject("java", "java.io.File").init(assetsDir).getCanonicalPath()
+				var assetsDir = expandPath("/wheels/docs/src/.gitbook/assets/");
+				var canonicalAssets = createObject("java", "java.io.File").init(assetsDir).getCanonicalPath();
 
-				var traversalPath = assetsDir & "../../Public.cfc"
-				var canonicalTraversal = createObject("java", "java.io.File").init(traversalPath).getCanonicalPath()
+				var traversalPath = assetsDir & "../../Public.cfc";
+				var canonicalTraversal = createObject("java", "java.io.File").init(traversalPath).getCanonicalPath();
 
-				expect(left(canonicalTraversal, len(canonicalAssets))).notToBe(canonicalAssets)
-			})
+				expect(CompareNoCase(left(canonicalTraversal, len(canonicalAssets)), canonicalAssets)).notToBe(0);
+			});
 
 			it("validates canonical path for a legitimate file stays within assets directory", () => {
-				var assetsDir = expandPath("/wheels/docs/src/.gitbook/assets/")
-				var canonicalAssets = createObject("java", "java.io.File").init(assetsDir).getCanonicalPath()
+				var assetsDir = expandPath("/wheels/docs/src/.gitbook/assets/");
+				var canonicalAssets = createObject("java", "java.io.File").init(assetsDir).getCanonicalPath();
 
-				var normalPath = assetsDir & "test.png"
-				var canonicalNormal = createObject("java", "java.io.File").init(normalPath).getCanonicalPath()
+				var normalPath = assetsDir & "test.png";
+				var canonicalNormal = createObject("java", "java.io.File").init(normalPath).getCanonicalPath();
 
-				expect(left(canonicalNormal, len(canonicalAssets))).toBe(canonicalAssets)
-			})
-		})
+				expect(CompareNoCase(left(canonicalNormal, len(canonicalAssets)), canonicalAssets)).toBe(0);
+			});
+
+		});
+
 	}
+
 }


### PR DESCRIPTION
## Summary
- **CRITICAL**: `guideImage()` concatenated user input directly into `expandPath()`, allowing arbitrary file reads via `../../` sequences
- Fix strips directory components with `getFileFromPath()`, rejects `..` patterns, and validates the canonical path stays within the assets directory
- Defense-in-depth: input sanitization + canonical path validation via Java `File.getCanonicalPath()`

## Test plan
- [ ] `PathTraversalSpec` passes on Lucee 6 + SQLite
- [ ] Verify `?file=../../etc/passwd` returns 404
- [ ] Verify legitimate image files still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)