### PR TITLE
fix(security): prevent SQL injection via index hints in $indexHint

### DIFF
--- a/vendor/wheels/model/sql.cfc
+++ b/vendor/wheels/model/sql.cfc
@@ -43,6 +43,14 @@ component {
 		local.rv = "";
 		if (StructKeyExists(arguments.useIndex, arguments.modelName)) {
 			local.indexName = arguments.useIndex[arguments.modelName];
+			// Validate index name to prevent SQL injection — only alphanumeric and underscores allowed
+			if (!IsSimpleValue(local.indexName) || !ReFind("^[a-zA-Z0-9_]+$", local.indexName)) {
+				Throw(
+					type = "Wheels.InvalidIndexName",
+					message = "Invalid index name.",
+					extendedInfo = "The index name contains invalid characters. Only letters, numbers, and underscores are allowed."
+				);
+			}
 			if (arguments.adapterName == "MySQLModel") {
 				local.rv = "USE INDEX(#local.indexName#)";
 			} else if (arguments.adapterName == "MicrosoftSQLServerModel") {
@@ -712,6 +720,10 @@ component {
 			}
 			ArrayPrepend(local.classes, variables.wheels.class);
 			// Issue#1273: Added this section to allow included tables to be referenced in the query
+			// SECURITY NOTE: The JOIN strings used below are safe from injection because they are
+			// constructed internally by $expandedAssociations() using $quoteIdentifier() for all
+			// table and column names (see the join-building loop in $expandedAssociations). The
+			// include parameter is validated against registered associations before reaching here.
 			local.joinclause = "";
 			local.migration = CreateObject("component", "wheels.migrator.Migration").init();
 			if(arguments.include != "" && ListFind('PostgreSQL,CockroachDB,H2', local.migration.adapter.adapterName()) && left(arguments.sql[1], 6) == 'UPDATE'){

--- a/vendor/wheels/tests/specs/model/useindexSpec.cfc
+++ b/vendor/wheels/tests/specs/model/useindexSpec.cfc
@@ -121,5 +121,105 @@ component extends="wheels.WheelsTest" {
                 expect(posts.recordcount).toBe(4)
             })
 		});
+
+		describe("$indexHint SQL injection prevention", () => {
+
+			it("accepts valid index names with letters numbers and underscores", () => {
+				result = g.model("post").$indexHint(
+					useIndex = {"post": "idx_users_email"},
+					modelName = "post",
+					adapterName = "MySQLModel"
+				);
+				expect(result).toBe("USE INDEX(idx_users_email)");
+			});
+
+			it("accepts valid index name for MSSQL adapter", () => {
+				result = g.model("post").$indexHint(
+					useIndex = {"post": "IX_Posts_AuthorId"},
+					modelName = "post",
+					adapterName = "MicrosoftSQLServerModel"
+				);
+				expect(result).toBe("WITH (INDEX(IX_Posts_AuthorId))");
+			});
+
+			it("returns empty string for unsupported adapter", () => {
+				result = g.model("post").$indexHint(
+					useIndex = {"post": "idx_test"},
+					modelName = "post",
+					adapterName = "PostgreSQLModel"
+				);
+				expect(result).toBe("");
+			});
+
+			it("returns empty string when model not in useIndex struct", () => {
+				result = g.model("post").$indexHint(
+					useIndex = {"other": "idx_test"},
+					modelName = "post",
+					adapterName = "MySQLModel"
+				);
+				expect(result).toBe("");
+			});
+
+			it("rejects index name containing SQL injection attempt", () => {
+				expect(function() {
+					g.model("post").$indexHint(
+						useIndex = {"post": "); DROP TABLE users;--"},
+						modelName = "post",
+						adapterName = "MySQLModel"
+					);
+				}).toThrow("Wheels.InvalidIndexName");
+			});
+
+			it("rejects index name with spaces", () => {
+				expect(function() {
+					g.model("post").$indexHint(
+						useIndex = {"post": "idx name"},
+						modelName = "post",
+						adapterName = "MySQLModel"
+					);
+				}).toThrow("Wheels.InvalidIndexName");
+			});
+
+			it("rejects index name with parentheses", () => {
+				expect(function() {
+					g.model("post").$indexHint(
+						useIndex = {"post": "idx(test)"},
+						modelName = "post",
+						adapterName = "MySQLModel"
+					);
+				}).toThrow("Wheels.InvalidIndexName");
+			});
+
+			it("rejects index name with single quotes", () => {
+				expect(function() {
+					g.model("post").$indexHint(
+						useIndex = {"post": "idx'test"},
+						modelName = "post",
+						adapterName = "MySQLModel"
+					);
+				}).toThrow("Wheels.InvalidIndexName");
+			});
+
+			it("rejects empty string as index name", () => {
+				expect(function() {
+					g.model("post").$indexHint(
+						useIndex = {"post": ""},
+						modelName = "post",
+						adapterName = "MySQLModel"
+					);
+				}).toThrow("Wheels.InvalidIndexName");
+			});
+
+			it("rejects non-simple value as index name", () => {
+				expect(function() {
+					g.model("post").$indexHint(
+						useIndex = {"post": ["array_value"]},
+						modelName = "post",
+						adapterName = "MySQLModel"
+					);
+				}).toThrow("Wheels.InvalidIndexName");
+			});
+
+		});
 	}
 }


### PR DESCRIPTION
## Summary
- Validates index names in `$indexHint()` against `^[a-zA-Z0-9_]+$` regex before interpolation into SQL, preventing injection via the `useIndex` parameter on `findAll()`/`updateAll()`/`deleteAll()`
- Adds security documentation explaining why JOIN clause interpolation in `$whereClause` is safe (built from validated association metadata)
- Adds 8 test cases covering valid index names, injection attempts, empty strings, and non-simple values

## Test plan
- [ ] Verify `$indexHint()` accepts valid index names (`idx_users_email`, `IX_Posts_AuthorId`)
- [ ] Verify `$indexHint()` throws `Wheels.InvalidIndexName` for malicious input (SQL injection payloads, spaces, quotes, parentheses)
- [ ] Run full test suite: `curl "http://localhost:60006/wheels/core/tests?db=sqlite&format=json"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)