### PR TITLE
fix(security): reject wildcard origin with credentials in CORS middleware

### DIFF
--- a/vendor/wheels/middleware/Cors.cfc
+++ b/vendor/wheels/middleware/Cors.cfc
@@ -23,6 +23,19 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		boolean allowCredentials = false,
 		numeric maxAge = 86400
 	) {
+		// The CORS spec forbids Access-Control-Allow-Origin: * with
+		// Access-Control-Allow-Credentials: true.  Browsers silently
+		// reject the response, which often leads developers to weaken
+		// security further.  Fail fast with a clear message instead.
+		if (arguments.allowOrigins == "*" && arguments.allowCredentials) {
+			Throw(
+				type    = "Wheels.Cors.InvalidConfiguration",
+				message = "CORS misconfiguration: allowOrigins=""*"" cannot be combined with allowCredentials=true. "
+					& "The CORS specification forbids this combination and browsers will reject the response. "
+					& "Either list specific origins (e.g. allowOrigins=""https://myapp.com"") or set allowCredentials=false."
+			);
+		}
+
 		variables.allowOrigins = arguments.allowOrigins;
 		variables.allowMethods = arguments.allowMethods;
 		variables.allowHeaders = arguments.allowHeaders;

--- a/vendor/wheels/tests/specs/middleware/CorsSpec.cfc
+++ b/vendor/wheels/tests/specs/middleware/CorsSpec.cfc
@@ -82,6 +82,56 @@ component extends="wheels.WheelsTest" {
 				expect(local.result).toBe("same-origin");
 			});
 
+			describe("wildcard + credentials validation", function() {
+
+				it("throws when allowOrigins is wildcard and allowCredentials is true", function() {
+					expect(function() {
+						new wheels.middleware.Cors(allowOrigins = "*", allowCredentials = true);
+					}).toThrow("Wheels.Cors.InvalidConfiguration");
+				});
+
+				it("includes a descriptive error message for the invalid combination", function() {
+					var caught = {};
+					try {
+						new wheels.middleware.Cors(allowOrigins = "*", allowCredentials = true);
+					} catch (any e) {
+						caught = e;
+					}
+					expect(caught).toHaveKey("message");
+					expect(caught.message).toInclude("allowOrigins");
+					expect(caught.message).toInclude("allowCredentials");
+					expect(caught.message).toInclude("CORS specification");
+				});
+
+				it("allows wildcard origin with allowCredentials false", function() {
+					local.cors = new wheels.middleware.Cors(allowOrigins = "*", allowCredentials = false);
+					local.reqCtx = {cgi = {http_origin = "https://any.com"}};
+					local.result = local.cors.handle(
+						request = local.reqCtx,
+						next = function(required struct request) {
+							return "ok";
+						}
+					);
+					expect(local.result).toBe("ok");
+				});
+
+				it("allows specific origins with allowCredentials true", function() {
+					local.cors = new wheels.middleware.Cors(
+						allowOrigins = "https://myapp.com",
+						allowCredentials = true
+					);
+					local.reqCtx = {cgi = {http_origin = "https://myapp.com"}};
+					local.result = local.cors.handle(
+						request = local.reqCtx,
+						next = function(required struct request) {
+							return "creds-ok";
+						}
+					);
+					expect(local.result).toBe("creds-ok");
+				});
+
+			});
+
 		});
 
 	}


### PR DESCRIPTION
## Summary
- Adds init-time validation to `Cors.cfc` that throws `Wheels.Cors.InvalidConfiguration` when `allowOrigins="*"` is combined with `allowCredentials=true`
- The CORS spec forbids this combination; browsers silently reject the response, which often leads developers to weaken security further
- Adds 4 test cases to `CorsSpec.cfc` verifying the validation and that valid configurations still work

## Test plan
- [x] Verified all 10 CORS tests pass on Lucee 6 (2539 pass, 0 CORS failures)
- [x] Verified all 10 CORS tests pass on Lucee 7 (2569 pass, 0 CORS failures)
- [ ] CI will run full matrix (all engines x databases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)