### PR TITLE
fix(security): harden enum scopes and scope handler args against SQL injection

### DIFF
--- a/vendor/wheels/model/properties.cfc
+++ b/vendor/wheels/model/properties.cfc
@@ -736,6 +736,11 @@ component {
 		for (local.key in arguments.args) {
 			local.val = arguments.args[local.key];
 			if (IsSimpleValue(local.val)) {
+				// Strip SQL comment/statement markers before escaping
+				local.val = Replace(local.val, "--", "", "all");
+				local.val = Replace(local.val, "/*", "", "all");
+				local.val = Replace(local.val, "*/", "", "all");
+				local.val = Replace(local.val, ";", "", "all");
 				local.sanitized[local.key] = $escapeSqlValue(local.val);
 			} else {
 				local.sanitized[local.key] = local.val;
@@ -886,7 +891,16 @@ component {
 		}
 		for (local.name in ListToArray(local.enumDef.names)) {
 			local.storedValue = local.enumDef.values[local.name];
-			local.escapedValue = $escapeSqlValue(local.storedValue);
+			// Validate enum stored values: only allow alphanumeric, underscore, hyphen, space, and dot.
+			// Enum values are developer-defined in model config(), so this is a strict allowlist.
+			if (IsSimpleValue(local.storedValue) && ReFind("[^a-zA-Z0-9_\- .]", ToString(local.storedValue))) {
+				Throw(
+					type = "Wheels.InvalidEnumValue",
+					message = "The enum value `#local.storedValue#` for property `#arguments.property#` contains invalid characters.",
+					extendedInfo = "Enum values must contain only alphanumeric characters, underscores, hyphens, spaces, and dots. Received: `#local.storedValue#`"
+				);
+			}
+			local.escapedValue = $escapeSqlValue(ToString(local.storedValue));
 			local.scopeDef = {};
 			local.scopeDef.where = "#arguments.property# = '#local.escapedValue#'";
 			variables.wheels.class.scopes[local.name] = local.scopeDef;

--- a/vendor/wheels/tests/specs/model/enumScopeEscapingSpec.cfc
+++ b/vendor/wheels/tests/specs/model/enumScopeEscapingSpec.cfc
@@ -42,34 +42,44 @@ component extends="wheels.WheelsTest" {
 				expect(scopes.high.where).toBe("priority = '2'")
 			})
 
-			it("escapes single quotes in enum stored values", () => {
+			it("rejects enum values containing single quotes", () => {
 				var m = g.model("post")
-				m.enum(property="status", values={it_s_fine: "it's fine", normal: "normal"})
-				var scopes = m.scopeInfo()
 
-				expect(scopes).toHaveKey("it_s_fine")
-				expect(scopes.it_s_fine.where).toBe("status = 'it''s fine'")
-
-				expect(scopes).toHaveKey("normal")
-				expect(scopes.normal.where).toBe("status = 'normal'")
+				expect(function() {
+					m.enum(property="status", values={it_s_fine: "it's fine", normal: "normal"})
+				}).toThrow("Wheels.InvalidEnumValue")
 			})
 
-			it("escapes multiple single quotes in enum stored values", () => {
+			it("rejects enum values containing SQL injection patterns", () => {
 				var m = g.model("post")
-				m.enum(property="status", values={tricky: "it''s a ''test''"})
-				var scopes = m.scopeInfo()
 
-				expect(scopes).toHaveKey("tricky")
-				expect(scopes.tricky.where).toBe("status = 'it''''s a ''''test'''''")
+				expect(function() {
+					m.enum(property="status", values={dangerous: "'; DROP TABLE users; --"})
+				}).toThrow("Wheels.InvalidEnumValue")
 			})
 
-			it("handles enum values containing SQL keywords safely", () => {
+			it("allows enum values with hyphens spaces and dots", () => {
 				var m = g.model("post")
-				m.enum(property="status", values={dangerous: "'; DROP TABLE users; --"})
+				m.enum(property="status", values={my_val: "some-value", other: "v1.0", spaced: "hello world"})
 				var scopes = m.scopeInfo()
 
-				expect(scopes).toHaveKey("dangerous")
-				expect(scopes.dangerous.where).toBe("status = '''; DROP TABLE users; --'")
+				expect(scopes).toHaveKey("my_val")
+				expect(scopes.my_val.where).toBe("status = 'some-value'")
+
+				expect(scopes).toHaveKey("other")
+				expect(scopes.other.where).toBe("status = 'v1.0'")
+
+				expect(scopes).toHaveKey("spaced")
+				expect(scopes.spaced.where).toBe("status = 'hello world'")
+			})
+
+			it("allows numeric enum stored values", () => {
+				var m = g.model("post")
+				m.enum(property="priority", values={low: 0, medium: 1, high: 2})
+				var scopes = m.scopeInfo()
+
+				expect(scopes).toHaveKey("low")
+				expect(scopes.low.where).toBe("priority = '0'")
 			})
 
 			it("rejects property names with invalid characters", () => {

--- a/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
+++ b/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
@@ -18,11 +18,12 @@ component extends="wheels.WheelsTest" {
 				expect(result["1"]).toBe("Djurner'' OR ''1''=''1");
 			});
 
-			it("escapes DROP TABLE injection in arguments", () => {
+			it("strips semicolons and comment markers from injection attempts", () => {
 				var m = application.wo.model("author");
 				var result = m.$sanitizeScopeHandlerArgs({"1": "'; DROP TABLE users; --"});
 
-				expect(result["1"]).toBe("''; DROP TABLE users; --");
+				// semicolons stripped, -- stripped, then quotes escaped
+				expect(result["1"]).toBe("'' DROP TABLE users ");
 			});
 
 			it("leaves clean string arguments unchanged", () => {
@@ -93,11 +94,12 @@ component extends="wheels.WheelsTest" {
 				expect(result["1"]).toBe("test\\path");
 			});
 
-			it("escapes backslash-quote bypass attempts", () => {
+			it("escapes backslash-quote bypass attempts and strips comments", () => {
 				var m = application.wo.model("author");
 				var result = m.$sanitizeScopeHandlerArgs({"1": "test\' OR 1=1 --"});
 
-				expect(result["1"]).toBe("test\\'' OR 1=1 --");
+				// -- stripped, then backslash escaped, then quote escaped
+				expect(result["1"]).toBe("test\\'' OR 1=1 ");
 			});
 
 			it("strips null bytes from string arguments", () => {
@@ -114,6 +116,34 @@ component extends="wheels.WheelsTest" {
 				expect(result["1"]).toBe("O\\''Brien");
 			});
 
+			it("strips SQL line comment sequences", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "admin-- comment"});
+
+				expect(result["1"]).toBe("admin comment");
+			});
+
+			it("strips SQL block comment markers", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "admin/* injected */value"});
+
+				expect(result["1"]).toBe("admin injectedvalue");
+			});
+
+			it("strips semicolons to prevent stacked queries", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "value; DROP TABLE users"});
+
+				expect(result["1"]).toBe("value DROP TABLE users");
+			});
+
+			it("handles all dangerous patterns combined", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": Chr(0) & "val'; DROP TABLE x;/* comment */--end"});
+
+				// null bytes stripped, -- stripped, /* */ stripped, ; stripped, \ escaped, ' escaped
+				expect(result["1"]).toBe("val'' DROP TABLE x comment end");
+			});
 
 		});
 

--- a/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
+++ b/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
@@ -127,7 +127,7 @@ component extends="wheels.WheelsTest" {
 				var m = application.wo.model("author");
 				var result = m.$sanitizeScopeHandlerArgs({"1": "admin/* injected */value"});
 
-				expect(result["1"]).toBe("admin injectedvalue");
+				expect(result["1"]).toBe("admin injected value");
 			});
 
 			it("strips semicolons to prevent stacked queries", () => {


### PR DESCRIPTION
## Summary
- **Enum scope WHERE clauses**: Replace single-quote escaping with strict alphanumeric allowlist validation. Enum values containing characters outside `[a-zA-Z0-9_\- .]` now throw `Wheels.InvalidEnumValue` at model config time, preventing any SQL injection via crafted enum definitions.
- **`$sanitizeScopeHandlerArgs()`**: Extend sanitization beyond null bytes/backslashes/quotes to also strip SQL line comments (`--`), block comment markers (`/*`, `*/`), and semicolons — preventing statement termination and query structure manipulation in scope handler string interpolation.
- Updated existing tests to match new behavior (rejection vs escaping) and added tests for comment stripping, semicolon removal, and combined attack patterns.

## Test plan
- [ ] Verify enum values with only alphanumeric, underscore, hyphen, space, and dot chars are accepted
- [ ] Verify enum values with single quotes, semicolons, or other special chars are rejected with `Wheels.InvalidEnumValue`
- [ ] Verify scope handler args have `--`, `/*`, `*/`, and `;` stripped before escaping
- [ ] Verify combined attack patterns (null bytes + comments + semicolons + quotes) are fully neutralized
- [ ] CI passes across all engines and databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)