### PR TITLE
fix(security): harden scope handler sanitization against bypass attacks

### DIFF
--- a/vendor/wheels/model/properties.cfc
+++ b/vendor/wheels/model/properties.cfc
@@ -709,10 +709,12 @@ component {
 	}
 
 	/**
-	 * Sanitizes arguments before they are passed to a scope handler function.
-	 * Escapes single quotes in all string argument values so that handlers using
-	 * string interpolation (e.g. `"lastname = '#arguments.name#'"`) produce safe SQL.
-	 * This matches the escaping pattern used for enum-generated scopes in `enum()`.
+	 * Sanitizes arguments passed to dynamic scope handler functions so that
+	 * string interpolation in WHERE clauses is safe against SQL injection.
+	 *
+	 * WARNING: For best security, scope handlers should use parameterized queries
+	 * rather than string interpolation. This sanitization is a safety net, not a
+	 * replacement for proper parameterization.
 	 *
 	 * @args The struct of arguments to sanitize (typically missingMethodArguments).
 	 */
@@ -720,8 +722,14 @@ component {
 		local.sanitized = {};
 		for (local.key in arguments.args) {
 			local.val = arguments.args[local.key];
-			if (IsSimpleValue(local.val) && Find("'", local.val)) {
-				local.sanitized[local.key] = Replace(local.val, "'", "''", "all");
+			if (IsSimpleValue(local.val)) {
+				// Strip null bytes (can terminate strings in some DB drivers)
+				local.val = Replace(local.val, Chr(0), "", "all");
+				// Escape backslashes (must be before single-quote escaping)
+				local.val = Replace(local.val, "\", "\\", "all");
+				// Escape single quotes (SQL standard doubling)
+				local.val = Replace(local.val, "'", "''", "all");
+				local.sanitized[local.key] = local.val;
 			} else {
 				local.sanitized[local.key] = local.val;
 			}

--- a/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
+++ b/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
@@ -86,6 +86,35 @@ component extends="wheels.WheelsTest" {
 				expect(result["1"]).toBe("");
 			});
 
+			it("escapes backslashes in string arguments", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "test\path"});
+
+				expect(result["1"]).toBe("test\\path");
+			});
+
+			it("escapes backslash-quote bypass attempts", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "test\' OR 1=1 --"});
+
+				expect(result["1"]).toBe("test\\'' OR 1=1 --");
+			});
+
+			it("strips null bytes from string arguments", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "test" & Chr(0) & "injection"});
+
+				expect(result["1"]).toBe("testinjection");
+			});
+
+			it("handles combined backslash quote and null byte attacks", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": Chr(0) & "O\'Brien"});
+
+				expect(result["1"]).toBe("O\\''Brien");
+			});
+
+
 		});
 
 	}


### PR DESCRIPTION
## Summary
- Hardens `$sanitizeScopeHandlerArgs()` in `vendor/wheels/model/properties.cfc` against SQL injection bypass techniques
- Removes the `Find("'", ...)` gate so ALL simple string values are sanitized unconditionally
- Adds null byte stripping (`Chr(0)`) and backslash escaping (`\` -> `\\`) before single-quote doubling
- Updates doc comment with parameterized-query recommendation

## Changes
- **Null bytes**: Stripped first to prevent string termination in some DB drivers
- **Backslashes**: Escaped before single quotes to prevent `\'` bypass on MySQL/PostgreSQL
- **Single quotes**: Doubled (existing behavior, now unconditional)
- **Tests**: 4 new test cases covering backslash escaping, backslash-quote bypass, null byte stripping, and combined attacks

## Test plan
- [ ] Verify new tests pass on Lucee 6 with SQLite
- [ ] Verify new tests pass on Adobe CF 2025
- [ ] Verify existing scope handler tests still pass (no regressions)
- [ ] CI matrix covers all engine/DB combos

🤖 Generated with [Claude Code](https://claude.com/claude-code)