### PR TITLE
fix(security): sanitize scope handler arguments to prevent SQL injection

### DIFF
--- a/vendor/wheels/model/onmissingmethod.cfc
+++ b/vendor/wheels/model/onmissingmethod.cfc
@@ -15,7 +15,8 @@ component {
 		) {
 			local.scopeDef = variables.wheels.class.scopes[arguments.missingMethodName];
 			if (StructKeyExists(local.scopeDef, "handler") && Len(local.scopeDef.handler)) {
-				local.spec = $invoke(method = local.scopeDef.handler, invokeArgs = arguments.missingMethodArguments);
+				local.sanitizedArgs = $sanitizeScopeHandlerArgs(arguments.missingMethodArguments);
+				local.spec = $invoke(method = local.scopeDef.handler, invokeArgs = local.sanitizedArgs);
 			} else {
 				local.spec = Duplicate(local.scopeDef);
 			}

--- a/vendor/wheels/model/properties.cfc
+++ b/vendor/wheels/model/properties.cfc
@@ -709,6 +709,27 @@ component {
 	}
 
 	/**
+	 * Sanitizes arguments before they are passed to a scope handler function.
+	 * Escapes single quotes in all string argument values so that handlers using
+	 * string interpolation (e.g. `"lastname = '#arguments.name#'"`) produce safe SQL.
+	 * This matches the escaping pattern used for enum-generated scopes in `enum()`.
+	 *
+	 * @args The struct of arguments to sanitize (typically missingMethodArguments).
+	 */
+	public struct function $sanitizeScopeHandlerArgs(required struct args) {
+		local.sanitized = {};
+		for (local.key in arguments.args) {
+			local.val = arguments.args[local.key];
+			if (IsSimpleValue(local.val) && Find("'", local.val)) {
+				local.sanitized[local.key] = Replace(local.val, "'", "''", "all");
+			} else {
+				local.sanitized[local.key] = local.val;
+			}
+		}
+		return local.sanitized;
+	}
+
+	/**
 	 * Returns a struct containing all callback definitions for this model, keyed by callback type
 	 * (e.g., `beforeSave`, `afterCreate`). Each callback type contains an array of callback method names.
 	 *

--- a/vendor/wheels/model/query/ScopeChain.cfc
+++ b/vendor/wheels/model/query/ScopeChain.cfc
@@ -196,9 +196,10 @@ component output="false" {
 
 			// If the scope has a handler, call it to get dynamic spec
 			if (StructKeyExists(local.scopeDef, "handler") && Len(local.scopeDef.handler)) {
+				local.sanitizedArgs = variables.modelReference.$sanitizeScopeHandlerArgs(arguments.missingMethodArguments);
 				local.spec = variables.modelReference.$invoke(
 					method = local.scopeDef.handler,
-					invokeArgs = arguments.missingMethodArguments
+					invokeArgs = local.sanitizedArgs
 				);
 			} else {
 				local.spec = Duplicate(local.scopeDef);

--- a/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
+++ b/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
@@ -2,91 +2,92 @@ component extends="wheels.WheelsTest" {
 
 	function run() {
 
-		g = application.wo
-
 		describe("Tests that scope handler arguments are sanitized against SQL injection", () => {
 
 			it("escapes single quotes in string arguments", () => {
-				var m = g.model("author")
-				var result = m.$sanitizeScopeHandlerArgs({"1": "O'Brien"})
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "O'Brien"});
 
-				expect(result["1"]).toBe("O''Brien")
-			})
+				expect(result["1"]).toBe("O''Brien");
+			});
 
 			it("escapes SQL injection attempt in arguments", () => {
-				var m = g.model("author")
-				var result = m.$sanitizeScopeHandlerArgs({"1": "Djurner' OR '1'='1"})
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "Djurner' OR '1'='1"});
 
-				expect(result["1"]).toBe("Djurner'' OR ''1''=''1")
-			})
+				expect(result["1"]).toBe("Djurner'' OR ''1''=''1");
+			});
 
 			it("escapes DROP TABLE injection in arguments", () => {
-				var m = g.model("author")
-				var result = m.$sanitizeScopeHandlerArgs({"1": "'; DROP TABLE users; --"})
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "'; DROP TABLE users; --"});
 
-				expect(result["1"]).toBe("''; DROP TABLE users; --")
-			})
+				expect(result["1"]).toBe("''; DROP TABLE users; --");
+			});
 
 			it("leaves clean string arguments unchanged", () => {
-				var m = g.model("author")
-				var result = m.$sanitizeScopeHandlerArgs({"1": "Djurner"})
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "Djurner"});
 
-				expect(result["1"]).toBe("Djurner")
-			})
+				expect(result["1"]).toBe("Djurner");
+			});
 
 			it("handles multiple arguments", () => {
-				var m = g.model("author")
-				var result = m.$sanitizeScopeHandlerArgs({"1": "O'Brien", "2": "It's"})
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "O'Brien", "2": "It's"});
 
-				expect(result["1"]).toBe("O''Brien")
-				expect(result["2"]).toBe("It''s")
-			})
+				expect(result["1"]).toBe("O''Brien");
+				expect(result["2"]).toBe("It''s");
+			});
 
 			it("preserves numeric arguments", () => {
-				var m = g.model("author")
-				var result = m.$sanitizeScopeHandlerArgs({"1": 42})
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": 42});
 
-				expect(result["1"]).toBe(42)
-			})
+				expect(result["1"]).toBe(42);
+			});
 
 			it("preserves boolean arguments", () => {
-				var m = g.model("author")
-				var result = m.$sanitizeScopeHandlerArgs({"1": true})
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": true});
 
-				expect(result["1"]).toBeTrue()
-			})
+				expect(result["1"]).toBeTrue();
+			});
 
 			it("preserves struct arguments without modification", () => {
-				var m = g.model("author")
-				var inner = {foo: "bar'baz"}
-				var result = m.$sanitizeScopeHandlerArgs({"1": inner})
+				var m = application.wo.model("author");
+				var inner = {foo: "bar'baz"};
+				var result = m.$sanitizeScopeHandlerArgs({"1": inner});
 
-				expect(result["1"]).toBeStruct()
-				expect(result["1"].foo).toBe("bar'baz")
-			})
+				expect(result["1"]).toBeStruct();
+				expect(result["1"].foo).toBe("bar'baz");
+			});
 
 			it("preserves array arguments without modification", () => {
-				var m = g.model("author")
-				var arr = ["it's", "test"]
-				var result = m.$sanitizeScopeHandlerArgs({"1": arr})
+				var m = application.wo.model("author");
+				var arr = ["it's", "test"];
+				var result = m.$sanitizeScopeHandlerArgs({"1": arr});
 
-				expect(result["1"]).toBeArray()
-			})
+				expect(result["1"]).toBeArray();
+			});
 
 			it("handles empty arguments struct", () => {
-				var m = g.model("author")
-				var result = m.$sanitizeScopeHandlerArgs({})
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({});
 
-				expect(result).toBeStruct()
-				expect(structIsEmpty(result)).toBeTrue()
-			})
+				expect(result).toBeStruct();
+				expect(structIsEmpty(result)).toBeTrue();
+			});
 
 			it("handles empty string arguments", () => {
-				var m = g.model("author")
-				var result = m.$sanitizeScopeHandlerArgs({"1": ""})
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": ""});
 
-				expect(result["1"]).toBe("")
-			})
-		})
+				expect(result["1"]).toBe("");
+			});
+
+		});
+
 	}
+
 }

--- a/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
+++ b/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
@@ -1,0 +1,92 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("Tests that scope handler arguments are sanitized against SQL injection", () => {
+
+			it("escapes single quotes in string arguments", () => {
+				var m = g.model("author")
+				var result = m.$sanitizeScopeHandlerArgs({"1": "O'Brien"})
+
+				expect(result["1"]).toBe("O''Brien")
+			})
+
+			it("escapes SQL injection attempt in arguments", () => {
+				var m = g.model("author")
+				var result = m.$sanitizeScopeHandlerArgs({"1": "Djurner' OR '1'='1"})
+
+				expect(result["1"]).toBe("Djurner'' OR ''1''=''1")
+			})
+
+			it("escapes DROP TABLE injection in arguments", () => {
+				var m = g.model("author")
+				var result = m.$sanitizeScopeHandlerArgs({"1": "'; DROP TABLE users; --"})
+
+				expect(result["1"]).toBe("''; DROP TABLE users; --")
+			})
+
+			it("leaves clean string arguments unchanged", () => {
+				var m = g.model("author")
+				var result = m.$sanitizeScopeHandlerArgs({"1": "Djurner"})
+
+				expect(result["1"]).toBe("Djurner")
+			})
+
+			it("handles multiple arguments", () => {
+				var m = g.model("author")
+				var result = m.$sanitizeScopeHandlerArgs({"1": "O'Brien", "2": "It's"})
+
+				expect(result["1"]).toBe("O''Brien")
+				expect(result["2"]).toBe("It''s")
+			})
+
+			it("preserves numeric arguments", () => {
+				var m = g.model("author")
+				var result = m.$sanitizeScopeHandlerArgs({"1": 42})
+
+				expect(result["1"]).toBe(42)
+			})
+
+			it("preserves boolean arguments", () => {
+				var m = g.model("author")
+				var result = m.$sanitizeScopeHandlerArgs({"1": true})
+
+				expect(result["1"]).toBeTrue()
+			})
+
+			it("preserves struct arguments without modification", () => {
+				var m = g.model("author")
+				var inner = {foo: "bar'baz"}
+				var result = m.$sanitizeScopeHandlerArgs({"1": inner})
+
+				expect(result["1"]).toBeStruct()
+				expect(result["1"].foo).toBe("bar'baz")
+			})
+
+			it("preserves array arguments without modification", () => {
+				var m = g.model("author")
+				var arr = ["it's", "test"]
+				var result = m.$sanitizeScopeHandlerArgs({"1": arr})
+
+				expect(result["1"]).toBeArray()
+			})
+
+			it("handles empty arguments struct", () => {
+				var m = g.model("author")
+				var result = m.$sanitizeScopeHandlerArgs({})
+
+				expect(result).toBeStruct()
+				expect(structIsEmpty(result)).toBeTrue()
+			})
+
+			it("handles empty string arguments", () => {
+				var m = g.model("author")
+				var result = m.$sanitizeScopeHandlerArgs({"1": ""})
+
+				expect(result["1"]).toBe("")
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `$sanitizeScopeHandlerArgs()` to escape single quotes in arguments before they reach scope handlers
- Applied in both `ScopeChain.cfc` and `onmissingmethod.cfc` (the two call sites for scope handlers)
- Matches the existing defense pattern used for enum-generated scopes in `properties.cfc`
- New test spec covers injection payloads, multiple quotes, non-string values, and empty args

## Test plan
- [ ] Verify `scopeHandlerSanitizationSpec` passes on Lucee 6 + SQLite
- [ ] Verify existing scope tests still pass
- [ ] Verify dynamic scopes with legitimate string arguments still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)