### PR TITLE
fix(security): harden rate limiter against memory exhaustion and IP spoofing

### DIFF
--- a/tests/specs/middleware/RateLimiterSpec.cfc
+++ b/tests/specs/middleware/RateLimiterSpec.cfc
@@ -43,6 +43,27 @@ component extends="wheels.WheelsTest" {
 					}).toThrow("Wheels.RateLimiter.InvalidStorage");
 				});
 
+				it("accepts proxyStrategy first", function() {
+					var mw = new wheels.middleware.RateLimiter(proxyStrategy = "first");
+					expect(mw).toBeInstanceOf("wheels.middleware.RateLimiter");
+				});
+
+				it("accepts proxyStrategy last", function() {
+					var mw = new wheels.middleware.RateLimiter(proxyStrategy = "last");
+					expect(mw).toBeInstanceOf("wheels.middleware.RateLimiter");
+				});
+
+				it("throws on invalid proxyStrategy", function() {
+					expect(function() {
+						new wheels.middleware.RateLimiter(proxyStrategy = "middle");
+					}).toThrow("Wheels.RateLimiter.InvalidProxyStrategy");
+				});
+
+				it("accepts custom maxStoreSize", function() {
+					var mw = new wheels.middleware.RateLimiter(maxStoreSize = 500);
+					expect(mw).toBeInstanceOf("wheels.middleware.RateLimiter");
+				});
+
 				it("accepts a custom keyFunction", function() {
 					var mw = new wheels.middleware.RateLimiter(
 						keyFunction = function(request) { return "custom-key"; }

--- a/vendor/wheels/middleware/RateLimiter.cfc
+++ b/vendor/wheels/middleware/RateLimiter.cfc
@@ -17,7 +17,19 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	 * @storage Backend: "memory" or "database".
 	 * @keyFunction Closure that receives the request struct and returns a string key. Defaults to client IP.
 	 * @headerPrefix Prefix for rate limit response headers.
-	 * @trustProxy Whether to use X-Forwarded-For for client IP resolution. Defaults to false for security — when true, any client can spoof their IP via X-Forwarded-For to bypass rate limiting. Only enable when behind a trusted reverse proxy (nginx, HAProxy, etc.) that strips or overwrites the X-Forwarded-For header from clients.
+	 * @trustProxy Whether to use X-Forwarded-For for client IP resolution. Defaults to false for security.
+	 *   WARNING: Only enable this when your application sits behind a trusted reverse proxy (e.g. nginx,
+	 *   HAProxy, AWS ALB) that strips or overwrites the X-Forwarded-For header from downstream clients.
+	 *   Without a proxy that sanitizes this header, any client can spoof arbitrary IPs to bypass rate
+	 *   limiting entirely. Your proxy MUST be configured to either: (a) drop incoming X-Forwarded-For and
+	 *   set it to the real client IP, or (b) append the client IP so the rightmost entry is trustworthy.
+	 *   If your proxy appends, set proxyStrategy="last" to use the rightmost (proxy-added) IP.
+	 * @proxyStrategy Which IP to extract from X-Forwarded-For: "first" (leftmost, client-supplied — default
+	 *   for backwards compatibility) or "last" (rightmost, added by the nearest trusted proxy — recommended
+	 *   when the proxy appends rather than overwrites the header).
+	 * @maxStoreSize Maximum number of entries allowed in the in-memory store. When exceeded during cleanup,
+	 *   the oldest entries are evicted. Prevents unbounded memory growth from attackers rotating client keys.
+	 *   Only applies when storage="memory". Default: 100000.
 	 */
 	public RateLimiter function init(
 		numeric maxRequests = 60,
@@ -26,7 +38,9 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		string storage = "memory",
 		any keyFunction = "",
 		string headerPrefix = "X-RateLimit",
-		boolean trustProxy = false
+		boolean trustProxy = false,
+		string proxyStrategy = "first",
+		numeric maxStoreSize = 100000
 	) {
 		if (!ListFindNoCase("fixedWindow,slidingWindow,tokenBucket", arguments.strategy)) {
 			throw(
@@ -42,6 +56,13 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 			);
 		}
 
+		if (!ListFindNoCase("first,last", arguments.proxyStrategy)) {
+			throw(
+				type = "Wheels.RateLimiter.InvalidProxyStrategy",
+				message = "Invalid proxy strategy: #arguments.proxyStrategy#. Must be first or last."
+			);
+		}
+
 		variables.maxRequests = arguments.maxRequests;
 		variables.windowSeconds = arguments.windowSeconds;
 		variables.strategy = arguments.strategy;
@@ -49,6 +70,8 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		variables.keyFunction = arguments.keyFunction;
 		variables.headerPrefix = arguments.headerPrefix;
 		variables.trustProxy = arguments.trustProxy;
+		variables.proxyStrategy = arguments.proxyStrategy;
+		variables.maxStoreSize = arguments.maxStoreSize;
 
 		// In-memory store using ConcurrentHashMap for thread safety.
 		if (variables.storage == "memory") {
@@ -74,6 +97,10 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		// Periodic cleanup for memory storage.
 		if (variables.storage == "memory") {
 			$maybeCleanup(local.now);
+			// Emergency eviction if store is at capacity and this is a new key.
+			if (variables.store.size() >= variables.maxStoreSize && !variables.store.containsKey(local.clientKey)) {
+				$evictOldest(local.now);
+			}
 		}
 
 		// Check rate limit based on strategy.
@@ -143,6 +170,9 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 					local.forwarded = cgi.http_x_forwarded_for;
 				}
 				if (Len(Trim(local.forwarded))) {
+					if (variables.proxyStrategy == "last") {
+						return Trim(ListLast(local.forwarded));
+					}
 					return Trim(ListFirst(local.forwarded));
 				}
 			} catch (any e) {
@@ -374,9 +404,69 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 				for (local.key in local.keysToRemove) {
 					variables.store.remove(local.key);
 				}
+
+				// If store still exceeds maxStoreSize after expiry cleanup, evict oldest entries.
+				if (variables.store.size() > variables.maxStoreSize) {
+					$evictOldest(arguments.now);
+				}
 			}
 		} catch (any e) {
 			// Lock timeout or error — skip cleanup this time.
+		}
+	}
+
+	/**
+	 * Evict entries from the in-memory store when it exceeds maxStoreSize.
+	 * Scores each entry by age and removes the oldest 10% to create headroom.
+	 * Entries whose age cannot be determined score 0 (youngest) and are evicted last.
+	 */
+	private void function $evictOldest(required numeric now) {
+		try {
+			local.keys = variables.store.keySet().toArray();
+			local.storeSize = ArrayLen(local.keys);
+			local.targetSize = Int(variables.maxStoreSize * 0.9);
+			local.toEvict = local.storeSize - local.targetSize;
+
+			if (local.toEvict <= 0) {
+				return;
+			}
+
+			// Build an array of {key, age} for sorting.
+			local.entries = [];
+			local.currentWindowId = Int(arguments.now / variables.windowSeconds);
+			for (local.key in local.keys) {
+				local.age = 0;
+				if (variables.store.containsKey(local.key)) {
+					local.value = variables.store.get(local.key);
+
+					if (variables.strategy == "fixedWindow" && Find(":", local.key)) {
+						local.windowId = Val(ListLast(local.key, ":"));
+						local.age = local.currentWindowId - local.windowId;
+					} else if (variables.strategy == "slidingWindow" && IsArray(local.value) && ArrayLen(local.value) > 0) {
+						local.age = arguments.now - local.value[1];
+					} else if (variables.strategy == "tokenBucket" && IsStruct(local.value) && StructKeyExists(local.value, "lastRefill")) {
+						local.age = arguments.now - local.value.lastRefill;
+					}
+				}
+				ArrayAppend(local.entries, {key: local.key, age: local.age});
+			}
+
+			// Sort by age descending (oldest first).
+			ArraySort(local.entries, function(a, b) {
+				return (b.age < a.age) ? -1 : ((b.age > a.age) ? 1 : 0);
+			});
+
+			// Evict the oldest entries.
+			local.evicted = 0;
+			for (local.entry in local.entries) {
+				if (local.evicted >= local.toEvict) {
+					break;
+				}
+				variables.store.remove(local.entry.key);
+				local.evicted++;
+			}
+		} catch (any e) {
+			// Best-effort eviction — don't let errors propagate.
 		}
 	}
 

--- a/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
+++ b/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
@@ -1,6 +1,6 @@
 /**
- * Tests for RateLimiter middleware, specifically covering the trustProxy setting
- * and its effect on client IP resolution for rate limiting.
+ * Tests for RateLimiter middleware covering trustProxy, proxyStrategy,
+ * and maxStoreSize parameters.
  */
 component extends="wheels.WheelsTest" {
 
@@ -164,6 +164,185 @@ component extends="wheels.WheelsTest" {
 				// Both should pass because they have different remoteAddr keys.
 				expect(result1).toBe("ok");
 				expect(result2).toBe("ok");
+			});
+
+		});
+
+		describe("RateLimiter proxyStrategy", function() {
+
+			it("defaults to first IP in X-Forwarded-For chain", function() {
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 1,
+					windowSeconds = 60,
+					trustProxy = true,
+					proxyStrategy = "first"
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				// "1.1.1.1, 10.0.0.1" — first strategy picks 1.1.1.1
+				var req1 = {
+					cgi: {
+						remote_addr: "10.0.0.50",
+						http_x_forwarded_for: "1.1.1.1, 10.0.0.1"
+					}
+				};
+				var req2 = {
+					cgi: {
+						remote_addr: "10.0.0.50",
+						http_x_forwarded_for: "1.1.1.1, 10.0.0.2"
+					}
+				};
+
+				var result1 = limiter.handle(request = req1, next = nextFn);
+				var result2 = limiter.handle(request = req2, next = nextFn);
+
+				// Both keyed to "1.1.1.1" so second is blocked.
+				expect(result1).toBe("ok");
+				expect(result2).toInclude("Rate limit exceeded");
+			});
+
+			it("uses last IP in X-Forwarded-For chain when proxyStrategy is last", function() {
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 1,
+					windowSeconds = 60,
+					trustProxy = true,
+					proxyStrategy = "last"
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				// "1.1.1.1, 10.0.0.1" — last strategy picks 10.0.0.1
+				var req1 = {
+					cgi: {
+						remote_addr: "10.0.0.50",
+						http_x_forwarded_for: "1.1.1.1, 10.0.0.1"
+					}
+				};
+				// "2.2.2.2, 10.0.0.1" — last strategy still picks 10.0.0.1
+				var req2 = {
+					cgi: {
+						remote_addr: "10.0.0.50",
+						http_x_forwarded_for: "2.2.2.2, 10.0.0.1"
+					}
+				};
+
+				var result1 = limiter.handle(request = req1, next = nextFn);
+				var result2 = limiter.handle(request = req2, next = nextFn);
+
+				// Both keyed to "10.0.0.1" so second is blocked.
+				expect(result1).toBe("ok");
+				expect(result2).toInclude("Rate limit exceeded");
+			});
+
+			it("last strategy prevents spoofed first-IP bypass", function() {
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 2,
+					windowSeconds = 60,
+					trustProxy = true,
+					proxyStrategy = "last"
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				// Attacker rotates the first (spoofed) IP but proxy always appends real IP.
+				var req1 = {
+					cgi: {
+						remote_addr: "10.0.0.50",
+						http_x_forwarded_for: "fake-1.1.1.1, 192.168.1.100"
+					}
+				};
+				var req2 = {
+					cgi: {
+						remote_addr: "10.0.0.50",
+						http_x_forwarded_for: "fake-2.2.2.2, 192.168.1.100"
+					}
+				};
+				var req3 = {
+					cgi: {
+						remote_addr: "10.0.0.50",
+						http_x_forwarded_for: "fake-3.3.3.3, 192.168.1.100"
+					}
+				};
+
+				var result1 = limiter.handle(request = req1, next = nextFn);
+				var result2 = limiter.handle(request = req2, next = nextFn);
+				var result3 = limiter.handle(request = req3, next = nextFn);
+
+				// All keyed to "192.168.1.100" — third request blocked.
+				expect(result1).toBe("ok");
+				expect(result2).toBe("ok");
+				expect(result3).toInclude("Rate limit exceeded");
+			});
+
+			it("throws on invalid proxyStrategy", function() {
+				expect(function() {
+					new wheels.middleware.RateLimiter(proxyStrategy = "middle");
+				}).toThrow("Wheels.RateLimiter.InvalidProxyStrategy");
+			});
+
+		});
+
+		describe("RateLimiter maxStoreSize", function() {
+
+			it("defaults maxStoreSize to 100000", function() {
+				var limiter = new wheels.middleware.RateLimiter();
+				// Should construct without error.
+				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+			});
+
+			it("accepts custom maxStoreSize", function() {
+				var limiter = new wheels.middleware.RateLimiter(maxStoreSize = 500);
+				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+			});
+
+			it("evicts entries when store exceeds maxStoreSize", function() {
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 1000,
+					windowSeconds = 60,
+					strategy = "fixedWindow",
+					maxStoreSize = 5
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				// Send requests from 10 unique IPs to exceed the store size of 5.
+				for (var i = 1; i <= 10; i++) {
+					var req = {remoteAddr: "client-evict-#i#"};
+					limiter.handle(request = req, next = nextFn);
+				}
+
+				// The limiter should still function correctly (not error out).
+				var finalReq = {remoteAddr: "client-evict-final"};
+				var result = limiter.handle(request = finalReq, next = nextFn);
+				expect(result).toBe("ok");
+			});
+
+			it("still rate limits correctly after eviction", function() {
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 2,
+					windowSeconds = 60,
+					strategy = "fixedWindow",
+					maxStoreSize = 5
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				// Fill store with unique clients.
+				for (var i = 1; i <= 4; i++) {
+					var req = {remoteAddr: "filler-#i#"};
+					limiter.handle(request = req, next = nextFn);
+				}
+
+				// Now test that rate limiting still works for a specific client.
+				var testReq = {remoteAddr: "test-client-rl"};
+				var r1 = limiter.handle(request = testReq, next = nextFn);
+				var r2 = limiter.handle(request = testReq, next = nextFn);
+				var r3 = limiter.handle(request = testReq, next = nextFn);
+
+				expect(r1).toBe("ok");
+				expect(r2).toBe("ok");
+				expect(r3).toInclude("Rate limit exceeded");
 			});
 
 		});


### PR DESCRIPTION
## Summary
- Adds `maxStoreSize` parameter (default 100,000) with LRU-like eviction to prevent unbounded memory growth
- Adds `proxyStrategy` parameter (`"first"` default, `"last"` recommended) for X-Forwarded-For IP selection
- Adds JSDoc warnings about `trustProxy` security implications
- 183+ lines of new test coverage for eviction, proxy strategies, and edge cases

## Test plan
- [ ] Verify `RateLimiterSpec` passes on Lucee 6 + SQLite
- [ ] Verify rate limiting still works with default settings
- [ ] Verify memory store doesn't grow past maxStoreSize under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)