### PR TITLE
fix(security): parameterize SQL in geography property detection

### DIFF
--- a/vendor/wheels/model/miscellaneous.cfc
+++ b/vendor/wheels/model/miscellaneous.cfc
@@ -301,8 +301,8 @@ component {
 		}
 		
 		if(local.rv.datatype eq 'geography'){
-			local.sqlQuery = "select type from geography_columns where f_table_name = '#tableName()#' and f_geography_column = '#arguments.property#'";
-			local.result = queryExecute(local.sqlQuery,[],{datasource: "#variables.wheels.class.datasource#"});
+			local.sqlQuery = "select type from geography_columns where f_table_name = ? and f_geography_column = ?";
+			local.result = queryExecute(local.sqlQuery, [tableName(), arguments.property], {datasource: variables.wheels.class.datasource});
 			if(local.result.type eq 'point'){
 				local.rv.value = 'POINT(#this[arguments.property]#)';
 			}


### PR DESCRIPTION
## Summary
- Parameterize the `queryExecute` call in `$propertyValue()` (`vendor/wheels/model/miscellaneous.cfc` line 304) to prevent SQL injection via `arguments.property` and `tableName()` values
- Replace string interpolation (`'#tableName()#'`, `'#arguments.property#'`) with positional `?` parameters
- Remove unnecessary string interpolation on `variables.wheels.class.datasource`

## Test plan
- [ ] CI passes on all engines (Lucee 5/6/7, Adobe 2018-2025, BoxLang) with SQLite
- [ ] Verify geography column detection still works on PostGIS databases (the `geography_columns` system table is PostGIS-specific, so SQLite tests won't exercise this path directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)