### PR TITLE
chore(config): bump version to 4.0.0-SNAPSHOT

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"Wheels.fw",
-    "version":"4.0.0-SNAPSHOT",
+    "version":"4.0.0",
     "author":"Wheels Core Team and Community",
     "shortDescription":"Wheels MVC Framework Core Directory",
     "location":"ForgeboxStorage",

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"Wheels.fw",
-    "version":"3.1.0",
+    "version":"4.0.0-SNAPSHOT",
     "author":"Wheels Core Team and Community",
     "shortDescription":"Wheels MVC Framework Core Directory",
     "location":"ForgeboxStorage",
@@ -19,7 +19,7 @@
         "URL":"https://github.com/wheels-dev/wheels"
     },
     "dependencies": {
-        "wheels-core": "^3.1.0"
+        "wheels-core": "^4.0.0"
     },
     "installPaths": {
         "wheels-core": "vendor/wheels"

--- a/cli/lucli/module.json
+++ b/cli/lucli/module.json
@@ -1,6 +1,6 @@
 {
   "name": "wheels",
-  "version": "3.1.0",
+  "version": "4.0.0-SNAPSHOT",
   "description": "Wheels CLI - Code generation, migrations, testing, and server management for Wheels",
   "author": "Wheels Team",
   "license": "Apache-2.0",

--- a/cli/lucli/module.json
+++ b/cli/lucli/module.json
@@ -1,6 +1,6 @@
 {
   "name": "wheels",
-  "version": "4.0.0-SNAPSHOT",
+  "version": "4.0.0",
   "description": "Wheels CLI - Code generation, migrations, testing, and server management for Wheels",
   "author": "Wheels Team",
   "license": "Apache-2.0",

--- a/cli/src/ModuleConfig.cfc
+++ b/cli/src/ModuleConfig.cfc
@@ -2,7 +2,7 @@ component {
     this.title = "Wheels CLI";
     this.author = "Wheels.dev Team";
     this.description = "Modern CLI for Wheels Framework";
-    this.version = "4.0.0-SNAPSHOT";
+    this.version = "4.0.0";
     this.autoMapModels = false;
     this.cfmapping = "wheels-cli";
     this.modelNamespace = "wheels-cli";

--- a/cli/src/ModuleConfig.cfc
+++ b/cli/src/ModuleConfig.cfc
@@ -2,7 +2,7 @@ component {
     this.title = "Wheels CLI";
     this.author = "Wheels.dev Team";
     this.description = "Modern CLI for Wheels Framework";
-    this.version = "3.1.0";
+    this.version = "4.0.0-SNAPSHOT";
     this.autoMapModels = false;
     this.cfmapping = "wheels-cli";
     this.modelNamespace = "wheels-cli";

--- a/examples/starter-app/box.json
+++ b/examples/starter-app/box.json
@@ -28,7 +28,7 @@
         ".env.example"
     ],
     "dependencies": {
-        "wheels-core": "^3.1.0",
+        "wheels-core": "^4.0.0",
         "wheels-authenticateThis":"^1"
     },
     "installPaths": {

--- a/examples/tweet/box.json
+++ b/examples/tweet/box.json
@@ -38,7 +38,7 @@
         "wheels-core":"vendor/wheels/"
     },
     "dependencies":{
-        "wheels-core":"^3.1.0",
+        "wheels-core":"^4.0.0",
         "orgh213172lex":"lex:https://ext.lucee.org/org.lucee.h2-2.1.214.0001L.lex"
     },
     "private":false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wheels",
-  "version": "3.1.0",
+  "version": "4.0.0-SNAPSHOT",
   "private": true,
   "type": "module",
   "description": "Wheels CFML MVC Framework — dev tooling only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wheels",
-  "version": "4.0.0-SNAPSHOT",
+  "version": "4.0.0",
   "private": true,
   "type": "module",
   "description": "Wheels CFML MVC Framework — dev tooling only",

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -82,7 +82,7 @@ component {
 
 		// Set up containers for routes, caches, settings etc.
 		// TODO remove the static version number
-		application.$wheels.version = "4.0.0-SNAPSHOT";
+		application.$wheels.version = "4.0.0";
 		try {
 			application.$wheels.hostName = CreateObject("java", "java.net.InetAddress").getLocalHost().getHostName();
 		} catch (any e) {

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -82,7 +82,7 @@ component {
 
 		// Set up containers for routes, caches, settings etc.
 		// TODO remove the static version number
-		application.$wheels.version = "3.0.0";
+		application.$wheels.version = "4.0.0-SNAPSHOT";
 		try {
 			application.$wheels.hostName = CreateObject("java", "java.net.InetAddress").getLocalHost().getHostName();
 		} catch (any e) {


### PR DESCRIPTION
## Summary

Bumps the framework version from 3.1.0 to 4.0.0-SNAPSHOT across all version declarations.

## Rationale

The scope of changes on develop since the 3.0 release warrants a major version bump:

- **LuCLI replaces CommandBox** as the CLI engine (breaking change for existing CLI workflows)
- **SQLite as primary platform** — zero-config out of box
- **Rebrand** from CFWheels to Wheels (namespace/branding changes)
- **In-process CLI architecture** — commands run in same JVM context
- **New scaffold system** — `wheels new` with LuCLI templates
- **Security hardening** — 7 vulnerability fixes across model/view/controller/middleware layers
- **Package system** — replacing legacy plugins/ with packages/vendor/

## Files changed

| File | What changed |
|---|---|
| `vendor/wheels/events/onapplicationstart.cfc` | Core `application.$wheels.version` |
| `box.json` | Root package version + dependency |
| `package.json` | NPM package version |
| `cli/src/ModuleConfig.cfc` | CommandBox CLI module version |
| `cli/lucli/module.json` | LuCLI CLI module version |
| `examples/starter-app/box.json` | Starter app dependency |
| `examples/tweet/box.json` | Tweet example dependency |

## Test plan

- [ ] CI passes (version string doesn't affect test execution)
- [ ] `application.wheels.version` reports `4.0.0-SNAPSHOT` at runtime

Generated with [Claude Code](https://claude.com/claude-code)