### PR TITLE
fix: sanitize prependToPage in paginationLinks to prevent XSS

### DIFF
--- a/vendor/wheels/tests/specs/view/linksSpec.cfc
+++ b/vendor/wheels/tests/specs/view/linksSpec.cfc
@@ -119,6 +119,59 @@ component extends="wheels.WheelsTest" {
 
 				expect(result).toInclude("<li class='active page-item'>")
 			})
+
+			it("strips event handler XSS from prependToPage when adding active class", () => {
+				authors = g.model("author").findAll(page = 2, perPage = 3, order = "lastName")
+				result = _controller.paginationLinks(
+					prepend                         = "<ul>",
+					append                          = "</ul>",
+					prependToPage                   = '<li class="page-item" onmouseover="alert(1)">',
+					appendToPage                    = "</li>",
+					addActiveClassToPrependedParent = true,
+					linkToCurrentPage               = true,
+					encode                          = "attributes",
+					class                           = "page-link"
+				)
+
+				expect(result).notToInclude("onmouseover")
+				expect(result).notToInclude("alert(1)")
+				expect(result).toInclude('class="active page-item"')
+			})
+
+			it("strips javascript URI XSS from prependToPage when adding active class", () => {
+				authors = g.model("author").findAll(page = 2, perPage = 3, order = "lastName")
+				result = _controller.paginationLinks(
+					prepend                         = "<ul>",
+					append                          = "</ul>",
+					prependToPage                   = '<li class="page-item" style="background:url(javascript:alert(1))">',
+					appendToPage                    = "</li>",
+					addActiveClassToPrependedParent = true,
+					linkToCurrentPage               = true,
+					encode                          = "attributes",
+					class                           = "page-link"
+				)
+
+				expect(result).notToInclude("javascript:")
+				expect(result).toInclude('class="active page-item"')
+			})
+
+			it("strips onclick XSS from prependToPage when adding active class", () => {
+				authors = g.model("author").findAll(page = 2, perPage = 3, order = "lastName")
+				result = _controller.paginationLinks(
+					prepend                         = "<ul>",
+					append                          = "</ul>",
+					prependToPage                   = "<li class='page-item' onclick='alert(document.cookie)'>",
+					appendToPage                    = "</li>",
+					addActiveClassToPrependedParent = true,
+					linkToCurrentPage               = true,
+					encode                          = "attributes",
+					class                           = "page-link"
+				)
+
+				expect(result).notToInclude("onclick")
+				expect(result).notToInclude("alert(document.cookie)")
+				expect(result).toInclude("class='active page-item'")
+			})
 		})
 	}
 

--- a/vendor/wheels/view/links.cfc
+++ b/vendor/wheels/view/links.cfc
@@ -348,17 +348,27 @@ component {
 							The changes made here set the active class to the immediate parent of the current page element in case nested elements are passed in.
 						 */
 						if(local.currentPage == local.i  && arguments.addActiveClassToPrependedParent && findNoCase('class', arguments.prependToPage)) {
-							local.prependToPageElementArr = listToArray(arguments.prependToPage, '<');
-							local.lastElementArrIndex = arrayLen(local.prependToPageElementArr);
-							local.lastElement = local.prependToPageElementArr[local.lastElementArrIndex];
-							local.classStringIndex = findNoCase('class=', local.lastElement) + 6;
-							local.startString = mid(local.lastElement, 1, local.classStringIndex);
-							local.midString = mid(local.lastElement, local.classStringIndex+1, len(local.lastElement)-local.classStringIndex+1);
-							local.activeMidString = 'active ' & local.midString;
-							local.modifiedLastElement = local.startString & local.activeMidString;
-							local.prependToPageElementArr[local.lastElementArrIndex] = local.modifiedLastElement;
-							local.activePrependToPage = arrayToList(local.prependToPageElementArr, '<');
-							local.activePrependToPage = '<' & local.activePrependToPage;
+							// Strip event handlers (on*=) and javascript: URIs to prevent XSS
+							local.sanitizedPrepend = reReplaceNoCase(arguments.prependToPage, '\s+on\w+\s*=\s*([''"])[^''"]*\1', '', 'all');
+							local.sanitizedPrepend = reReplaceNoCase(local.sanitizedPrepend, '\s+on\w+\s*=\s*[^\s>]+', '', 'all');
+							local.sanitizedPrepend = reReplaceNoCase(local.sanitizedPrepend, 'javascript\s*:', '', 'all');
+
+							// Inject "active " into the class attribute value via regex
+							if (reFindNoCase('class\s*=\s*[''"]', local.sanitizedPrepend)) {
+								local.activePrependToPage = reReplaceNoCase(
+									local.sanitizedPrepend,
+									'(class\s*=\s*[''"])',
+									'\1active ',
+									'one'
+								);
+							} else {
+								local.activePrependToPage = reReplaceNoCase(
+									local.sanitizedPrepend,
+									'(class\s*=\s*)',
+									'\1active ',
+									'one'
+								);
+							}
 							local.middle &= local.activePrependToPage;
 						} else {
 							local.middle &= arguments.prependToPage;


### PR DESCRIPTION
## Summary
- **Security fix**: The `paginationLinks()` active class injection performed raw string manipulation on `prependToPage`, allowing event handlers (`onmouseover`, `onclick`, etc.) and `javascript:` URIs to pass through unescaped into HTML output.
- Replaced the fragile `listToArray`/`mid`/string-concat approach with regex-based class attribute injection, preceded by stripping `on*=` event handler attributes and `javascript:` URIs.
- Added 3 test cases covering `onmouseover`, `onclick`, and `javascript:` URI injection vectors.

## Test plan
- [ ] Existing "adds active class to parent element" test still passes (regression)
- [ ] New "strips event handler XSS" test verifies `onmouseover` is stripped
- [ ] New "strips javascript URI XSS" test verifies `javascript:` is stripped  
- [ ] New "strips onclick XSS" test verifies `onclick` is stripped
- [ ] Manual: pass `<li class="page-item" onfocus="alert(1)">` to `prependToPage` with `addActiveClassToPrependedParent=true` and verify sanitized output

🤖 Generated with [Claude Code](https://claude.com/claude-code)