### PR TITLE
feat(cli): phase 3-4 scaffold, seed command, and in-process services

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -659,6 +659,23 @@ component extends="modules.BaseModule" {
 					System.out.print(chr(27) & "[2J" & chr(27) & "[H");
 					System.out.flush();
 					continue;
+
+				case "/models":
+					consoleExec(evalUrl, "structKeyArray(application.wheels.models).sort('textnocase')", password);
+					continue;
+
+				case "/routes":
+					consoleExec(evalUrl, "application.wheels.routes.map(function(r){ return r.pattern & ' -> ' & r.controller & '##' & r.action; })", password);
+					continue;
+
+				case "/version":
+					consoleExec(evalUrl, "application.wheels.version", password);
+					continue;
+
+				case "/ds":
+				case "/datasource":
+					consoleExec(evalUrl, "application.wheels.dataSourceName", password);
+					continue;
 			}
 
 			// Evaluate expression
@@ -855,11 +872,15 @@ component extends="modules.BaseModule" {
 	private void function printConsoleHelp() {
 		out("");
 		out("Wheels Console Commands:", "bold");
-		out("  /help, /h     Show this help");
-		out("  /env          Show environment info");
-		out("  /reload       Reload the application");
-		out("  /clear        Clear the screen");
-		out("  /exit, /quit  Exit the console");
+		out("  /help, /h       Show this help");
+		out("  /env            Show environment info");
+		out("  /models         List all registered models");
+		out("  /routes         List all routes");
+		out("  /version        Show Wheels version");
+		out("  /ds             Show current datasource");
+		out("  /reload         Reload the application");
+		out("  /clear          Clear the screen");
+		out("  /exit, /quit    Exit the console");
 		out("");
 		out("Expression Examples:", "bold");
 		out('  model("User").findAll()                      Query all users');
@@ -868,8 +889,8 @@ component extends="modules.BaseModule" {
 		out('  model("User").count()                        Count records');
 		out('  model("Post").findAll(where="status=''draft''")  Filtered query');
 		out('  get("environment")                           Framework setting');
-		out('  application.wheels.version                   Wheels version');
 		out('  service("emailService")                      Resolve a service');
+		out('  application.wheels.version                   Wheels version');
 		out("");
 	}
 

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -150,6 +150,32 @@ component extends="modules.BaseModule" {
 	}
 
 	// ─────────────────────────────────────────────────
+	//  seed — Database seeding
+	// ─────────────────────────────────────────────────
+
+	/**
+	 * hint: Run database seeds (convention-based or generated)
+	 */
+	public string function seed() {
+		var args = __arguments ?: [];
+		var environment = "";
+		var mode = "auto";
+
+		for (var i = 1; i <= arrayLen(args); i++) {
+			var arg = args[i];
+			if (reFindNoCase("^--environment=", arg)) {
+				environment = valueAfterEquals(arg);
+			} else if (reFindNoCase("^--mode=", arg)) {
+				mode = valueAfterEquals(arg);
+			} else if (arg == "--generate") {
+				mode = "generate";
+			}
+		}
+
+		return runSeed(mode, environment);
+	}
+
+	// ─────────────────────────────────────────────────
 	//  test — Run test suite
 	// ─────────────────────────────────────────────────
 
@@ -331,9 +357,9 @@ component extends="modules.BaseModule" {
 			return "";
 		}
 
-		// Default datasource and reload password to app name if not specified
+		// Default datasource to app name, generate random reload password
 		if (!len(options.datasource)) options.datasource = lCase(appName);
-		if (!len(options.reloadPassword)) options.reloadPassword = lCase(appName);
+		if (!len(options.reloadPassword)) options.reloadPassword = generateRandomPassword();
 
 		return scaffoldNewApp(appName, options);
 	}
@@ -2041,35 +2067,84 @@ component extends="modules.BaseModule" {
 		var serverPort = detectServerPort();
 		if (!serverPort) {
 			out("No running Wheels server detected.", "red");
-			out("Migrations require a running server. Start with: wheels start");
+			out("Migrations require a running server. Start with: wheels server start");
 			return "";
 		}
 
 		out("Running migration: #action#...", "cyan");
 
 		try {
-			var migrateUrl = "http://localhost:#serverPort#/wheels/app/tests?type=app&reload=true";
-
+			var command = "";
 			switch (action) {
-				case "latest":
-					migrateUrl = "http://localhost:#serverPort#/?controller=wheels&action=wheels&view=migrate&type=migrateToLatest&reload=true&password=";
-					break;
-				case "up":
-					migrateUrl = "http://localhost:#serverPort#/?controller=wheels&action=wheels&view=migrate&type=migrateUp&reload=true&password=";
-					break;
-				case "down":
-					migrateUrl = "http://localhost:#serverPort#/?controller=wheels&action=wheels&view=migrate&type=migrateDown&reload=true&password=";
-					break;
-				case "info":
-					migrateUrl = "http://localhost:#serverPort#/?controller=wheels&action=wheels&view=migrate&type=info&reload=true&password=";
-					break;
+				case "latest": command = "migrateTo"; break;
+				case "up":     command = "migrateUp"; break;
+				case "down":   command = "migrateDown"; break;
+				case "info":   command = "info"; break;
+			}
+
+			var migrateUrl = "http://localhost:#serverPort#/wheels/cli?command=#command#&format=json";
+			if (action == "latest") {
+				// migrateTo needs a version — omitting it runs to latest
+				migrateUrl &= "&version=";
 			}
 
 			var httpResult = makeHttpRequest(migrateUrl);
-			out("Migration #action# completed.", "green");
-			verbose(httpResult);
+
+			try {
+				var result = deserializeJSON(httpResult);
+				if (structKeyExists(result, "message") && len(result.message)) {
+					out(result.message, "green");
+				} else {
+					out("Migration #action# completed.", "green");
+				}
+			} catch (any jsonErr) {
+				out("Migration #action# completed.", "green");
+				verbose(httpResult);
+			}
 		} catch (any e) {
 			out("Migration failed: #e.message#", "red");
+		}
+
+		return "";
+	}
+
+	// ── Seed Execution ──────────────────────────────
+
+	private string function runSeed(string mode = "auto", string environment = "") {
+		var serverPort = detectServerPort();
+		if (!serverPort) {
+			out("No running Wheels server detected.", "red");
+			out("Seeding requires a running server. Start with: wheels server start");
+			return "";
+		}
+
+		out("Running database seeds...", "cyan");
+
+		try {
+			var seedUrl = "http://localhost:#serverPort#/wheels/cli?command=dbSeed&format=json&mode=#mode#";
+			if (len(environment)) {
+				seedUrl &= "&environment=#environment#";
+			}
+
+			var httpResult = makeHttpRequest(seedUrl);
+
+			try {
+				var result = deserializeJSON(httpResult);
+				if (structKeyExists(result, "success") && result.success) {
+					if (structKeyExists(result, "totalCreated")) {
+						out("Seeded: #result.totalCreated# created, #result.totalSkipped# skipped", "green");
+					} else {
+						out("Seeding completed.", "green");
+					}
+				} else {
+					out("Seeding failed: #result.message ?: 'unknown error'#", "red");
+				}
+			} catch (any jsonErr) {
+				out("Seeding completed.", "green");
+				verbose(httpResult);
+			}
+		} catch (any e) {
+			out("Seeding failed: #e.message#", "red");
 		}
 
 		return "";
@@ -2257,7 +2332,7 @@ component extends="modules.BaseModule" {
 		var opts = {
 			port: structKeyExists(options, "port") ? options.port : 8080,
 			datasource: structKeyExists(options, "datasource") ? options.datasource : lCase(appName),
-			reloadPassword: structKeyExists(options, "reloadPassword") ? options.reloadPassword : lCase(appName),
+			reloadPassword: structKeyExists(options, "reloadPassword") ? options.reloadPassword : generateRandomPassword(),
 			setupH2: structKeyExists(options, "setupH2") ? options.setupH2 : false,
 			noSQLite: structKeyExists(options, "noSQLite") ? options.noSQLite : false,
 			openBrowser: structKeyExists(options, "openBrowser") ? options.openBrowser : true
@@ -2317,17 +2392,18 @@ component extends="modules.BaseModule" {
 		out("Application created!", "green");
 		out("");
 		out("Configuration:", "bold");
-		out("  Port:       #opts.port#");
-		out("  Datasource: #opts.datasource#");
+		out("  Port:            #opts.port#");
+		out("  Datasource:      #opts.datasource#");
+		out("  Reload password: #opts.reloadPassword#");
 		if (opts.setupH2) {
-			out("  Database:   H2 embedded (db/h2/)", "green");
+			out("  Database:        H2 embedded (db/h2/)", "green");
 		} else if (!opts.noSQLite) {
-			out("  Database:   SQLite (db/development.sqlite)", "green");
+			out("  Database:        SQLite (db/development.sqlite)", "green");
 		}
 		out("");
 		out("Next steps:", "bold");
 		out("  cd #appName#");
-		out("  wheels start");
+		out("  wheels server start");
 		return "";
 	}
 
@@ -2390,10 +2466,14 @@ component extends="modules.BaseModule" {
 		var nl = chr(10);
 		var tab = chr(9);
 
-		// Create db directory for SQLite data files
+		// Create db directory and empty SQLite files
 		var dbDir = targetDir & "/db";
 		ensureDirectory(dbDir);
+		fileWrite(dbDir & "/development.sqlite", "");
+		fileWrite(dbDir & "/test.sqlite", "");
 		printCreated(appName & "/db/");
+		printCreated(appName & "/db/development.sqlite");
+		printCreated(appName & "/db/test.sqlite");
 
 		// Build SQLite datasource configuration for config/app.cfm
 		var sqliteConfig = "";
@@ -2405,7 +2485,7 @@ component extends="modules.BaseModule" {
 		sqliteConfig &= tab & "};";
 
 		// Also add a test database datasource
-		sqliteConfig &= nl & tab & 'this.datasources["wheelstestdb"] = {' & nl;
+		sqliteConfig &= nl & tab & 'this.datasources["#datasourceName#_test"] = {' & nl;
 		sqliteConfig &= tab & tab & 'class: "org.sqlite.JDBC",' & nl;
 		sqliteConfig &= tab & tab & 'bundleName: "org.xerial.sqlite-jdbc",' & nl;
 		sqliteConfig &= tab & tab & 'connectionString: "jdbc:sqlite:" & expandPath("../db/test.sqlite")' & nl;
@@ -2813,6 +2893,18 @@ component extends="modules.BaseModule" {
 		var pos = find("=", arg);
 		if (pos == 0) return "";
 		return mid(arg, pos + 1, len(arg));
+	}
+
+	/**
+	 * Generate a random alphanumeric password for reload protection.
+	 */
+	private string function generateRandomPassword(numeric length = 16) {
+		var chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+		var result = "";
+		for (var i = 1; i <= arguments.length; i++) {
+			result &= mid(chars, randRange(1, len(chars)), 1);
+		}
+		return result;
 	}
 
 }

--- a/cli/lucli/services/MCP.cfc
+++ b/cli/lucli/services/MCP.cfc
@@ -1,0 +1,105 @@
+/**
+ * MCP (Model Context Protocol) tool implementations for LuCLI stdio transport.
+ *
+ * LuCLI's McpCommand auto-discovers public functions from the Wheels module
+ * (Module.cfc) and exposes them as MCP tools over stdio. This service provides
+ * additional structured tool implementations with rich schemas.
+ *
+ * Configuration for Claude Code (.mcp.json):
+ *   {
+ *     "mcpServers": {
+ *       "wheels": {
+ *         "command": "wheels",
+ *         "args": ["mcp"]
+ *       }
+ *     }
+ *   }
+ *
+ * Tools auto-discovered from Module.cfc:
+ *   wheels_generate, wheels_migrate, wheels_test, wheels_seed,
+ *   wheels_reload, wheels_analyze, wheels_validate, wheels_routes, wheels_info
+ */
+component {
+
+	function init(required string projectRoot) {
+		variables.projectRoot = arguments.projectRoot;
+		return this;
+	}
+
+	/**
+	 * Return the tool schema definitions for structured MCP tool registration.
+	 * These schemas describe the input parameters for each tool, enabling
+	 * Claude to generate well-formed tool calls.
+	 */
+	public array function getToolSchemas() {
+		return [
+			{
+				name: "wheels_generate",
+				description: "Generate Wheels components (model, controller, view, migration, scaffold, api-resource, route, test, property, helper, snippets)",
+				inputSchema: {
+					type: "object",
+					properties: {
+						type: { type: "string", enum: ["model","controller","view","migration","scaffold","api-resource","route","test","property","helper","snippets"] },
+						name: { type: "string", description: "Component name (PascalCase for models/controllers)" },
+						attributes: { type: "string", description: "Space-separated attributes (e.g., 'name email:string active:boolean')" }
+					},
+					required: ["type", "name"]
+				}
+			},
+			{
+				name: "wheels_migrate",
+				description: "Run database migrations (latest, up, down, info)",
+				inputSchema: {
+					type: "object",
+					properties: {
+						action: { type: "string", enum: ["latest","up","down","info"], default: "latest" }
+					}
+				}
+			},
+			{
+				name: "wheels_test",
+				description: "Run the Wheels test suite with optional filtering",
+				inputSchema: {
+					type: "object",
+					properties: {
+						filter: { type: "string", description: "Test directory or spec file path" },
+						db: { type: "string", default: "sqlite", description: "Database to test against" },
+						core: { type: "boolean", default: true, description: "Run core (framework) tests vs app tests" }
+					}
+				}
+			},
+			{
+				name: "wheels_seed",
+				description: "Run database seeds (convention-based or generated)",
+				inputSchema: {
+					type: "object",
+					properties: {
+						mode: { type: "string", enum: ["auto","convention","generate"], default: "auto" },
+						environment: { type: "string", description: "Target environment (default: current)" }
+					}
+				}
+			},
+			{
+				name: "wheels_reload",
+				description: "Reload the Wheels application (picks up code changes)",
+				inputSchema: { type: "object", properties: {} }
+			},
+			{
+				name: "wheels_analyze",
+				description: "Analyze the Wheels application for issues, conventions, and optimization opportunities",
+				inputSchema: {
+					type: "object",
+					properties: {
+						target: { type: "string", default: "all", description: "What to analyze (all, models, controllers, routes, config)" }
+					}
+				}
+			},
+			{
+				name: "wheels_routes",
+				description: "List all configured routes with their patterns and targets",
+				inputSchema: { type: "object", properties: {} }
+			}
+		];
+	}
+
+}

--- a/cli/lucli/services/MigrationRunner.cfc
+++ b/cli/lucli/services/MigrationRunner.cfc
@@ -1,0 +1,133 @@
+/**
+ * In-process migration runner for Wheels applications.
+ *
+ * Designed to be invoked by LuCLI's LuceeScriptEngine for Phase 4
+ * in-process command execution. Falls back to HTTP when a server is running.
+ *
+ * Usage from LuceeScriptEngine:
+ *   var runner = new cli.lucli.services.MigrationRunner(projectRoot);
+ *   var result = runner.latest();
+ */
+component {
+
+	function init(required string projectRoot) {
+		variables.projectRoot = arguments.projectRoot;
+		return this;
+	}
+
+	/**
+	 * Run migrations to latest version (in-process).
+	 * Requires application.wheels.migrator to be initialized.
+	 */
+	public struct function latest() {
+		return executeMigration("migrateToLatest");
+	}
+
+	/**
+	 * Run one migration up (in-process).
+	 */
+	public struct function up() {
+		return executeMigration("migrateUp");
+	}
+
+	/**
+	 * Roll back one migration (in-process).
+	 */
+	public struct function down() {
+		return executeMigration("migrateDown");
+	}
+
+	/**
+	 * Get migration status info (in-process).
+	 */
+	public struct function info() {
+		ensureContext();
+		var migrator = application.wheels.migrator;
+		var migrations = migrator.getAvailableMigrations();
+		var currentVersion = migrator.getCurrentMigrationVersion();
+
+		var result = {
+			success: true,
+			currentVersion: currentVersion,
+			migrations: [],
+			summary: { total: 0, applied: 0, pending: 0 }
+		};
+
+		for (var m in migrations) {
+			var status = m.version <= currentVersion ? "applied" : "pending";
+			arrayAppend(result.migrations, {
+				version: m.version,
+				description: m.name,
+				status: status
+			});
+			if (status == "applied") result.summary.applied++;
+			else result.summary.pending++;
+		}
+		result.summary.total = arrayLen(result.migrations);
+
+		return result;
+	}
+
+	/**
+	 * Migrate to a specific version (in-process).
+	 */
+	public struct function migrateTo(required string version) {
+		ensureContext();
+		var migrator = application.wheels.migrator;
+
+		try {
+			var message = migrator.migrateTo(arguments.version);
+			return { success: true, message: message };
+		} catch (any e) {
+			return { success: false, message: e.message, detail: e.detail ?: "" };
+		}
+	}
+
+	/**
+	 * Run via HTTP to a running server (Phase 2-3 fallback).
+	 */
+	public struct function runViaHttp(required numeric serverPort, required string action) {
+		var command = "";
+		switch (action) {
+			case "latest": command = "migrateTo"; break;
+			case "up":     command = "migrateUp"; break;
+			case "down":   command = "migrateDown"; break;
+			case "info":   command = "info"; break;
+			default:       command = action;
+		}
+
+		var url = "http://localhost:#serverPort#/wheels/cli?command=#command#&format=json";
+		var httpService = new http(url=url, method="GET", timeout=120);
+		var httpResult = httpService.send().getPrefix();
+
+		if (httpResult.statusCode contains "200" && isJSON(httpResult.fileContent)) {
+			return deserializeJSON(httpResult.fileContent);
+		}
+
+		return { success: false, message: "HTTP #httpResult.statusCode#" };
+	}
+
+	// ── Private ─────────────────────────────────────
+
+	private struct function executeMigration(required string method) {
+		ensureContext();
+		var migrator = application.wheels.migrator;
+
+		try {
+			var message = invoke(migrator, arguments.method);
+			return { success: true, message: message ?: "Migration completed." };
+		} catch (any e) {
+			return { success: false, message: e.message, detail: e.detail ?: "" };
+		}
+	}
+
+	private void function ensureContext() {
+		if (!structKeyExists(application, "wheels") || !structKeyExists(application.wheels, "migrator")) {
+			throw(
+				type="Wheels.MigrationRunner.NoContext",
+				message="Wheels application context not initialized. Run wheels server start or load the app context first."
+			);
+		}
+	}
+
+}

--- a/cli/lucli/services/TestRunner.cfc
+++ b/cli/lucli/services/TestRunner.cfc
@@ -1,0 +1,153 @@
+/**
+ * In-process test runner for Wheels applications.
+ *
+ * Designed to be invoked by LuCLI's LuceeScriptEngine, sharing the same
+ * JVM and Lucee context as the application. This eliminates HTTP round-trips
+ * for test execution.
+ *
+ * Usage from LuceeScriptEngine:
+ *   var runner = new cli.lucli.services.TestRunner(projectRoot);
+ *   var result = runner.run(options);
+ *
+ * Usage from HTTP fallback (Module.cfc delegates here when server is available):
+ *   var runner = new cli.lucli.services.TestRunner(projectRoot);
+ *   var result = runner.runViaHttp(serverPort, options);
+ */
+component {
+
+	/**
+	 * @projectRoot Absolute path to the project root (where vendor/wheels lives)
+	 */
+	function init(required string projectRoot) {
+		variables.projectRoot = arguments.projectRoot;
+		return this;
+	}
+
+	/**
+	 * Run tests in-process by invoking the Wheels test runner directly.
+	 *
+	 * Requires the Wheels application context (application.wheels) to be initialized.
+	 * This is the Phase 4 path — LuCLI's ScriptEngine loads the app context first.
+	 *
+	 * @options Struct with keys: type (core|app), db, directory, format, reload
+	 * @return Struct with test results (same shape as TestBox JSON output)
+	 */
+	public struct function run(struct options = {}) {
+		var opts = {
+			type: options.type ?: "core",
+			db: options.db ?: "sqlite",
+			format: options.format ?: "json",
+			directory: options.directory ?: "",
+			reload: options.reload ?: true
+		};
+
+		// Ensure application context exists
+		if (!structKeyExists(application, "wheels")) {
+			throw(
+				type="Wheels.TestRunner.NoContext",
+				message="Wheels application context not initialized. Run wheels server start or load the app context first."
+			);
+		}
+
+		// Build the params struct that $WheelsRunner expects
+		var params = {
+			type: opts.type,
+			format: "json",
+			db: opts.db,
+			reload: opts.reload
+		};
+		if (len(opts.directory)) {
+			params.directory = opts.directory;
+		}
+
+		// Invoke the Wheels test runner directly
+		var testResult = $createObjectFromRoot(
+			fileName="Test",
+			method="$WheelsRunner",
+			options=params,
+			path=application.wheels.wheelsComponentPath
+		);
+
+		// Parse JSON result into struct
+		if (isSimpleValue(testResult) && isJSON(testResult)) {
+			return deserializeJSON(testResult);
+		}
+		if (isStruct(testResult)) {
+			return testResult;
+		}
+
+		return {
+			success: false,
+			message: "Unexpected test result format",
+			raw: isSimpleValue(testResult) ? testResult : serializeJSON(testResult)
+		};
+	}
+
+	/**
+	 * Run tests via HTTP to a running Wheels server.
+	 *
+	 * This is the Phase 2-3 path — used when a server is running.
+	 *
+	 * @serverPort Port of the running Wheels server
+	 * @options Struct with keys: coreTests, db, filter, format
+	 * @return Struct with test results
+	 */
+	public struct function runViaHttp(required numeric serverPort, struct options = {}) {
+		var coreTests = options.coreTests ?: true;
+		var db = options.db ?: "sqlite";
+		var filter = options.filter ?: "";
+		var format = options.format ?: "json";
+
+		var testPath = coreTests ? "/wheels/core/tests" : "/wheels/app/tests";
+		var testUrl = "http://localhost:#serverPort##testPath#?format=#format#&db=#db#&reload=true";
+		if (len(filter)) {
+			testUrl &= "&directory=#filter#";
+		}
+
+		var httpService = new http(url=testUrl, method="GET", timeout=600);
+		var httpResult = httpService.send().getPrefix();
+
+		if (httpResult.statusCode contains "200" && isJSON(httpResult.fileContent)) {
+			return deserializeJSON(httpResult.fileContent);
+		}
+
+		return {
+			success: false,
+			message: "HTTP #httpResult.statusCode#",
+			raw: httpResult.fileContent
+		};
+	}
+
+	/**
+	 * Determine whether tests should run as core (framework) or app tests.
+	 *
+	 * @return "core" if vendor/wheels/tests/ exists, "app" otherwise
+	 */
+	public string function detectTestType() {
+		if (directoryExists(variables.projectRoot & "/vendor/wheels/tests")) {
+			return "core";
+		}
+		return "app";
+	}
+
+	/**
+	 * Get the test directory path based on type and filter.
+	 *
+	 * @type "core" or "app"
+	 * @filter Optional directory/file filter (e.g., "model", "controller")
+	 * @return Dot-delimited directory path for TestBox
+	 */
+	public string function resolveTestDirectory(required string type, string filter = "") {
+		var basePath = type == "core" ? "wheels.tests.specs" : "tests.specs";
+		if (!len(filter)) {
+			return basePath;
+		}
+		// If filter is a simple name, treat as subdirectory
+		if (!find("/", filter) && !find(".", filter)) {
+			return basePath & "." & filter;
+		}
+		// If filter contains path separators, convert to dots
+		return replace(filter, "/", ".", "all");
+	}
+
+}

--- a/cli/lucli/templates/app/_env
+++ b/cli/lucli/templates/app/_env
@@ -1,5 +1,6 @@
 # Environment configuration for {{appName}}
-# Copy this file to .env and update values for your environment.
-# Never commit .env to version control.
+# Never commit this file to version control.
 
 WHEELS_ENV=development
+WHEELS_DATASOURCE={{datasourceName}}
+RELOAD_PASSWORD={{reloadPassword}}

--- a/cli/lucli/templates/app/_gitignore
+++ b/cli/lucli/templates/app/_gitignore
@@ -21,14 +21,13 @@ WEB-INF
 # Vendor dependencies (install with: wheels install)
 /vendor/
 
-# Database files
-/db/
+# Database files (SQLite databases are created by the server)
+/db/*.sqlite
+/db/*.db
 
 # Server state
 settings.json
 settings.xml
-*.db
-*.sqlite
 .wheels/
 
 # Environment files (contain secrets)

--- a/cli/lucli/templates/app/config/settings.cfm
+++ b/cli/lucli/templates/app/config/settings.cfm
@@ -16,7 +16,7 @@
 
 	/*
 		URL rewriting mode: "On", "Partial", or "Off".
-		"On" requires web server rewrite rules (or urlrewrite.xml for Tuckey/CommandBox).
+		"On" requires web server rewrite rules (or urlrewrite.xml for LuCLI/Tuckey).
 		"Partial" requires cgi.path_info support.
 	*/
 	set(URLRewriting="On");

--- a/cli/lucli/templates/app/db/.gitignore
+++ b/cli/lucli/templates/app/db/.gitignore
@@ -1,0 +1,3 @@
+# SQLite database files (created by wheels server start)
+*.sqlite
+*.db

--- a/cli/lucli/templates/app/lucee.json
+++ b/cli/lucli/templates/app/lucee.json
@@ -1,6 +1,8 @@
 {
   "name": "{{appName}}",
-  "version": "7.0.2.101",
+  "lucee": {
+    "version": "7.0.0.395"
+  },
   "port": {{port}},
   "shutdownPort": {{shutdownPort}},
   "webroot": "./public",
@@ -14,7 +16,8 @@
     "routerFile": "index.cfm"
   },
   "admin": {
-    "enabled": true
+    "enabled": true,
+    "password": "{{reloadPassword}}"
   },
   "enableLucee": true,
   "enableREST": false,
@@ -22,7 +25,26 @@
     "enabled": false
   },
   "configuration": {
-    "datasources": {},
+    "datasources": {
+      "{{datasourceName}}": {
+        "class": "org.sqlite.JDBC",
+        "database": "{{datasourceName}}",
+        "dbdriver": "Other",
+        "dsn": "jdbc:sqlite:{project}/db/development.sqlite",
+        "host": "",
+        "password": "",
+        "username": ""
+      },
+      "{{datasourceName}}_test": {
+        "class": "org.sqlite.JDBC",
+        "database": "{{datasourceName}}_test",
+        "dbdriver": "Other",
+        "dsn": "jdbc:sqlite:{project}/db/test.sqlite",
+        "host": "",
+        "password": "",
+        "username": ""
+      }
+    },
     "mappings": {
       "/wheels": "../vendor/wheels",
       "/app": "../app",


### PR DESCRIPTION
## Summary

### Phase 3: Scaffold & Distribution
- Updated scaffold `lucee.json` template with SQLite datasources using `{project}` placeholder
- `wheels new myapp` generates a random reload password instead of using app name
- Scaffold creates `db/` directory with empty `.sqlite` files and `.gitignore`
- Added `wheels seed` command with HTTP delegation to `/wheels/cli?command=dbSeed`
- Modernized `wheels migrate` to use `/wheels/cli` endpoint instead of legacy URLs

### Phase 4: In-Process Services
- `TestRunner.cfc` — in-process test execution via LuceeScriptEngine (with HTTP fallback)
- `MigrationRunner.cfc` — in-process migration execution (latest, up, down, info)
- `MCP.cfc` — structured tool schemas for LuCLI stdio MCP transport
- Console enhancements: `/models`, `/routes`, `/version`, `/ds` commands

## What's blocked

- **Homebrew/Chocolatey formula rewrite** — needs LuCLI PRs merged (cybersonic/LuCLI#48, #49, #50)
- **In-process execution activation** — needs LuCLI ScriptEngine integration
- **Binary rename** — needs LuCLI profile system PR merged

## Test plan

- [ ] Verify `wheels new testapp` creates project with SQLite in lucee.json
- [ ] Verify random reload password in `.env` and `config/settings.cfm`
- [ ] Verify `db/` directory created with `.sqlite` files
- [ ] Verify `wheels seed` delegates to running server
- [ ] Verify console `/models`, `/routes`, `/version` commands work
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)