### PR TITLE
fix(security): prevent open redirect in redirectTo()

### DIFF
--- a/vendor/wheels/controller/redirection.cfc
+++ b/vendor/wheels/controller/redirection.cfc
@@ -101,11 +101,11 @@ component {
 				}
 			}
 		} else if (Len(arguments.url)) {
-			if (!$isSafeRedirectUrl(url = arguments.url, serverName = request.cgi.server_name)) {
+			if (!$get("allowExternalRedirects") && !$isSafeRedirectUrl(url = arguments.url, serverName = request.cgi.server_name)) {
 				Throw(
 					type = "Wheels.UnsafeRedirect",
 					message = "The URL passed to `redirectTo()` is not safe for redirection.",
-					extendedInfo = "Only relative URLs and URLs matching the current domain are allowed. URL: #arguments.url#"
+					extendedInfo = "Only relative URLs and URLs matching the current domain are allowed. Set allowExternalRedirects=true to permit external redirects. URL: #EncodeForHTML(arguments.url)#"
 				);
 			}
 			local.url = arguments.url;

--- a/vendor/wheels/controller/redirection.cfc
+++ b/vendor/wheels/controller/redirection.cfc
@@ -79,7 +79,7 @@ component {
 
 		// Set the url that will be used in the cflocation tag.
 		if (arguments.back) {
-			if (Len(request.cgi.http_referer) && FindNoCase(request.cgi.server_name, request.cgi.http_referer)) {
+			if (Len(request.cgi.http_referer) && $isSafeRedirectUrl(url = request.cgi.http_referer, serverName = request.cgi.server_name)) {
 				// Referrer exists and points to the same domain so it's ok to redirect to it.
 				local.url = request.cgi.http_referer;
 				if (Len(arguments.params)) {
@@ -101,6 +101,13 @@ component {
 				}
 			}
 		} else if (Len(arguments.url)) {
+			if (!$isSafeRedirectUrl(url = arguments.url, serverName = request.cgi.server_name)) {
+				Throw(
+					type = "Wheels.UnsafeRedirect",
+					message = "The URL passed to `redirectTo()` is not safe for redirection.",
+					extendedInfo = "Only relative URLs and URLs matching the current domain are allowed. URL: #arguments.url#"
+				);
+			}
 			local.url = arguments.url;
 			if (Len(arguments.params)) {
 				if (Find("?", arguments.url)) {
@@ -130,5 +137,39 @@ component {
 			// Do the redirect now using cflocation.
 			$location(url = local.url, addToken = arguments.addToken, statusCode = arguments.statusCode);
 		}
+	}
+
+	/**
+	 * Validates that a URL is safe for redirection (relative or same-domain).
+	 * Prevents open redirect attacks by extracting the hostname from absolute URLs
+	 * and comparing it exactly to the current server name.
+	 *
+	 * [section: Controller]
+	 * [category: Miscellaneous Functions]
+	 */
+	public boolean function $isSafeRedirectUrl(required string url, required string serverName) {
+		// Relative URLs (starting with "/" but not "//") are always safe.
+		if (Left(arguments.url, 1) == "/" && (Len(arguments.url) == 1 || Left(arguments.url, 2) != "//")) {
+			return true;
+		}
+
+		// Extract the hostname from the URL for exact comparison.
+		if (Left(arguments.url, 2) == "//") {
+			// Protocol-relative URL: //hostname/path
+			local.afterScheme = Mid(arguments.url, 3, Len(arguments.url) - 2);
+		} else {
+			local.schemeEnd = Find("://", arguments.url);
+			if (local.schemeEnd == 0) {
+				// No scheme and doesn't start with "/" — treat as relative path (e.g. "page", "dir/page").
+				return true;
+			}
+			// Absolute URL: scheme://hostname/path
+			local.afterScheme = Mid(arguments.url, local.schemeEnd + 3, Len(arguments.url) - local.schemeEnd - 2);
+		}
+
+		// Extract hostname before any port, path, query, or fragment delimiter.
+		local.refererHost = ListFirst(local.afterScheme, ":/?\##");
+
+		return CompareNoCase(local.refererHost, arguments.serverName) == 0;
 	}
 }

--- a/vendor/wheels/events/init/security.cfm
+++ b/vendor/wheels/events/init/security.cfm
@@ -20,6 +20,9 @@
 		application.$wheels.accessControlAllowCredentials = false;
 		application.$wheels.accessControlAllowHeaders = "Origin, Content-Type, X-Auth-Token, X-Requested-By, X-Requested-With";
 
+		// Redirect security settings.
+		application.$wheels.allowExternalRedirects = false;
+
 		// IP based restriction settings
 		application.$wheels.debugAccessIPs = [];
 		application.$wheels.allowIPBasedDebugAccess = false;

--- a/vendor/wheels/tests/specs/controller/redirectionSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/redirectionSpec.cfc
@@ -226,6 +226,18 @@ component extends="wheels.WheelsTest" {
 
 				expect(r.url).toBe("//" & request.cgi.server_name & "/page")
 			})
+
+			it("allows external redirect when allowExternalRedirects is true", () => {
+				application.wheels.allowExternalRedirects = true;
+				try {
+					_controller.redirectTo(url = "http://external.com/page")
+					r = _controller.getRedirect()
+
+					expect(r.url).toBe("http://external.com/page")
+				} finally {
+					application.wheels.allowExternalRedirects = false;
+				}
+			})
 		})
 	}
 }

--- a/vendor/wheels/tests/specs/controller/redirectionSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/redirectionSpec.cfc
@@ -99,27 +99,132 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("is redirecting to URL", () => {
-				_controller.redirectTo(url = "http://www.google.com")
+				_controller.redirectTo(url = "http://" & request.cgi.server_name & "/some-page")
 				r = _controller.getRedirect()
 
 				expect(_controller.$performedRedirect()).toBeTrue()
 				expect(r).toHaveKey("url")
 			})
 
+			it("is redirecting to relative URL", () => {
+				_controller.redirectTo(url = "/some-page")
+				r = _controller.getRedirect()
+
+				expect(_controller.$performedRedirect()).toBeTrue()
+				expect(r.url).toBe("/some-page")
+			})
+
 			it("is redirecting to URL with params", () => {
-				_controller.redirectTo(url = "http://www.google.com", params = "foo=bar")
+				_controller.redirectTo(url = "http://" & request.cgi.server_name & "/page", params = "foo=bar")
 				actual = _controller.getRedirect().url
-				expected = "http://www.google.com?foo=bar"
+				expected = "http://" & request.cgi.server_name & "/page?foo=bar"
 
 				expect(actual).toBe(expected)
 			})
 
 			it("is redirecting to URL with query string and with params", () => {
-				_controller.redirectTo(url = "http://www.google.com?foo=bar", params = "baz=qux")
+				_controller.redirectTo(url = "http://" & request.cgi.server_name & "/page?foo=bar", params = "baz=qux")
 				actual = _controller.getRedirect().url
-				expected = "http://www.google.com?foo=bar&baz=qux"
+				expected = "http://" & request.cgi.server_name & "/page?foo=bar&baz=qux"
 
 				expect(actual).toBe(expected)
+			})
+		})
+
+		describe("Tests that redirectto prevents open redirect", () => {
+
+			beforeEach(() => {
+				params = {controller = "test", action = "testRedirect"}
+				_controller = application.wo.controller("test", params)
+				copies.request.cgi = request.cgi
+			})
+
+			afterEach(() => {
+				request.cgi = copies.request.cgi
+			})
+
+			it("rejects referer with server name in query string", () => {
+				request.cgi.http_referer = "http://attacker.com?url=http://" & request.cgi.server_name
+				_controller.redirectTo(back = true)
+				r = _controller.getRedirect()
+
+				expect(r.url).toBe(application.wheels.webPath)
+			})
+
+			it("rejects referer with server name as subdomain of attacker", () => {
+				request.cgi.http_referer = "http://" & request.cgi.server_name & ".attacker.com/page"
+				_controller.redirectTo(back = true)
+				r = _controller.getRedirect()
+
+				expect(r.url).toBe(application.wheels.webPath)
+			})
+
+			it("accepts referer with exact server name match", () => {
+				path = "/test-controller/test-action"
+				request.cgi.http_referer = "http://" & request.cgi.server_name & path
+				_controller.redirectTo(back = true)
+				r = _controller.getRedirect()
+
+				expect(r.url).toInclude(path)
+			})
+
+			it("accepts referer with exact server name and port", () => {
+				path = "/test-controller/test-action"
+				request.cgi.http_referer = "http://" & request.cgi.server_name & ":8080" & path
+				_controller.redirectTo(back = true)
+				r = _controller.getRedirect()
+
+				expect(r.url).toInclude(path)
+			})
+
+			it("accepts referer with https scheme", () => {
+				path = "/secure-page"
+				request.cgi.http_referer = "https://" & request.cgi.server_name & path
+				_controller.redirectTo(back = true)
+				r = _controller.getRedirect()
+
+				expect(r.url).toInclude(path)
+			})
+
+			it("rejects referer with server name in path", () => {
+				request.cgi.http_referer = "http://evil.com/" & request.cgi.server_name
+				_controller.redirectTo(back = true)
+				r = _controller.getRedirect()
+
+				expect(r.url).toBe(application.wheels.webPath)
+			})
+
+			it("throws on redirectTo url with external domain", () => {
+				expect(function(){
+					_controller.redirectTo(url = "http://evil.com/phish")
+				}).toThrow("Wheels.UnsafeRedirect")
+			})
+
+			it("allows redirectTo url with relative path", () => {
+				_controller.redirectTo(url = "/safe/path")
+				r = _controller.getRedirect()
+
+				expect(r.url).toBe("/safe/path")
+			})
+
+			it("allows redirectTo url matching current domain", () => {
+				_controller.redirectTo(url = "http://" & request.cgi.server_name & "/page")
+				r = _controller.getRedirect()
+
+				expect(r.url).toBe("http://" & request.cgi.server_name & "/page")
+			})
+
+			it("throws on redirectTo url with protocol-relative external domain", () => {
+				expect(function(){
+					_controller.redirectTo(url = "//evil.com/phish")
+				}).toThrow("Wheels.UnsafeRedirect")
+			})
+
+			it("allows redirectTo url with protocol-relative same domain", () => {
+				_controller.redirectTo(url = "//" & request.cgi.server_name & "/page")
+				r = _controller.getRedirect()
+
+				expect(r.url).toBe("//" & request.cgi.server_name & "/page")
 			})
 		})
 	}


### PR DESCRIPTION
## Summary
- Replace vulnerable `FindNoCase()` substring match in referer validation with exact hostname extraction and comparison via new `$isSafeRedirectUrl()` helper
- Add URL validation to `redirectTo(url=...)` path — throws `Wheels.UnsafeRedirect` for external domains
- Handles absolute URLs, protocol-relative URLs (`//host/path`), and relative paths correctly

## Vulnerability
`FindNoCase(request.cgi.server_name, request.cgi.http_referer)` matches substrings, so a crafted referer like `http://attacker.com?url=http://mysite.com` or `http://mysite.com.attacker.com` would pass validation and redirect users to an attacker-controlled site.

## Test plan
- [x] Existing redirect tests updated (external domain URLs replaced with same-domain)
- [x] 11 new security tests covering: referer spoofing via query string, subdomain impersonation, path injection, external URL rejection, protocol-relative URL handling, and legitimate same-domain/relative URL acceptance
- [ ] CI: Lucee + Adobe engines pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)