### PR TITLE
fix(security): prevent XSS pagination bypass via HTML entity encoding

### DIFF
--- a/vendor/wheels/tests/specs/security/PaginationXssSpec.cfc
+++ b/vendor/wheels/tests/specs/security/PaginationXssSpec.cfc
@@ -1,0 +1,88 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo;
+
+		describe("Pagination XSS entity-encoding bypass prevention", () => {
+
+			beforeEach(() => {
+				_params = {controller = "dummy", action = "dummy"};
+				_controller = g.controller("dummy", _params);
+				_originalRoutes = Duplicate(application.wheels.routes);
+				_originalRewrite = application.wheels.URLRewriting;
+				$clearRoutes();
+				g.mapper().$match(name = "pagination", pattern = "pag/ina/tion/[special]", to = "pagi##nation").end();
+				g.$setNamedRoutePositions();
+				application.wheels.URLRewriting = "On";
+				g.set(functionName = "linkTo", encode = false);
+				g.set(functionName = "paginationLinks", encode = false);
+			});
+
+			afterEach(() => {
+				application.wheels.routes = _originalRoutes;
+				application.wheels.URLRewriting = _originalRewrite;
+				g.set(functionName = "linkTo", encode = true);
+				g.set(functionName = "paginationLinks", encode = true);
+			});
+
+			it("strips decimal entity-encoded onmouseover handler", () => {
+				authors = g.model("author").findAll(page = 2, perPage = 3, order = "lastName");
+				// &#111; = 'o', so this decodes to <li onmouseover="alert(1)">
+				var result = _controller.paginationLinks(
+					prependToPage = '<li &#111;nmouseover="alert(1)">'
+				);
+				expect(result).notToInclude("onmouseover");
+				expect(result).notToInclude("alert");
+			});
+
+			it("strips hex entity-encoded onmouseover handler", () => {
+				authors = g.model("author").findAll(page = 2, perPage = 3, order = "lastName");
+				// &#x6F; = 'o', so this decodes to <li onmouseover="alert(1)">
+				var result = _controller.paginationLinks(
+					prependToPage = '<li &#x6F;nmouseover="alert(1)">'
+				);
+				expect(result).notToInclude("onmouseover");
+				expect(result).notToInclude("alert");
+			});
+
+			it("strips entity-encoded javascript URI", () => {
+				authors = g.model("author").findAll(page = 2, perPage = 3, order = "lastName");
+				// &#106; = 'j', so this decodes to javascript:alert(1)
+				var result = _controller.paginationLinks(
+					prependToPage = '<li><a href="&#106;avascript:alert(1)">'
+				);
+				expect(result).notToInclude("javascript");
+				expect(result).notToInclude("alert");
+			});
+
+			it("preserves normal HTML with class and id attributes", () => {
+				authors = g.model("author").findAll(page = 2, perPage = 3, order = "lastName");
+				var result = _controller.paginationLinks(
+					prependToPage = '<li class="page-item" id="nav">'
+				);
+				expect(result).toInclude('class="page-item"');
+				expect(result).toInclude('id="nav"');
+			});
+
+			it("still strips plain onmouseover without entity encoding", () => {
+				authors = g.model("author").findAll(page = 2, perPage = 3, order = "lastName");
+				var result = _controller.paginationLinks(
+					prependToPage = '<li onmouseover="alert(1)">'
+				);
+				expect(result).notToInclude("onmouseover");
+				expect(result).notToInclude("alert");
+			});
+
+			it("decodes mixed decimal and hex entities in $decodeHtmlEntities", () => {
+				// &#111; = 'o' (decimal), &#x6E; = 'n' (hex)
+				var input = "&#111;&#x6E;mouseover";
+				var result = _controller.$decodeHtmlEntities(input);
+				expect(result).toBe("onmouseover");
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/view/links.cfc
+++ b/vendor/wheels/view/links.cfc
@@ -313,6 +313,16 @@ component {
 					local.start &= arguments.anchorDivider;
 				}
 			}
+			// Sanitize prependToPage once before the loop (input doesn't change per iteration).
+			// First decode HTML numeric entities so that encoded payloads like &#111;nmouseover
+			// are normalised before the regex strips event handlers and javascript: URIs.
+			if (Len(arguments.prependToPage)) {
+				local.decodedPrepend = $decodeHtmlEntities(arguments.prependToPage);
+				local.sanitizedPrepend = reReplaceNoCase(local.decodedPrepend, '\s+on\w+\s*=\s*([''"])[^''"]*\1', '', 'all');
+				local.sanitizedPrepend = reReplaceNoCase(local.sanitizedPrepend, '\s+on\w+\s*=\s*[^\s>]+', '', 'all');
+				local.sanitizedPrepend = reReplaceNoCase(local.sanitizedPrepend, 'javascript\s*:', '', 'all');
+			}
+
 			local.middle = "";
 			for (local.i = 1; local.i <= local.totalPages; local.i++) {
 				if (
@@ -347,10 +357,6 @@ component {
 							We need the paginationLinks() function to set the active class to the parent of the current page item.
 							The changes made here set the active class to the immediate parent of the current page element in case nested elements are passed in.
 						 */
-						// Strip event handlers (on*=) and javascript: URIs to prevent XSS
-						local.sanitizedPrepend = reReplaceNoCase(arguments.prependToPage, '\s+on\w+\s*=\s*([''"])[^''"]*\1', '', 'all');
-						local.sanitizedPrepend = reReplaceNoCase(local.sanitizedPrepend, '\s+on\w+\s*=\s*[^\s>]+', '', 'all');
-						local.sanitizedPrepend = reReplaceNoCase(local.sanitizedPrepend, 'javascript\s*:', '', 'all');
 
 						if(local.currentPage == local.i  && arguments.addActiveClassToPrependedParent && findNoCase('class', local.sanitizedPrepend)) {
 							// Inject "active " into the class attribute value via regex
@@ -528,6 +534,36 @@ component {
 			local.match = ReFindNoCase(arguments.regex, arguments.text, local.startPosition, true);
 		}
 		return arguments.text;
+	}
+
+	/**
+	 * Decodes HTML numeric entities (decimal &#NNN; and hex &#xHH;) to their character equivalents.
+	 * Used to normalise input before regex-based XSS sanitisation so that entity-encoded
+	 * payloads like &#111;nmouseover cannot bypass the pattern checks.
+	 */
+	public string function $decodeHtmlEntities(required string input) {
+		local.result = arguments.input;
+		// Decode hex entities: &#xHH;
+		local.pos = 1;
+		while (true) {
+			local.match = reFindNoCase('&##x([0-9a-f]+);', local.result, local.pos, true);
+			if (local.match.pos[1] == 0) break;
+			local.hex = Mid(local.result, local.match.pos[2], local.match.len[2]);
+			local.char = Chr(InputBaseN(local.hex, 16));
+			local.result = Left(local.result, local.match.pos[1] - 1) & local.char & Mid(local.result, local.match.pos[1] + local.match.len[1], Len(local.result));
+			local.pos = local.match.pos[1] + Len(local.char);
+		}
+		// Decode decimal entities: &#NNN;
+		local.pos = 1;
+		while (true) {
+			local.match = reFind('&##(\d+);', local.result, local.pos, true);
+			if (local.match.pos[1] == 0) break;
+			local.dec = Mid(local.result, local.match.pos[2], local.match.len[2]);
+			local.char = Chr(Int(local.dec));
+			local.result = Left(local.result, local.match.pos[1] - 1) & local.char & Mid(local.result, local.match.pos[1] + local.match.len[1], Len(local.result));
+			local.pos = local.match.pos[1] + Len(local.char);
+		}
+		return local.result;
 	}
 
 	public string function $paramsToQueryString(required any params) {


### PR DESCRIPTION
## Summary
- Fixes a MEDIUM severity XSS bypass where HTML numeric entity encoding (`&#111;nmouseover`, `&#x6F;nmouseover`, `&#106;avascript:`) could evade the regex-based sanitization of `prependToPage` in `paginationLinks()`
- Adds `$decodeHtmlEntities()` helper that normalizes `&#NNN;` and `&#xHH;` patterns to their character equivalents before the existing regex strips event handlers and `javascript:` URIs
- Hoists the sanitization logic before the pagination loop (the input is invariant per iteration, so computing it once is both correct and more efficient)

## Test plan
- [x] Added `PaginationXssSpec.cfc` with 6 test cases covering:
  - Decimal entity-encoded `onmouseover` handler is stripped
  - Hex entity-encoded `onmouseover` handler is stripped
  - Entity-encoded `javascript:` URI is stripped
  - Normal HTML with `class`/`id` attributes is preserved
  - Plain (non-encoded) `onmouseover` still stripped (regression check)
  - `$decodeHtmlEntities` correctly decodes mixed decimal and hex entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)