### PR TITLE
fix(security): prevent SSE newline injection in event fields and data

### DIFF
--- a/vendor/wheels/controller/sse.cfc
+++ b/vendor/wheels/controller/sse.cfc
@@ -116,7 +116,9 @@ component {
 	 * @comment Optional comment text.
 	 */
 	public void function sendSSEComment(required any writer, string comment = "ping") {
-		arguments.writer.write(": #arguments.comment##Chr(10)##Chr(10)#");
+		// Strip CR/LF to prevent field injection via comments
+		local.safeComment = ReReplace(arguments.comment, '[\r\n]', '', 'all');
+		arguments.writer.write(": #local.safeComment##Chr(10)##Chr(10)#");
 		arguments.writer.flush();
 	}
 
@@ -167,14 +169,14 @@ component {
 	) {
 		local.lines = [];
 
-		// Event ID
+		// Event ID (strip CR/LF to prevent field injection)
 		if (Len(arguments.id)) {
-			ArrayAppend(local.lines, "id: #arguments.id#");
+			ArrayAppend(local.lines, "id: #ReReplace(arguments.id, '[\r\n]', '', 'all')#");
 		}
 
-		// Event type
+		// Event type (strip CR/LF to prevent field injection)
 		if (Len(arguments.event)) {
-			ArrayAppend(local.lines, "event: #arguments.event#");
+			ArrayAppend(local.lines, "event: #ReReplace(arguments.event, '[\r\n]', '', 'all')#");
 		}
 
 		// Retry interval
@@ -183,8 +185,11 @@ component {
 		}
 
 		// Data lines (each line of data gets its own "data:" prefix per SSE spec)
+		// Normalize line endings: CRLF -> LF, then lone CR -> LF, before splitting
 		if (Len(arguments.data)) {
-			local.dataLines = ListToArray(arguments.data, Chr(10));
+			local.normalizedData = Replace(arguments.data, Chr(13) & Chr(10), Chr(10), "all");
+			local.normalizedData = Replace(local.normalizedData, Chr(13), Chr(10), "all");
+			local.dataLines = ListToArray(local.normalizedData, Chr(10));
 			for (local.line in local.dataLines) {
 				ArrayAppend(local.lines, "data: #local.line#");
 			}

--- a/vendor/wheels/tests/specs/controller/sseSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/sseSpec.cfc
@@ -130,5 +130,71 @@ component extends="wheels.WheelsTest" {
 				expect(local.result).toInclude("data: ");
 			});
 		});
+
+		describe("SSE Newline Injection Prevention", function() {
+
+			beforeEach(function() {
+				params = {controller = "dummy", action = "dummy"};
+				_controller = g.controller("dummy", params);
+			});
+
+			it("strips newlines from id field to prevent field injection", function() {
+				local.result = _controller.$formatSSEEvent(data = "test", id = "123" & Chr(10) & "event: malicious");
+				expect(local.result).toInclude("id: 123event: malicious");
+				// No line should start with "event:" — the injected text is harmlessly concatenated in the id value
+				local.lines = ListToArray(local.result, Chr(10));
+				for (local.line in local.lines) {
+					if (Left(Trim(local.line), 6) == "event:") {
+						fail("Injected event: field found on its own line");
+					}
+				}
+			});
+
+			it("strips carriage returns from id field", function() {
+				local.result = _controller.$formatSSEEvent(data = "test", id = "123" & Chr(13) & "event: malicious");
+				// CR stripped, so the id line contains the injected text harmlessly concatenated
+				expect(local.result).toInclude("id: 123event: malicious");
+				// No CR characters should remain in output
+				expect(local.result).notToInclude(Chr(13));
+			});
+
+			it("strips newlines from event field to prevent field injection", function() {
+				local.result = _controller.$formatSSEEvent(data = "test", event = "update" & Chr(10) & "id: spoofed");
+				expect(local.result).toInclude("event: updateid: spoofed");
+				// The injected id: should not be on its own line
+				local.lines = ListToArray(local.result, Chr(10));
+				for (local.line in local.lines) {
+					if (Left(local.line, 3) == "id:") {
+						fail("Injected id: field found on its own line");
+					}
+				}
+			});
+
+			it("strips carriage returns from event field", function() {
+				local.result = _controller.$formatSSEEvent(data = "test", event = "update" & Chr(13) & "data: injected");
+				expect(local.result).notToInclude(Chr(13));
+			});
+
+			it("normalizes CRLF in data to separate data lines", function() {
+				local.input = "line1" & Chr(13) & Chr(10) & "line2";
+				local.result = _controller.$formatSSEEvent(data = local.input);
+				expect(local.result).toInclude("data: line1");
+				expect(local.result).toInclude("data: line2");
+			});
+
+			it("normalizes lone CR in data to separate data lines", function() {
+				local.input = "line1" & Chr(13) & "line2";
+				local.result = _controller.$formatSSEEvent(data = local.input);
+				expect(local.result).toInclude("data: line1");
+				expect(local.result).toInclude("data: line2");
+			});
+
+			it("prevents CR-based field injection in data", function() {
+				local.input = "safe data" & Chr(13) & "event: malicious";
+				local.result = _controller.$formatSSEEvent(data = local.input);
+				// CR should be normalized to LF, so "event: malicious" becomes a data: line
+				expect(local.result).toInclude("data: event: malicious");
+			});
+		});
 	}
 }


### PR DESCRIPTION
## Summary
- Strip CR (`\r`) and LF (`\n`) characters from `id` and `event` SSE fields to prevent attackers from injecting fake SSE event fields via newline characters
- Normalize all line endings (CRLF, lone CR) to LF in `data` before splitting into `data:` lines, preventing CR-based field injection
- Sanitize `sendSSEComment()` comment text to strip CR/LF as well
- Add 7 new security tests covering newline injection vectors for id, event, and data fields

## Test plan
- [x] All 21 SSE tests pass on Lucee 6 (14 existing + 7 new)
- [x] 0 failures, 0 errors in full suite (2552 pass)
- [ ] CI matrix validates across all engines and databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)