### PR TITLE
fix(security): auto-generate CSRF cookie encryption key when empty

### DIFF
--- a/vendor/wheels/controller/csrf.cfc
+++ b/vendor/wheels/controller/csrf.cfc
@@ -147,17 +147,34 @@ component {
 
 	/**
 	 * Internal function.
+	 * Ensures a valid CSRF cookie encryption key exists when csrfStore is "cookie".
+	 */
+	public string function $ensureCsrfCookieEncryptionKey() {
+		if (!Len(application.wheels.csrfCookieEncryptionSecretKey)) {
+			application.wheels.csrfCookieEncryptionSecretKey = GenerateSecretKey("AES");
+			writeLog(
+				text = "Wheels: csrfCookieEncryptionSecretKey was empty — auto-generated a temporary AES key. Set a persistent key via set(csrfCookieEncryptionSecretKey=""your-key"") in config/settings.cfm to prevent token invalidation on app restart.",
+				type = "warning",
+				file = "wheels_security"
+			);
+		}
+		return application.wheels.csrfCookieEncryptionSecretKey;
+	}
+
+	/**
+	 * Internal function.
 	 */
 	public string function $generateCookieAuthenticityToken() {
 		local.authenticityToken = $readAuthenticityTokenFromCookie();
 
 		// If cookie doesn't yet exist, create it.
 		if (!Len(local.authenticityToken)) {
+			local.encryptionKey = $ensureCsrfCookieEncryptionKey();
 			local.authenticityToken = GenerateSecretKey(application.wheels.csrfCookieEncryptionAlgorithm);
 			local.value = SerializeJSON({sessionId = CreateUUID(), authenticityToken = local.authenticityToken});
 			local.value = Encrypt(
 				local.value,
-				application.wheels.csrfCookieEncryptionSecretKey,
+				local.encryptionKey,
 				application.wheels.csrfCookieEncryptionAlgorithm,
 				application.wheels.csrfCookieEncryptionEncoding
 			);
@@ -189,9 +206,10 @@ component {
 		local.cookie = cookie[local.cookieName];
 
 		try {
+			local.encryptionKey = $ensureCsrfCookieEncryptionKey();
 			local.cookieAttrs = Decrypt(
 				local.cookie,
-				application.wheels.csrfCookieEncryptionSecretKey,
+				local.encryptionKey,
 				application.wheels.csrfCookieEncryptionAlgorithm,
 				application.wheels.csrfCookieEncryptionEncoding
 			);

--- a/vendor/wheels/tests/specs/security/CsrfCookieKeySpec.cfc
+++ b/vendor/wheels/tests/specs/security/CsrfCookieKeySpec.cfc
@@ -1,0 +1,75 @@
+/**
+ * Tests that CSRF cookie encryption key is auto-generated when empty.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("CSRF cookie encryption key auto-generation", function() {
+
+			beforeEach(function() {
+				$originalKey = application.wheels.csrfCookieEncryptionSecretKey;
+				$originalStore = application.wheels.csrfStore;
+			});
+
+			afterEach(function() {
+				application.wheels.csrfCookieEncryptionSecretKey = $originalKey;
+				application.wheels.csrfStore = $originalStore;
+			});
+
+			it("auto-generates a key when csrfStore is cookie and key is empty", function() {
+				application.wheels.csrfCookieEncryptionSecretKey = "";
+				application.wheels.csrfStore = "cookie";
+
+				var _controller = application.wo.controller("dummy");
+				var result = _controller.$ensureCsrfCookieEncryptionKey();
+
+				expect(Len(result)).toBeGT(0);
+				expect(Len(application.wheels.csrfCookieEncryptionSecretKey)).toBeGT(0);
+			});
+
+			it("generates a valid AES key that works for encryption", function() {
+				application.wheels.csrfCookieEncryptionSecretKey = "";
+				application.wheels.csrfStore = "cookie";
+
+				var _controller = application.wo.controller("dummy");
+				var result = _controller.$ensureCsrfCookieEncryptionKey();
+
+				// Key must be non-empty (length varies by engine: 128-bit=24 chars, 256-bit=44 chars).
+				expect(Len(result)).toBeGT(0);
+
+				// Verify the key actually works for encryption/decryption.
+				var plaintext = "test-csrf-token";
+				var encrypted = Encrypt(plaintext, result, "AES", "Base64");
+				var decrypted = Decrypt(encrypted, result, "AES", "Base64");
+				expect(decrypted).toBe(plaintext);
+			});
+
+			it("preserves an explicitly set key", function() {
+				var explicitKey = GenerateSecretKey("AES");
+				application.wheels.csrfCookieEncryptionSecretKey = explicitKey;
+				application.wheels.csrfStore = "cookie";
+
+				var _controller = application.wo.controller("dummy");
+				var result = _controller.$ensureCsrfCookieEncryptionKey();
+
+				expect(result).toBe(explicitKey);
+				expect(application.wheels.csrfCookieEncryptionSecretKey).toBe(explicitKey);
+			});
+
+			it("only generates the key once across multiple calls", function() {
+				application.wheels.csrfCookieEncryptionSecretKey = "";
+				application.wheels.csrfStore = "cookie";
+
+				var _controller = application.wo.controller("dummy");
+				var firstResult = _controller.$ensureCsrfCookieEncryptionKey();
+				var secondResult = _controller.$ensureCsrfCookieEncryptionKey();
+
+				expect(firstResult).toBe(secondResult);
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary
- When `csrfStore` is set to `"cookie"`, the `csrfCookieEncryptionSecretKey` defaults to an empty string, making CSRF token encryption ineffective and allowing token forgery
- Added `$ensureCsrfCookieEncryptionKey()` in `csrf.cfc` that auto-generates an AES key on first use when the configured key is empty
- Logs a warning to `wheels_security` recommending developers set a persistent key in `config/settings.cfm`
- The auto-generated key is ephemeral (lost on app restart, invalidating existing cookies), but strictly better than no encryption

## Test plan
- [x] New `CsrfCookieKeySpec.cfc` with 4 specs: auto-generation, key validity, explicit key preservation, idempotency
- [x] Verified on Lucee 6 (4/4 pass) and Adobe CF 2025 (4/4 pass)
- [x] Existing CSRF cookie tests unaffected (pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)