### PR TITLE
fix(security): harden rate limiter against per-key memory exhaustion

### DIFF
--- a/vendor/wheels/middleware/RateLimiter.cfc
+++ b/vendor/wheels/middleware/RateLimiter.cfc
@@ -30,6 +30,10 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	 * @maxStoreSize Maximum number of entries allowed in the in-memory store. When exceeded during cleanup,
 	 *   the oldest entries are evicted. Prevents unbounded memory growth from attackers rotating client keys.
 	 *   Only applies when storage="memory". Default: 100000.
+	 * @maxTimestampsPerKey Maximum number of timestamps stored per client key in the sliding window strategy.
+	 *   Prevents a single attacker from exhausting heap memory by making rapid requests. After pruning expired
+	 *   entries, arrays exceeding this limit are truncated to keep only the most recent timestamps.
+	 *   Default: maxRequests * 3. Only applies to the "slidingWindow" strategy with storage="memory".
 	 */
 	public RateLimiter function init(
 		numeric maxRequests = 60,
@@ -40,7 +44,8 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		string headerPrefix = "X-RateLimit",
 		boolean trustProxy = false,
 		string proxyStrategy = "first",
-		numeric maxStoreSize = 100000
+		numeric maxStoreSize = 100000,
+		numeric maxTimestampsPerKey = 0
 	) {
 		if (!ListFindNoCase("fixedWindow,slidingWindow,tokenBucket", arguments.strategy)) {
 			throw(
@@ -72,6 +77,7 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		variables.trustProxy = arguments.trustProxy;
 		variables.proxyStrategy = arguments.proxyStrategy;
 		variables.maxStoreSize = arguments.maxStoreSize;
+		variables.maxTimestampsPerKey = arguments.maxTimestampsPerKey > 0 ? arguments.maxTimestampsPerKey : arguments.maxRequests * 3;
 
 		// In-memory store using ConcurrentHashMap for thread safety.
 		if (variables.storage == "memory") {
@@ -267,6 +273,11 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 					}
 				}
 
+				// Cap per-key array size to prevent memory exhaustion from rapid requests.
+				if (ArrayLen(local.pruned) > variables.maxTimestampsPerKey) {
+					local.pruned = local.pruned.slice(ArrayLen(local.pruned) - variables.maxTimestampsPerKey + 1);
+				}
+
 				if (ArrayLen(local.pruned) >= variables.maxRequests) {
 					local.allowed = false;
 					local.remaining = 0;
@@ -417,23 +428,62 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 
 	/**
 	 * Evict entries from the in-memory store when it exceeds maxStoreSize.
-	 * Scores each entry by age and removes the oldest 10% to create headroom.
+	 * First removes fully expired entries, then evicts the oldest 25% to create headroom.
 	 * Entries whose age cannot be determined score 0 (youngest) and are evicted last.
 	 */
 	private void function $evictOldest(required numeric now) {
 		try {
 			local.keys = variables.store.keySet().toArray();
 			local.storeSize = ArrayLen(local.keys);
-			local.targetSize = Int(variables.maxStoreSize * 0.9);
+			local.targetSize = Int(variables.maxStoreSize * 0.75);
 			local.toEvict = local.storeSize - local.targetSize;
 
 			if (local.toEvict <= 0) {
 				return;
 			}
 
-			// Build an array of {key, age} for sorting.
-			local.entries = [];
+			// First pass: remove fully expired entries (cheap, no sorting needed).
 			local.currentWindowId = Int(arguments.now / variables.windowSeconds);
+			local.windowStart = arguments.now - variables.windowSeconds;
+			local.expiredCount = 0;
+			for (local.key in local.keys) {
+				if (local.expiredCount >= local.toEvict) {
+					break;
+				}
+				if (variables.store.containsKey(local.key)) {
+					local.value = variables.store.get(local.key);
+					local.isExpired = false;
+
+					if (variables.strategy == "fixedWindow" && Find(":", local.key)) {
+						local.windowId = Val(ListLast(local.key, ":"));
+						local.isExpired = local.windowId < local.currentWindowId;
+					} else if (variables.strategy == "slidingWindow" && IsArray(local.value)) {
+						if (ArrayLen(local.value) == 0) {
+							local.isExpired = true;
+						} else {
+							// Expired if newest timestamp is outside the window.
+							local.isExpired = local.value[ArrayLen(local.value)] <= local.windowStart;
+						}
+					} else if (variables.strategy == "tokenBucket" && IsStruct(local.value) && StructKeyExists(local.value, "tokens")) {
+						local.isExpired = local.value.tokens >= variables.maxRequests && (arguments.now - local.value.lastRefill) > variables.windowSeconds;
+					}
+
+					if (local.isExpired) {
+						variables.store.remove(local.key);
+						local.expiredCount++;
+					}
+				}
+			}
+
+			// If expired-entry removal was sufficient, skip the expensive sort.
+			if (local.expiredCount >= local.toEvict) {
+				return;
+			}
+
+			// Second pass: sort remaining entries by age and evict oldest.
+			local.remainingToEvict = local.toEvict - local.expiredCount;
+			local.keys = variables.store.keySet().toArray();
+			local.entries = [];
 			for (local.key in local.keys) {
 				local.age = 0;
 				if (variables.store.containsKey(local.key)) {
@@ -459,7 +509,7 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 			// Evict the oldest entries.
 			local.evicted = 0;
 			for (local.entry in local.entries) {
-				if (local.evicted >= local.toEvict) {
+				if (local.evicted >= local.remainingToEvict) {
 					break;
 				}
 				variables.store.remove(local.entry.key);

--- a/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
+++ b/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
@@ -347,6 +347,96 @@ component extends="wheels.WheelsTest" {
 
 		});
 
+		describe("RateLimiter maxTimestampsPerKey", function() {
+
+			it("defaults maxTimestampsPerKey to maxRequests * 3", function() {
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 10,
+					strategy = "slidingWindow"
+				);
+				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+			});
+
+			it("accepts custom maxTimestampsPerKey", function() {
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 10,
+					strategy = "slidingWindow",
+					maxTimestampsPerKey = 50
+				);
+				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+			});
+
+			it("caps sliding window timestamps per key", function() {
+				// Set maxRequests high so we never get blocked, but cap timestamps low.
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 1000,
+					windowSeconds = 60,
+					strategy = "slidingWindow",
+					maxTimestampsPerKey = 5
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				// Send 20 requests from the same client.
+				for (var i = 1; i <= 20; i++) {
+					var req = {remoteAddr: "flood-client"};
+					limiter.handle(request = req, next = nextFn);
+				}
+
+				// The limiter should still function correctly after capping.
+				var finalReq = {remoteAddr: "flood-client"};
+				var result = limiter.handle(request = finalReq, next = nextFn);
+				expect(result).toBe("ok");
+			});
+
+			it("still enforces rate limit with timestamp cap active", function() {
+				// maxRequests=3, maxTimestampsPerKey defaults to 9 (3*3).
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 3,
+					windowSeconds = 60,
+					strategy = "slidingWindow"
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				var r1 = limiter.handle(request = {remoteAddr: "cap-test"}, next = nextFn);
+				var r2 = limiter.handle(request = {remoteAddr: "cap-test"}, next = nextFn);
+				var r3 = limiter.handle(request = {remoteAddr: "cap-test"}, next = nextFn);
+				var r4 = limiter.handle(request = {remoteAddr: "cap-test"}, next = nextFn);
+
+				expect(r1).toBe("ok");
+				expect(r2).toBe("ok");
+				expect(r3).toBe("ok");
+				expect(r4).toInclude("Rate limit exceeded");
+			});
+
+		});
+
+		describe("RateLimiter eviction improvements", function() {
+
+			it("evicts 25 percent of entries creating more headroom", function() {
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 1000,
+					windowSeconds = 60,
+					strategy = "fixedWindow",
+					maxStoreSize = 4
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				// Fill store to capacity with unique clients.
+				for (var i = 1; i <= 8; i++) {
+					var req = {remoteAddr: "evict25-#i#"};
+					limiter.handle(request = req, next = nextFn);
+				}
+
+				// Should still work after eviction.
+				var result = limiter.handle(request = {remoteAddr: "evict25-final"}, next = nextFn);
+				expect(result).toBe("ok");
+			});
+
+		});
+
 	}
 
 }


### PR DESCRIPTION
## Summary
- Add `maxTimestampsPerKey` cap to sliding window strategy to prevent unbounded array growth from rapid requests by a single client
- Improve emergency eviction from 10% to 25% with two-pass expired-first strategy
- Add configurable `maxTimestampsPerKey` init parameter (default: `maxRequests * 3`)

## Test plan
- [ ] Verify sliding window still correctly rate-limits within normal usage
- [ ] Verify per-key array cap prevents memory exhaustion under rapid requests
- [ ] Run existing RateLimiterSpec tests pass
- [ ] Run full test suite on Lucee 6 + SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)