### PR TITLE
fix(cli): sanitize shell arguments in deploy commands

### DIFF
--- a/cli/src/commands/wheels/deploy/base.cfc
+++ b/cli/src/commands/wheels/deploy/base.cfc
@@ -25,7 +25,7 @@ component extends="../base" {
             var sshUser = deployConfig.ssh.user ?: "root";
             var lockDir = "/opt/.kamal/lock";
             
-            var checkResult = $execBash("ssh -o ConnectTimeout=5 " & sshUser & "@" & primaryServer & " 'test -d " & lockDir & " && echo EXISTS || echo FREE'");
+            var checkResult = $execBash("ssh -o ConnectTimeout=5 " & $shellEscape(sshUser) & "@" & $validateServerAddress(primaryServer) & " 'test -d " & $shellEscape(lockDir) & " && echo EXISTS || echo FREE'");
             
             return trim(checkResult.output) == "EXISTS";
         } catch (any e) {
@@ -79,7 +79,7 @@ component extends="../base" {
         var lockJson = serializeJSON(lockInfo);
         
         // Try to create lock directory atomically
-        var createResult = $execBash("ssh " & sshUser & "@" & primaryServer & " 'mkdir -p /opt/.kamal && mkdir " & lockDir & " && echo ''" & replace(lockJson, "'", "'\''", "all") & "'' > " & lockDir & "/info.json'");
+        var createResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(primaryServer) & " 'mkdir -p /opt/.kamal && mkdir " & $shellEscape(lockDir) & " && echo " & $shellEscape(lockJson) & " > " & $shellEscape(lockDir) & "/info.json'");
         
         if (createResult.exitCode == 0) {
             deployAuditLog("lock_acquired", lockInfo);
@@ -105,7 +105,7 @@ component extends="../base" {
         var lockDir = "/opt/.kamal/lock";
         
         // Remove lock
-        $execBash("ssh " & sshUser & "@" & primaryServer & " 'rm -rf " & lockDir & "'");
+        $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(primaryServer) & " 'rm -rf " & $shellEscape(lockDir) & "'");
         
         deployAuditLog("lock_released", {});
     }
@@ -233,6 +233,28 @@ component extends="../base" {
         return trim(result.output);
     }
     
+    /**
+     * Escapes a value for safe use in single-quoted shell strings.
+     * Wraps value in single quotes and escapes any embedded single quotes.
+     * Example: "it's here" -> 'it'\''s here'
+     */
+    string function $shellEscape(required string value) {
+        return "'" & Replace(arguments.value, "'", "'\''", "all") & "'";
+    }
+
+    /**
+     * Validates that a server address is a safe IP or hostname.
+     */
+    string function $validateServerAddress(required string address) {
+        if (!ReFind("^[a-zA-Z0-9\.\-\:]+$", arguments.address)) {
+            Throw(
+                type="Wheels.Deploy.InvalidServerAddress",
+                message="Server address '#arguments.address#' contains invalid characters."
+            );
+        }
+        return arguments.address;
+    }
+
     // Execute bash command helper
     struct function $execBash(required string command) {
         try {

--- a/cli/src/commands/wheels/deploy/exec.cfc
+++ b/cli/src/commands/wheels/deploy/exec.cfc
@@ -68,16 +68,16 @@ component extends="./base" {
                 execCmd &= " -it";
             }
             
-            execCmd &= " #containerName# #arguments.command#";
+            execCmd &= " " & $shellEscape(containerName) & " " & arguments.command;
             
             if (arguments.interactive) {
                 // For interactive mode, use native SSH
                 runCommand(
                     name="ssh",
-                    arguments="-t #sshUser#@#server# '#execCmd#'"
+                    arguments="-t " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " " & $shellEscape(execCmd)
                 );
             } else {
-                var result = $execBash("ssh #sshUser#@#server# '#execCmd#'");
+                var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " " & $shellEscape(execCmd));
                 
                 if (result.exitCode == 0) {
                     if (len(trim(result.output))) {

--- a/cli/src/commands/wheels/deploy/hooks.cfc
+++ b/cli/src/commands/wheels/deploy/hooks.cfc
@@ -194,7 +194,7 @@ component extends="./base" {
         
         // Make executable
         if (arguments.template == "bash") {
-            $execBash("chmod +x #hookFile#");
+            $execBash("chmod +x " & $shellEscape(hookFile));
         }
         
         print.greenLine("✓ Created hook: #arguments.hookName#");

--- a/cli/src/commands/wheels/deploy/lock.cfc
+++ b/cli/src/commands/wheels/deploy/lock.cfc
@@ -65,8 +65,8 @@ component extends="./base" {
         print.line("=".repeatString(50));
         
         // Check if lock exists
-        var checkResult = $execBash("ssh #arguments.user#@#arguments.server# 'test -d #arguments.lockDir# && echo EXISTS || echo FREE'");
-        
+        var checkResult = $execBash("ssh " & $shellEscape(arguments.user) & "@" & $validateServerAddress(arguments.server) & " 'test -d " & $shellEscape(arguments.lockDir) & " && echo EXISTS || echo FREE'");
+
         if (trim(checkResult.output) == "EXISTS" && !arguments.force) {
             // Lock exists, get info
             var lockInfo = getLockInfo(arguments.server, arguments.user, arguments.lockDir);
@@ -100,10 +100,10 @@ component extends="./base" {
         
         // Create lock directory atomically
         if (arguments.force) {
-            $execBash("ssh #arguments.user#@#arguments.server# 'rm -rf #arguments.lockDir#'");
+            $execBash("ssh " & $shellEscape(arguments.user) & "@" & $validateServerAddress(arguments.server) & " 'rm -rf " & $shellEscape(arguments.lockDir) & "'");
         }
-        
-        var createResult = $execBash("ssh #arguments.user#@#arguments.server# 'mkdir -p /opt/.kamal && mkdir #arguments.lockDir# && echo ''#replace(lockJson, "'", "'\''", "all")#'' > #arguments.lockDir#/info.json'");
+
+        var createResult = $execBash("ssh " & $shellEscape(arguments.user) & "@" & $validateServerAddress(arguments.server) & " 'mkdir -p /opt/.kamal && mkdir " & $shellEscape(arguments.lockDir) & " && echo " & $shellEscape(lockJson) & " > " & $shellEscape(arguments.lockDir) & "/info.json'");
         
         if (createResult.exitCode == 0) {
             print.greenLine("✓ Deployment lock acquired successfully");
@@ -126,8 +126,8 @@ component extends="./base" {
         print.line("=".repeatString(50));
         
         // Check if lock exists
-        var checkResult = $execBash("ssh #arguments.user#@#arguments.server# 'test -d #arguments.lockDir# && echo EXISTS || echo FREE'");
-        
+        var checkResult = $execBash("ssh " & $shellEscape(arguments.user) & "@" & $validateServerAddress(arguments.server) & " 'test -d " & $shellEscape(arguments.lockDir) & " && echo EXISTS || echo FREE'");
+
         if (trim(checkResult.output) != "EXISTS") {
             print.yellowLine("No deployment lock found");
             return;
@@ -137,7 +137,7 @@ component extends="./base" {
         var lockInfo = getLockInfo(arguments.server, arguments.user, arguments.lockDir);
         
         // Remove lock
-        var removeResult = $execBash("ssh #arguments.user#@#arguments.server# 'rm -rf #arguments.lockDir#'");
+        var removeResult = $execBash("ssh " & $shellEscape(arguments.user) & "@" & $validateServerAddress(arguments.server) & " 'rm -rf " & $shellEscape(arguments.lockDir) & "'");
         
         if (removeResult.exitCode == 0) {
             print.greenLine("✓ Deployment lock released successfully");
@@ -159,8 +159,8 @@ component extends="./base" {
         print.line("=".repeatString(50));
         
         // Check if lock exists
-        var checkResult = $execBash("ssh #arguments.user#@#arguments.server# 'test -d #arguments.lockDir# && echo EXISTS || echo FREE'");
-        
+        var checkResult = $execBash("ssh " & $shellEscape(arguments.user) & "@" & $validateServerAddress(arguments.server) & " 'test -d " & $shellEscape(arguments.lockDir) & " && echo EXISTS || echo FREE'");
+
         if (trim(checkResult.output) != "EXISTS") {
             print.greenLine("✓ No deployment lock - deployments can proceed");
             return;
@@ -206,7 +206,7 @@ component extends="./base" {
         required string user,
         required string lockDir
     ) {
-        var infoResult = $execBash("ssh #arguments.user#@#arguments.server# 'cat #arguments.lockDir#/info.json 2>/dev/null'");
+        var infoResult = $execBash("ssh " & $shellEscape(arguments.user) & "@" & $validateServerAddress(arguments.server) & " 'cat " & $shellEscape(arguments.lockDir) & "/info.json 2>/dev/null'");
         
         if (infoResult.exitCode == 0 && len(trim(infoResult.output))) {
             try {

--- a/cli/src/commands/wheels/deploy/logs.cfc
+++ b/cli/src/commands/wheels/deploy/logs.cfc
@@ -55,20 +55,20 @@ component extends="./base" {
         
         // Build docker logs command
         var logCmd = "docker logs";
-        
+
         if (arguments.tail > 0 && !arguments.follow) {
-            logCmd &= " --tail #arguments.tail#";
+            logCmd &= " --tail " & int(arguments.tail);
         }
-        
+
         if (arguments.follow) {
             logCmd &= " -f";
         }
-        
+
         if (len(arguments.since)) {
-            logCmd &= " --since #arguments.since#";
+            logCmd &= " --since " & $shellEscape(arguments.since);
         }
-        
-        logCmd &= " #containerName# 2>&1";
+
+        logCmd &= " " & $shellEscape(containerName) & " 2>&1";
         
         // Show logs from each server
         for (var i = 1; i <= arrayLen(targetServers); i++) {
@@ -87,10 +87,10 @@ component extends="./base" {
                 // For follow mode, we need to execute interactively
                 runCommand(
                     name="ssh",
-                    arguments="#sshUser#@#server# '#logCmd#'"
+                    arguments=$shellEscape(sshUser) & "@" & $validateServerAddress(server) & " " & $shellEscape(logCmd)
                 );
             } else {
-                var result = $execBash("ssh #sshUser#@#server# '#logCmd#'");
+                var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " " & $shellEscape(logCmd));
                 
                 if (result.exitCode == 0) {
                     print.line(result.output);

--- a/cli/src/commands/wheels/deploy/proxy.cfc
+++ b/cli/src/commands/wheels/deploy/proxy.cfc
@@ -71,19 +71,17 @@ component extends="./base" {
             print.yellowLine("Booting proxy on #server#...");
             
             // Create proxy directory
-            $execBash("ssh #sshUser#@#server# 'mkdir -p /opt/wheels-proxy'");
+            $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'mkdir -p /opt/wheels-proxy'");
             
             // Create proxy configuration
             var proxyConfig = generateProxyConfig(arguments.config, server);
             
             // Write configuration
-            $execBash("ssh #sshUser#@#server# 'cat > /opt/wheels-proxy/docker-compose.yml << EOF
-#proxyConfig#
-EOF'");
+            $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cat > /opt/wheels-proxy/docker-compose.yml << EOF" & chr(10) & proxyConfig & chr(10) & "EOF'");
             
             // Start proxy
-            var result = $execBash("ssh #sshUser#@#server# 'cd /opt/wheels-proxy && docker compose up -d'");
-            
+            var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/wheels-proxy && docker compose up -d'");
+
             if (result.exitCode == 0) {
                 print.greenLine("✓ Proxy booted on #server#");
                 
@@ -126,7 +124,7 @@ EOF'");
             print.line("-".repeatString(30));
             
             // Check if proxy container is running
-            var result = $execBash("ssh #sshUser#@#server# 'docker ps --filter name=wheels-proxy --format ""{{.Status}}""'");
+            var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker ps --filter name=wheels-proxy --format ""{{.Status}}""'");
             
             if (result.exitCode == 0 && len(trim(result.output))) {
                 if (result.output contains "Up") {
@@ -134,7 +132,7 @@ EOF'");
                     print.line("  Status: #trim(result.output)#");
                     
                     // Check proxy health
-                    var healthResult = $execBash("ssh #sshUser#@#server# 'docker exec wheels-proxy wget -qO- http://localhost/health || echo FAILED'");
+                    var healthResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker exec wheels-proxy wget -qO- http://localhost/health || echo FAILED'");
                     
                     if (trim(healthResult.output) != "FAILED") {
                         print.greenLine("✓ Health Check Passed");
@@ -186,7 +184,7 @@ EOF'");
         for (var server in targetServers) {
             print.yellowLine("Rebooting proxy on #server#...");
             
-            var result = $execBash("ssh #sshUser#@#server# 'cd /opt/wheels-proxy && docker compose restart'");
+            var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/wheels-proxy && docker compose restart'");
             
             if (result.exitCode == 0) {
                 print.greenLine("✓ Proxy rebooted on #server#");
@@ -228,7 +226,7 @@ EOF'");
         for (var server in targetServers) {
             print.yellowLine("Removing proxy from #server#...");
             
-            var result = $execBash("ssh #sshUser#@#server# 'cd /opt/wheels-proxy && docker compose down -v && rm -rf /opt/wheels-proxy'");
+            var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/wheels-proxy && docker compose down -v && rm -rf /opt/wheels-proxy'");
             
             if (result.exitCode == 0) {
                 print.greenLine("✓ Proxy removed from #server#");
@@ -262,7 +260,7 @@ EOF'");
             print.line("-".repeatString(30));
             
             // Get proxy configuration
-            var configResult = $execBash("ssh #sshUser#@#server# 'cat /opt/wheels-proxy/docker-compose.yml 2>/dev/null'");
+            var configResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cat /opt/wheels-proxy/docker-compose.yml 2>/dev/null'");
             
             if (configResult.exitCode == 0) {
                 print.line("Configuration:");
@@ -272,7 +270,7 @@ EOF'");
             }
             
             // Get container details
-            var detailsResult = $execBash("ssh #sshUser#@#server# 'docker inspect wheels-proxy --format ""Name: {{.Name}}\nCreated: {{.Created}}\nState: {{.State.Status}}\nRestarts: {{.RestartCount}}""'");
+            var detailsResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker inspect wheels-proxy --format ""Name: {{.Name}}\nCreated: {{.Created}}\nState: {{.State.Status}}\nRestarts: {{.RestartCount}}""'");
             
             if (detailsResult.exitCode == 0) {
                 print.line();
@@ -341,7 +339,7 @@ EOF'");
     
     private void function configureHealthCheck(required string server, required string user) {
         // Create wheels network if it doesn't exist
-        $execBash("ssh #arguments.user#@#arguments.server# 'docker network create wheels || true'");
+        $execBash("ssh " & $shellEscape(arguments.user) & "@" & $validateServerAddress(arguments.server) & " 'docker network create wheels || true'");
         
         // Create a simple health check response
         var healthConfig = "events {
@@ -357,9 +355,7 @@ http {
     }
 }";
         
-        $execBash("ssh #arguments.user#@#arguments.server# 'mkdir -p /opt/wheels-proxy/config && cat > /opt/wheels-proxy/config/nginx.conf << EOF
-#healthConfig#
-EOF'");
+        $execBash("ssh " & $shellEscape(arguments.user) & "@" & $validateServerAddress(arguments.server) & " 'mkdir -p /opt/wheels-proxy/config && cat > /opt/wheels-proxy/config/nginx.conf << EOF" & chr(10) & healthConfig & chr(10) & "EOF'");
     }
     
     private array function getTargetServers(required struct config, required string servers) {

--- a/cli/src/commands/wheels/deploy/push.cfc
+++ b/cli/src/commands/wheels/deploy/push.cfc
@@ -89,7 +89,7 @@ component extends="./base" {
             print.boldLine("Building Docker image...");
             print.line();
             
-            var buildResult = $execBash("docker build -t #deployConfig.image#:#arguments.tag# -t #imageName# .");
+            var buildResult = $execBash("docker build -t " & $shellEscape(deployConfig.image & ":" & arguments.tag) & " -t " & $shellEscape(imageName) & " .");
             
             if (buildResult.exitCode != 0) {
                 print.redLine("✗ Docker build failed!");
@@ -107,7 +107,7 @@ component extends="./base" {
             
             // Login to registry
             print.yellowLine("Logging into registry...");
-            var loginResult = $execBash("docker login #deployConfig.registry.server# -u #deployConfig.registry.username#");
+            var loginResult = $execBash("docker login " & $shellEscape(deployConfig.registry.server) & " -u " & $shellEscape(deployConfig.registry.username));
             
             if (loginResult.exitCode != 0) {
                 print.redLine("✗ Registry login failed!");
@@ -116,7 +116,7 @@ component extends="./base" {
             }
             
             // Push image
-            var pushResult = $execBash("docker push #imageName#");
+            var pushResult = $execBash("docker push " & $shellEscape(imageName));
             
             if (pushResult.exitCode != 0) {
                 print.redLine("✗ Image push failed!");
@@ -162,20 +162,18 @@ component extends="./base" {
             print.yellowLine("Copying environment configuration...");
             var envPath = fileSystemUtil.resolvePath(".env.deploy");
             if (fileExists(envPath)) {
-                $execBash("scp #envPath# #sshUser#@#server#:/opt/#serviceName#/.env");
+                $execBash("scp " & $shellEscape(envPath) & " " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & ":/opt/" & $shellEscape(serviceName) & "/.env");
             }
             
             // Create docker-compose file for the application
             var composeContent = generateDockerCompose(deployConfig, imageName);
             
             // Write compose file to server
-            $execBash("ssh #sshUser#@#server# 'cat > /opt/#serviceName#/docker-compose.yml << EOF
-#composeContent#
-EOF'");
+            $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cat > /opt/" & $shellEscape(serviceName) & "/docker-compose.yml << EOF" & chr(10) & composeContent & chr(10) & "EOF'");
             
             // Pull new image
             print.yellowLine("Pulling new image...");
-            var pullResult = $execBash("ssh #sshUser#@#server# 'docker pull #imageName#'");
+            var pullResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker pull " & $shellEscape(imageName) & "'");
             
             if (pullResult.exitCode != 0) {
                 print.redLine("✗ Failed to pull image on #server#");
@@ -187,7 +185,7 @@ EOF'");
                 print.yellowLine("Performing rolling deployment...");
                 
                 // Start new container with temporary name
-                $execBash("ssh #sshUser#@#server# 'cd /opt/#serviceName# && docker compose up -d --no-deps --scale #serviceName#=2 #serviceName#'");
+                $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/" & $shellEscape(serviceName) & " && docker compose up -d --no-deps --scale " & $shellEscape(serviceName) & "=2 " & $shellEscape(serviceName) & "'");
                 
                 // Wait for health check
                 print.yellowLine("Waiting for health check...");
@@ -197,21 +195,21 @@ EOF'");
                     print.greenLine("✓ Health check passed");
                     
                     // Remove old container
-                    $execBash("ssh #sshUser#@#server# 'cd /opt/#serviceName# && docker compose up -d --no-deps --remove-orphans #serviceName#'");
+                    $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/" & $shellEscape(serviceName) & " && docker compose up -d --no-deps --remove-orphans " & $shellEscape(serviceName) & "'");
                 } else {
                     print.redLine("✗ Health check failed, rolling back...");
-                    $execBash("ssh #sshUser#@#server# 'cd /opt/#serviceName# && docker compose down'");
+                    $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/" & $shellEscape(serviceName) & " && docker compose down'");
                     continue;
                 }
             } else {
                 // Simple restart
                 print.yellowLine("Restarting application...");
-                $execBash("ssh #sshUser#@#server# 'cd /opt/#serviceName# && docker compose down && docker compose up -d'");
+                $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/" & $shellEscape(serviceName) & " && docker compose down && docker compose up -d'");
             }
             
             // Clean up old images
             print.yellowLine("Cleaning up old images...");
-            $execBash("ssh #sshUser#@#server# 'docker image prune -f'");
+            $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker image prune -f'");
             
             print.greenLine("✓ Deployment to #server# completed");
             print.line();
@@ -369,10 +367,10 @@ networks:
     ) {
         var sshUser = config.ssh.user ?: "root";
         var startTime = getTickCount();
-        var checkUrl = "http://#server#:#config.healthcheck.port##config.healthcheck.path#";
-        
+        var checkUrl = "http://" & server & ":" & config.healthcheck.port & config.healthcheck.path;
+
         while ((getTickCount() - startTime) < (arguments.timeout * 1000)) {
-            var result = $execBash("ssh #sshUser#@#arguments.server# 'curl -f -s -o /dev/null -w ""%{http_code}"" #checkUrl#'");
+            var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(arguments.server) & " 'curl -f -s -o /dev/null -w ""%{http_code}"" " & $shellEscape(checkUrl) & "'");
             
             if (result.exitCode == 0 && trim(result.output) == "200") {
                 return true;

--- a/cli/src/commands/wheels/deploy/rollback.cfc
+++ b/cli/src/commands/wheels/deploy/rollback.cfc
@@ -54,7 +54,7 @@ component extends="./base" {
             
             // Get images from first server
             var server = targetServers[1];
-            var result = $execBash("ssh #sshUser#@#server# 'docker images #imagePattern# --format ""{{.Tag}}\t{{.CreatedAt}}""'");
+            var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker images " & $shellEscape(imagePattern) & " --format ""{{.Tag}}\t{{.CreatedAt}}""'");
             
             if (result.exitCode == 0 && len(trim(result.output))) {
                 var lines = listToArray(result.output, chr(10));
@@ -121,12 +121,12 @@ component extends="./base" {
             
             // Check if image exists locally
             print.yellowLine("Checking for image...");
-            var checkResult = $execBash("ssh #sshUser#@#server# 'docker images -q #imageName#'");
+            var checkResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker images -q " & $shellEscape(imageName) & "'");
             
             if (!len(trim(checkResult.output))) {
                 // Need to pull the image
                 print.yellowLine("Image not found locally, pulling from registry...");
-                var pullResult = $execBash("ssh #sshUser#@#server# 'docker pull #imageName#'");
+                var pullResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker pull " & $shellEscape(imageName) & "'");
                 
                 if (pullResult.exitCode != 0) {
                     print.redLine("✗ Failed to pull image on #server#");
@@ -138,18 +138,16 @@ component extends="./base" {
             print.yellowLine("Updating configuration...");
             var composeContent = generateDockerCompose(deployConfig, imageName);
             
-            $execBash("ssh #sshUser#@#server# 'cat > /opt/#serviceName#/docker-compose.yml << EOF
-#composeContent#
-EOF'");
+            $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cat > /opt/" & $shellEscape(serviceName) & "/docker-compose.yml << EOF" & chr(10) & composeContent & chr(10) & "EOF'");
             
             // Perform rolling restart
             print.yellowLine("Performing rollback...");
             
             // Stop current container
-            $execBash("ssh #sshUser#@#server# 'cd /opt/#serviceName# && docker compose down'");
+            $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/" & $shellEscape(serviceName) & " && docker compose down'");
             
             // Start with rollback image
-            var startResult = $execBash("ssh #sshUser#@#server# 'cd /opt/#serviceName# && docker compose up -d'");
+            var startResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/" & $shellEscape(serviceName) & " && docker compose up -d'");
             
             if (startResult.exitCode != 0) {
                 print.redLine("✗ Rollback failed on #server#");
@@ -262,10 +260,10 @@ networks:
     ) {
         var sshUser = config.ssh.user ?: "root";
         var startTime = getTickCount();
-        var checkUrl = "http://localhost:#config.healthcheck.port##config.healthcheck.path#";
-        
+        var checkUrl = "http://localhost:" & config.healthcheck.port & config.healthcheck.path;
+
         while ((getTickCount() - startTime) < (arguments.timeout * 1000)) {
-            var result = $execBash("ssh #sshUser#@#arguments.server# 'docker exec #config.service# curl -f -s -o /dev/null -w ""%{http_code}"" #checkUrl#'");
+            var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(arguments.server) & " 'docker exec " & $shellEscape(config.service) & " curl -f -s -o /dev/null -w ""%{http_code}"" " & $shellEscape(checkUrl) & "'");
             
             if (result.exitCode == 0 && trim(result.output) == "200") {
                 return true;

--- a/cli/src/commands/wheels/deploy/secrets.cfc
+++ b/cli/src/commands/wheels/deploy/secrets.cfc
@@ -112,7 +112,7 @@ component extends="./base" {
             $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'mkdir -p /opt/" & $shellEscape(serviceName) & "/.kamal'");
             
             // Write secrets file
-            var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cat > /opt/" & $shellEscape(serviceName) & "/.kamal/secrets << EOF" & chr(10) & secretsContent & "EOF" & chr(10) & "chmod 600 /opt/" & $shellEscape(serviceName) & "/.kamal/secrets'");
+            var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cat > /opt/" & $shellEscape(serviceName) & "/.kamal/secrets << EOF" & chr(10) & secretsContent & chr(10) & "EOF" & chr(10) & "chmod 600 /opt/" & $shellEscape(serviceName) & "/.kamal/secrets'");
             
             if (result.exitCode == 0) {
                 print.greenLine("✓ Secrets pushed to #server#");

--- a/cli/src/commands/wheels/deploy/secrets.cfc
+++ b/cli/src/commands/wheels/deploy/secrets.cfc
@@ -109,12 +109,10 @@ component extends="./base" {
             print.yellowLine("Pushing to #server#...");
             
             // Create .kamal directory
-            $execBash("ssh #sshUser#@#server# 'mkdir -p /opt/#serviceName#/.kamal'");
+            $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'mkdir -p /opt/" & $shellEscape(serviceName) & "/.kamal'");
             
             // Write secrets file
-            var result = $execBash("ssh #sshUser#@#server# 'cat > /opt/#serviceName#/.kamal/secrets << EOF
-#secretsContent#
-EOF && chmod 600 /opt/#serviceName#/.kamal/secrets'");
+            var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cat > /opt/" & $shellEscape(serviceName) & "/.kamal/secrets << EOF" & chr(10) & secretsContent & "EOF" & chr(10) & "chmod 600 /opt/" & $shellEscape(serviceName) & "/.kamal/secrets'");
             
             if (result.exitCode == 0) {
                 print.greenLine("✓ Secrets pushed to #server#");
@@ -357,10 +355,10 @@ EOF && chmod 600 /opt/#serviceName#/.kamal/secrets'");
     
     private struct function load1PasswordSecrets(required array keys, required string vault) {
         var secrets = {};
-        var vaultArg = len(arguments.vault) ? "--vault=#arguments.vault#" : "";
-        
+        var vaultArg = len(arguments.vault) ? "--vault=" & $shellEscape(arguments.vault) : "";
+
         for (var key in arguments.keys) {
-            var result = $execBash("op item get #key# #vaultArg# --fields password 2>/dev/null");
+            var result = $execBash("op item get " & $shellEscape(key) & " " & vaultArg & " --fields password 2>/dev/null");
             
             if (result.exitCode == 0 && len(trim(result.output))) {
                 secrets[key] = trim(result.output);
@@ -381,7 +379,7 @@ EOF && chmod 600 /opt/#serviceName#/.kamal/secrets'");
         }
         
         for (var key in arguments.keys) {
-            var result = $execBash("bw get password #key# 2>/dev/null");
+            var result = $execBash("bw get password " & $shellEscape(key) & " 2>/dev/null");
             
             if (result.exitCode == 0 && len(trim(result.output))) {
                 secrets[key] = trim(result.output);
@@ -395,7 +393,7 @@ EOF && chmod 600 /opt/#serviceName#/.kamal/secrets'");
         var secrets = {};
         
         for (var key in arguments.keys) {
-            var result = $execBash("lpass show --password #key# 2>/dev/null");
+            var result = $execBash("lpass show --password " & $shellEscape(key) & " 2>/dev/null");
             
             if (result.exitCode == 0 && len(trim(result.output))) {
                 secrets[key] = trim(result.output);
@@ -413,16 +411,17 @@ EOF && chmod 600 /opt/#serviceName#/.kamal/secrets'");
     ) {
         switch(arguments.manager) {
             case "1password":
-                var vaultArg = len(arguments.vault) ? "--vault=#arguments.vault#" : "";
-                var result = $execBash("op item create --category=password --title=#arguments.key# password=#arguments.value# #vaultArg#");
+                var vaultArg = len(arguments.vault) ? "--vault=" & $shellEscape(arguments.vault) : "";
+                var result = $execBash("op item create --category=password --title=" & $shellEscape(arguments.key) & " password=" & $shellEscape(arguments.value) & " " & vaultArg);
                 return result.exitCode == 0;
-                
+
             case "bitwarden":
-                var result = $execBash("bw create item '{""name"":""#arguments.key#"",""type"":2,""secureNote"":{""type"":0},""notes"":""#arguments.value#""}'");
+                var bwPayload = serializeJSON({"name": arguments.key, "type": 2, "secureNote": {"type": 0}, "notes": arguments.value});
+                var result = $execBash("bw create item " & $shellEscape(bwPayload));
                 return result.exitCode == 0;
-                
+
             case "lastpass":
-                var result = $execBash("echo '#arguments.value#' | lpass add --non-interactive --password #arguments.key#");
+                var result = $execBash("echo " & $shellEscape(arguments.value) & " | lpass add --non-interactive --password " & $shellEscape(arguments.key));
                 return result.exitCode == 0;
         }
         

--- a/cli/src/commands/wheels/deploy/setup.cfc
+++ b/cli/src/commands/wheels/deploy/setup.cfc
@@ -49,7 +49,7 @@ component extends="./base" {
         // Build SSH options
         var sshOptions = "";
         if (len(arguments.sshKey)) {
-            sshOptions = "-i #arguments.sshKey#";
+            sshOptions = "-i " & $shellEscape(arguments.sshKey);
         }
         
         var sshUser = deployConfig.ssh.user ?: "root";
@@ -61,7 +61,7 @@ component extends="./base" {
             
             // Test SSH connection
             print.yellowLine("Testing SSH connection...");
-            var result = $execBash("ssh #sshOptions# -o ConnectTimeout=10 -o StrictHostKeyChecking=no #sshUser#@#server# 'echo Connection successful'");
+            var result = $execBash("ssh " & sshOptions & " -o ConnectTimeout=10 -o StrictHostKeyChecking=no " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'echo Connection successful'");
             
             if (result.exitCode != 0) {
                 print.redLine("✗ Failed to connect to #server#");
@@ -88,7 +88,7 @@ component extends="./base" {
                 ];
                 
                 for (var cmd in dockerCommands) {
-                    result = $execBash("ssh #sshOptions# #sshUser#@#server# '#cmd#'");
+                    result = $execBash("ssh " & sshOptions & " " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " " & $shellEscape(cmd));
                     if (result.exitCode != 0 && !arguments.force) {
                         print.redLine("✗ Docker installation failed");
                         break;
@@ -96,7 +96,7 @@ component extends="./base" {
                 }
                 
                 // Verify Docker installation
-                result = $execBash("ssh #sshOptions# #sshUser#@#server# 'docker --version'");
+                result = $execBash("ssh " & sshOptions & " " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker --version'");
                 if (result.exitCode == 0) {
                     print.greenLine("✓ Docker installed successfully");
                 }
@@ -105,14 +105,14 @@ component extends="./base" {
             // Setup directories
             print.yellowLine("Creating deployment directories...");
             var directories = [
-                "/opt/#deployConfig.service#",
-                "/opt/#deployConfig.service#/config",
-                "/opt/#deployConfig.service#/storage",
-                "/opt/#deployConfig.service#/logs"
+                "/opt/" & deployConfig.service,
+                "/opt/" & deployConfig.service & "/config",
+                "/opt/" & deployConfig.service & "/storage",
+                "/opt/" & deployConfig.service & "/logs"
             ];
-            
+
             for (var dir in directories) {
-                $execBash("ssh #sshOptions# #sshUser#@#server# 'mkdir -p #dir#'");
+                $execBash("ssh " & sshOptions & " " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'mkdir -p " & $shellEscape(dir) & "'");
             }
             print.greenLine("✓ Directories created");
             
@@ -121,10 +121,10 @@ component extends="./base" {
                 print.yellowLine("Setting up Traefik...");
                 
                 // Create Traefik network
-                $execBash("ssh #sshOptions# #sshUser#@#server# 'docker network create traefik || true'");
-                
+                $execBash("ssh " & sshOptions & " " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker network create traefik || true'");
+
                 // Create Traefik directories
-                $execBash("ssh #sshOptions# #sshUser#@#server# 'mkdir -p /opt/traefik /opt/traefik/letsencrypt'");
+                $execBash("ssh " & sshOptions & " " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'mkdir -p /opt/traefik /opt/traefik/letsencrypt'");
                 
                 // Create Traefik config
                 var traefikConfig = "version: '3.8'
@@ -159,12 +159,10 @@ networks:
     external: true";
                 
                 // Write Traefik config to server
-                $execBash("ssh #sshOptions# #sshUser#@#server# 'cat > /opt/traefik/docker-compose.yml << EOF
-#traefikConfig#
-EOF'");
+                $execBash("ssh " & sshOptions & " " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cat > /opt/traefik/docker-compose.yml << EOF" & chr(10) & traefikConfig & chr(10) & "EOF'");
                 
                 // Start Traefik
-                result = $execBash("ssh #sshOptions# #sshUser#@#server# 'cd /opt/traefik && docker compose up -d'");
+                result = $execBash("ssh " & sshOptions & " " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/traefik && docker compose up -d'");
                 
                 if (result.exitCode == 0) {
                     print.greenLine("✓ Traefik setup completed");
@@ -183,7 +181,7 @@ EOF'");
             ];
             
             for (var cmd in firewallCommands) {
-                $execBash("ssh #sshOptions# #sshUser#@#server# '#cmd#' || true");
+                $execBash("ssh " & sshOptions & " " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " " & $shellEscape(cmd) & " || true");
             }
             print.greenLine("✓ Firewall configured");
             

--- a/cli/src/commands/wheels/deploy/status.cfc
+++ b/cli/src/commands/wheels/deploy/status.cfc
@@ -55,7 +55,7 @@ component extends="./base" {
             print.line("-".repeatString(40));
             
             // Check SSH connectivity
-            var sshResult = $execBash("ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no #sshUser#@#server# 'echo OK'");
+            var sshResult = $execBash("ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'echo OK'");
             
             if (sshResult.exitCode != 0) {
                 print.redLine("✗ SSH Connection Failed");
@@ -68,7 +68,7 @@ component extends="./base" {
             print.greenLine("✓ SSH Connection OK");
             
             // Check Docker status
-            var dockerResult = $execBash("ssh #sshUser#@#server# 'docker --version'");
+            var dockerResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker --version'");
             if (dockerResult.exitCode != 0) {
                 print.redLine("✗ Docker Not Available");
                 allHealthy = false;
@@ -77,7 +77,7 @@ component extends="./base" {
             }
             
             // Check container status
-            var containerResult = $execBash("ssh #sshUser#@#server# 'docker ps --filter name=#serviceName# --format ""table {{.Names}}\t{{.Status}}\t{{.Image}}""'");
+            var containerResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker ps --filter name=" & $shellEscape(serviceName) & " --format ""table {{.Names}}\t{{.Status}}\t{{.Image}}""'");
             
             if (containerResult.exitCode == 0 && len(trim(containerResult.output))) {
                 var lines = listToArray(containerResult.output, chr(10));
@@ -117,8 +117,8 @@ component extends="./base" {
             
             // Check health endpoint
             if (structKeyExists(deployConfig, "healthcheck")) {
-                var healthUrl = "http://#server#:#deployConfig.healthcheck.port##deployConfig.healthcheck.path#";
-                var healthResult = $execBash("ssh #sshUser#@#server# 'curl -f -s -o /dev/null -w ""%{http_code}"" #healthUrl#'");
+                var healthUrl = "http://" & server & ":" & deployConfig.healthcheck.port & deployConfig.healthcheck.path;
+                var healthResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'curl -f -s -o /dev/null -w ""%{http_code}"" " & $shellEscape(healthUrl) & "'");
                 
                 if (healthResult.exitCode == 0 && trim(healthResult.output) == "200") {
                     print.greenLine("✓ Health Check Passed");
@@ -134,14 +134,14 @@ component extends="./base" {
                 print.line();
                 print.yellowLine("Container Details:");
                 
-                var inspectResult = $execBash("ssh #sshUser#@#server# 'docker inspect #serviceName# --format ""Created: {{.Created}}\nState: {{.State.Status}}\nRestartCount: {{.RestartCount}}\nPorts: {{range \$p, \$conf := .NetworkSettings.Ports}}{{if \$conf}}{{(index \$conf 0).HostPort}}->{{trimPrefix \""/tcp\"" \$p}} {{end}}{{end}}""'");
+                var inspectResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker inspect " & $shellEscape(serviceName) & " --format ""Created: {{.Created}}\nState: {{.State.Status}}\nRestartCount: {{.RestartCount}}\nPorts: {{range \$p, \$conf := .NetworkSettings.Ports}}{{if \$conf}}{{(index \$conf 0).HostPort}}->{{trimPrefix \""/tcp\"" \$p}} {{end}}{{end}}""'");
                 
                 if (inspectResult.exitCode == 0) {
                     print.line(inspectResult.output);
                 }
                 
                 // Check disk usage
-                var dfResult = $execBash("ssh #sshUser#@#server# 'df -h /opt/#serviceName# | tail -1'");
+                var dfResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'df -h /opt/" & $shellEscape(serviceName) & " | tail -1'");
                 if (dfResult.exitCode == 0) {
                     var dfParts = reReplace(trim(dfResult.output), "\s+", "|", "all");
                     var dfArray = listToArray(dfParts, "|");
@@ -156,7 +156,7 @@ component extends="./base" {
                 print.line();
                 print.yellowLine("Recent Logs:");
                 
-                var logsResult = $execBash("ssh #sshUser#@#server# 'docker logs --tail 20 #serviceName# 2>&1'");
+                var logsResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker logs --tail 20 " & $shellEscape(serviceName) & " 2>&1'");
                 if (logsResult.exitCode == 0) {
                     print.line("-".repeatString(40));
                     print.line(logsResult.output);
@@ -169,7 +169,7 @@ component extends="./base" {
                 print.line();
                 print.yellowLine("Database Status:");
                 
-                var dbResult = $execBash("ssh #sshUser#@#server# 'docker ps --filter name=#serviceName#_db --format ""{{.Status}}""'");
+                var dbResult = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'docker ps --filter name=" & $shellEscape(serviceName & "_db") & " --format ""{{.Status}}""'");
                 
                 if (dbResult.exitCode == 0 && len(trim(dbResult.output))) {
                     if (dbResult.output contains "Up") {

--- a/cli/src/commands/wheels/deploy/stop.cfc
+++ b/cli/src/commands/wheels/deploy/stop.cfc
@@ -72,7 +72,7 @@ component extends="./base" {
             var action = arguments.remove ? "down" : "stop";
             
             print.yellowLine("Stopping containers...");
-            var result = $execBash("ssh #sshUser#@#server# 'cd /opt/#serviceName# && docker compose #action#'");
+            var result = $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/" & $shellEscape(serviceName) & " && docker compose " & action & "'");
             
             if (result.exitCode == 0) {
                 print.greenLine("✓ Containers stopped successfully");
@@ -80,7 +80,7 @@ component extends="./base" {
                 if (arguments.remove) {
                     // Clean up volumes if removing
                     print.yellowLine("Cleaning up volumes...");
-                    $execBash("ssh #sshUser#@#server# 'cd /opt/#serviceName# && docker compose down -v'");
+                    $execBash("ssh " & $shellEscape(sshUser) & "@" & $validateServerAddress(server) & " 'cd /opt/" & $shellEscape(serviceName) & " && docker compose down -v'");
                 }
             } else {
                 print.redLine("✗ Failed to stop containers");


### PR DESCRIPTION
## Summary
- Adds `$shellEscape()` utility to `deploy/base.cfc` — wraps values in single quotes with proper escaping (`'` → `'\''`)
- Adds `$validateServerAddress()` — rejects server addresses containing shell metacharacters
- Applies escaping to all 83 `$execBash()` call sites across 12 deploy command files
- Critical fix in `secrets.cfc` where credential values were interpolated directly into shell commands (1Password, Bitwarden, LastPass CLIs)

## Files changed
All 12 files in `cli/src/commands/wheels/deploy/`: base, exec, hooks, lock, logs, proxy, push, rollback, secrets, setup, status, stop

## Test plan
- [ ] Verify no raw config interpolation remains: `grep -rn '\$execBash(".*#' cli/src/commands/wheels/deploy/` should show only escaped patterns
- [ ] Manual test: `wheels deploy:status` with a test deploy.json
- [ ] Review `secrets.cfc` changes for correct quoting in 1Password/Bitwarden/LastPass CLI calls