### PR TITLE
fix(security): prevent SQL injection via include param in UPDATE queries

### DIFF
--- a/vendor/wheels/model/sql.cfc
+++ b/vendor/wheels/model/sql.cfc
@@ -676,19 +676,20 @@ component {
 			useIndex = arguments.useIndex,
 			sql = local.tempSql
 		);
-		if(arguments.include != "" && ListFind('PostgreSQL,CockroachDB', local.migration.adapter.adapterName()) && structKeyExists(arguments, "sql")){
-			if(left(arguments.sql[1], 6) == 'UPDATE'){
-				ArrayAppend(arguments.sql, "FROM #arguments.include#");
-			}
-		}
-		else if(arguments.include != "" && ListFind('MicrosoftSQLServer', local.migration.adapter.adapterName()) && structKeyExists(arguments, "sql")){
-			if(left(arguments.sql[1], 6) == 'UPDATE'){
-				ArrayAppend(arguments.sql, "FROM #$quotedTableName()#");
-			}
-		}
-		else if(arguments.include != "" && ListFind('H2,Oracle,SQLite', local.migration.adapter.adapterName()) && structKeyExists(arguments, "sql")){
-			if(left(arguments.sql[1], 6) == 'UPDATE'){
-				ArrayAppend(arguments.sql, "WHERE EXISTS (SELECT 1 FROM #arguments.include#");
+		if(arguments.include != "" && structKeyExists(arguments, "sql") && left(arguments.sql[1], 6) == 'UPDATE'){
+			// Resolve include via $expandedAssociations to get safe table names (prevents SQL injection)
+			local.expandedAssociations = $expandedAssociations(include=arguments.include);
+			if(ArrayLen(local.expandedAssociations)){
+				local.resolvedTableName = variables.wheels.class.adapter.$quoteIdentifier(local.expandedAssociations[1].tableName);
+				if(ListFind('PostgreSQL,CockroachDB', local.migration.adapter.adapterName())){
+					ArrayAppend(arguments.sql, "FROM #local.resolvedTableName#");
+				}
+				else if(ListFind('MicrosoftSQLServer', local.migration.adapter.adapterName())){
+					ArrayAppend(arguments.sql, "FROM #$quotedTableName()#");
+				}
+				else if(ListFind('H2,Oracle,SQLite', local.migration.adapter.adapterName())){
+					ArrayAppend(arguments.sql, "WHERE EXISTS (SELECT 1 FROM #local.resolvedTableName#");
+				}
 			}
 		}
 		local.iEnd = ArrayLen(local.whereClause);


### PR DESCRIPTION
## Summary
- **CRITICAL**: The `$addWhereClause` function in `sql.cfc` directly interpolated the raw `arguments.include` string into SQL for PostgreSQL, CockroachDB, H2, Oracle, and SQLite UPDATE code paths (lines 681, 691)
- Fix resolves include names through `$expandedAssociations()` before interpolation, which validates against registered model associations and extracts safe table names from association metadata
- Invalid include names now throw `Wheels.AssociationNotFound` instead of being injected into SQL
- The MSSQL path was already safe (used `$quotedTableName()`); the MySQL path in `update.cfc` was already safe (used `$expandedAssociations` directly)

## Test plan
- [ ] Run full test suite on Lucee 6 + SQLite (`/wheels/core/tests?db=sqlite&format=json`)
- [ ] Run full test suite on Adobe 2025 + SQLite
- [ ] Verify UPDATE with valid `include` parameter still generates correct SQL for PostgreSQL/H2/SQLite paths
- [ ] Verify invalid `include` values throw `Wheels.AssociationNotFound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)