### PR TITLE
fix(security): change CORS default from wildcard to deny-all

### DIFF
--- a/docs/src/handling-requests-with-controllers/cors-requests.md
+++ b/docs/src/handling-requests-with-controllers/cors-requests.md
@@ -8,15 +8,20 @@ Wheels can often act as the "backend" in a modern web application, serving data 
 
 When we separate our systems in such a manner, we need to consider CORS (Cross Origin Resource Sharing) and how to properly serve requests which modern browsers will allow.
 
-### The "Quick and Dirty" approach
+### Getting Started
 
-If you just need to satisfy your CORS requirement quickly, you can do so with a simple configuration switch in your `/config/settings.cfm` file: `set(allowCorsRequests=true);`.
+To enable CORS, add `set(allowCorsRequests=true);` to your `/config/settings.cfm` file. You must also configure your allowed origins explicitly — by default, no origins are permitted:
 
-By default, this will enable the following CORS headers:
+```javascript
+set(allowCorsRequests=true);
+set(accessControlAllowOrigin="https://app.domain.com");
+```
+
+This will enable the following CORS headers for matching requests:
 
 ```
 Access-Control-Allow-Origin 
-*
+https://app.domain.com
 
 Access-Control-Allow-Methods 
 GET, POST, PATCH, PUT, DELETE, OPTIONS
@@ -25,7 +30,9 @@ Access-Control-Allow-Headers
 Origin, Content-Type, X-Auth-Token, X-Requested-By, X-Requested-With
 ```
 
-This will satisfy most requirements to get going quickly, but is more of a blanket "catch all" configuration which doesn't really restrict anything, or provide much information to the API consumer about your available resources.
+{% hint style="warning" %}
+Setting `accessControlAllowOrigin` to `"*"` (wildcard) allows any website to make cross-origin requests to your application. Only use this in development or when you explicitly intend to provide a public API.
+{% endhint %}
 
 ### Custom CORS Headers
 
@@ -35,7 +42,7 @@ We can be more specific. We still need to specify `set(allowCorsRequests=true);`
 
 The Access Control Allow Origin header tells the browser whether the domain they are connecting from can access the requested resource.
 
-By default, this header is set to a wildcard allowing connection from any domain. But it might be your VueJS app lives at `app.domain.com` and we only want to allow access from that domain to our API.
+By default, this header is not set (empty string), meaning no cross-origin requests are allowed. You must explicitly configure your allowed origins. For example, if your VueJS app lives at `app.domain.com`:
 
 ```javascript
 // Wildcard

--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -3319,7 +3319,7 @@ component output="false" {
 	 * Set CORS Headers: only triggered if application.wheels.allowCorsRequests = true
 	 */
 	public void function $setCORSHeaders(
-		string allowOrigin = "*",
+		string allowOrigin = "",
 		string allowCredentials = false,
 		string allowHeaders = "Origin, Content-Type, X-Auth-Token, X-Requested-By, X-Requested-With",
 		string allowMethods = "GET, POST, PATCH, PUT, DELETE, OPTIONS",
@@ -3328,6 +3328,11 @@ component output="false" {
 		string scriptName = request.cgi.script_name
 	) {
 		local.incomingOrigin = StructKeyExists(request.wheels.httprequestdata.headers, "origin") ? request.wheels.httprequestdata.headers.origin : false;
+
+		// No origins configured — skip all CORS headers (deny all by default)
+		if (!Len(arguments.allowOrigin)) {
+			return;
+		}
 
 		// Either a wildcard, or if a specific domain is set, we need to ensure the incoming request matches it
 		if (arguments.allowOrigin == "*") {

--- a/vendor/wheels/events/init/security.cfm
+++ b/vendor/wheels/events/init/security.cfm
@@ -14,7 +14,7 @@
 
 		// CORS (Cross-Origin Resource Sharing) settings.
 		application.$wheels.allowCorsRequests = false;
-		application.$wheels.accessControlAllowOrigin = "*";
+		application.$wheels.accessControlAllowOrigin = "";
 		application.$wheels.accessControlAllowMethods = "GET, POST, PATCH, PUT, DELETE, OPTIONS";
 		application.$wheels.accessControlAllowMethodsByRoute = false;
 		application.$wheels.accessControlAllowCredentials = false;

--- a/vendor/wheels/tests/specs/dispatch/corsSecurityDefaultsSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/corsSecurityDefaultsSpec.cfc
@@ -1,0 +1,22 @@
+/**
+ * Tests that CORS security defaults are safe (deny-all, not wildcard).
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("CORS security defaults", () => {
+
+			it("defaults accessControlAllowOrigin to empty string not wildcard", () => {
+				expect(application.$wheels.accessControlAllowOrigin).toBe("");
+			});
+
+			it("defaults allowCorsRequests to false", () => {
+				expect(application.$wheels.allowCorsRequests).toBeFalse();
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary
- Changes `accessControlAllowOrigin` default from `"*"` to `""` (deny all)
- Updates `$setCORSHeaders()` to skip all CORS headers when no origin is configured
- Updates CORS documentation to reflect the new secure default
- Adds test verifying the default doesn't send `Access-Control-Allow-Origin: *`

## Test plan
- [ ] Verify `corsSecurityDefaultsSpec` passes on Lucee 6 + SQLite
- [ ] Verify existing CORS tests still pass
- [ ] Verify apps that explicitly set `accessControlAllowOrigin` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)