### PR TITLE
fix(security): sanitize anchorDivider and appendToPage in paginationLinks XSS

### DIFF
--- a/vendor/wheels/tests/specs/view/linksSpec.cfc
+++ b/vendor/wheels/tests/specs/view/linksSpec.cfc
@@ -172,6 +172,35 @@ component extends="wheels.WheelsTest" {
 				expect(result).notToInclude("alert(document.cookie)")
 				expect(result).toInclude("class='active page-item'")
 			})
+
+			it("encodes anchorDivider to prevent XSS", () => {
+				authors = g.model("author").findAll(page = 2, perPage = 3, order = "lastName")
+				result = _controller.paginationLinks(
+					windowSize       = 0,
+					alwaysShowAnchors = true,
+					anchorDivider    = '<script>alert(1)</script>',
+					encode           = true
+				)
+
+				expect(result).notToInclude("<script>")
+				expect(result).notToInclude("</script>")
+				expect(result).notToInclude("alert(1)")
+			})
+
+			it("strips event handler XSS from appendToPage", () => {
+				authors = g.model("author").findAll(page = 2, perPage = 3, order = "lastName")
+				result = _controller.paginationLinks(
+					prependToPage                   = "<li>",
+					appendToPage                    = '<span onmouseover="alert(1)">x</span></li>',
+					addActiveClassToPrependedParent = false,
+					linkToCurrentPage               = true,
+					encode                          = "attributes"
+				)
+
+				expect(result).notToInclude("onmouseover")
+				expect(result).notToInclude("alert(1)")
+				expect(result).toInclude("<span")
+			})
 		})
 	}
 

--- a/vendor/wheels/view/links.cfc
+++ b/vendor/wheels/view/links.cfc
@@ -285,9 +285,20 @@ component {
 			if (Len(arguments.appendToPage)) {
 				arguments.appendToPage = EncodeForHTML($canonicalize(arguments.appendToPage));
 			}
+			if (Len(arguments.anchorDivider)) {
+				arguments.anchorDivider = EncodeForHTML($canonicalize(arguments.anchorDivider));
+			}
 		}
 
 		if (arguments.showSinglePage || local.totalPages > 1) {
+			// Strip event handlers from appendToPage (parallel to prependToPage sanitization in the loop)
+			if (Len(arguments.appendToPage)) {
+				local.sanitizedAppend = reReplaceNoCase(arguments.appendToPage, '\s+on\w+\s*=\s*([''"])[^''"]*\1', '', 'all');
+				local.sanitizedAppend = reReplaceNoCase(local.sanitizedAppend, '\s+on\w+\s*=\s*[^\s>]+', '', 'all');
+				local.sanitizedAppend = reReplaceNoCase(local.sanitizedAppend, 'javascript\s*:', '', 'all');
+			} else {
+				local.sanitizedAppend = arguments.appendToPage;
+			}
 			if (Len(arguments.prepend)) {
 				local.start &= arguments.prepend;
 			}
@@ -307,8 +318,8 @@ component {
 						local.start &= arguments.prependToPage;
 					}
 					local.start &= linkTo(argumentCollection = local.linkToArguments);
-					if (Len(arguments.appendToPage) && arguments.appendOnAnchor) {
-						local.start &= arguments.appendToPage;
+					if (Len(local.sanitizedAppend) && arguments.appendOnAnchor) {
+						local.start &= local.sanitizedAppend;
 					}
 					local.start &= arguments.anchorDivider;
 				}
@@ -394,8 +405,8 @@ component {
 							local.middle &= NumberFormat(local.i);
 						}
 					}
-					if (Len(arguments.appendToPage)) {
-						local.middle &= arguments.appendToPage;
+					if (Len(local.sanitizedAppend)) {
+						local.middle &= local.sanitizedAppend;
 					}
 				}
 			}
@@ -415,8 +426,8 @@ component {
 						local.end &= arguments.prependToPage;
 					}
 					local.end &= linkTo(argumentCollection = local.linkToArguments);
-					if (Len(arguments.appendToPage) && arguments.appendOnAnchor) {
-						local.end &= arguments.appendToPage;
+					if (Len(local.sanitizedAppend) && arguments.appendOnAnchor) {
+						local.end &= local.sanitizedAppend;
 					}
 				}
 			}
@@ -432,8 +443,8 @@ component {
 					Len(local.middle) - Len(arguments.prependToPage)
 				);
 			}
-			if (Len(arguments.appendToPage) && !arguments.appendOnLast) {
-				local.middle = Mid(local.middle, 1, Len(local.middle) - Len(arguments.appendToPage));
+			if (Len(local.sanitizedAppend) && !arguments.appendOnLast) {
+				local.middle = Mid(local.middle, 1, Len(local.middle) - Len(local.sanitizedAppend));
 			}
 		}
 		return local.start & local.middle & local.end;


### PR DESCRIPTION
## Summary
- **anchorDivider** was concatenated into HTML output without `EncodeForHTML($canonicalize())` encoding, unlike all other prepend/append parameters — now encoded consistently
- **appendToPage** lacked event handler stripping (`on*=`, `javascript:` URI removal) that `prependToPage` already had — now sanitized with the same regex pattern
- All uses of `appendToPage` inside the pagination output (loop body, start anchor, end anchor, trimming logic) now use the sanitized `local.sanitizedAppend` variable

## Test plan
- [ ] `anchorDivider` with `<script>alert(1)</script>` should be HTML-encoded in output
- [ ] `appendToPage` with `onmouseover=alert(1)` should have event handler stripped
- [ ] Existing pagination tests continue to pass (active class injection, route params, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)