### PR TITLE
fix(model): parameterize enum scope WHERE clauses and harden scope handler sanitization

### DIFF
--- a/vendor/wheels/model/properties.cfc
+++ b/vendor/wheels/model/properties.cfc
@@ -712,6 +712,10 @@ component {
 	 * Escapes a string value for safe inclusion in a SQL literal.
 	 * Strips null bytes, doubles backslashes (MySQL escape sequences), and doubles single quotes.
 	 *
+	 * DEPRECATED: Prefer parameterized queries (cfqueryparam / whereParams) over string escaping.
+	 * This function is retained for backwards compatibility with existing scope handlers
+	 * that use string interpolation in WHERE clauses.
+	 *
 	 * @value The string value to escape.
 	 */
 	public string function $escapeSqlValue(required string value) {
@@ -736,11 +740,17 @@ component {
 		for (local.key in arguments.args) {
 			local.val = arguments.args[local.key];
 			if (IsSimpleValue(local.val)) {
+				// Strip null bytes
+				local.val = Replace(local.val, Chr(0), "", "all");
 				// Strip SQL comment/statement markers before escaping
 				local.val = Replace(local.val, "--", "", "all");
 				local.val = Replace(local.val, "/*", "", "all");
 				local.val = Replace(local.val, "*/", "", "all");
 				local.val = Replace(local.val, ";", "", "all");
+				// Strip dangerous SQL keywords that could be used for injection.
+				// Word-boundary matching prevents false positives in normal values.
+				local.val = REReplaceNoCase(local.val, "\b(UNION|EXEC|EXECUTE|BENCHMARK|SLEEP)\b", "", "all");
+				local.val = REReplaceNoCase(local.val, "\bxp_\w*", "", "all");
 				local.sanitized[local.key] = $escapeSqlValue(local.val);
 			} else {
 				local.sanitized[local.key] = local.val;
@@ -900,9 +910,15 @@ component {
 					extendedInfo = "Enum values must contain only alphanumeric characters, underscores, hyphens, spaces, and dots. Received: `#local.storedValue#`"
 				);
 			}
-			local.escapedValue = $escapeSqlValue(ToString(local.storedValue));
 			local.scopeDef = {};
-			local.scopeDef.where = "#arguments.property# = '#local.escapedValue#'";
+			// Store value in whereParams for parameterized execution rather than
+			// interpolating into the WHERE string. ScopeChain.$mergeSpecs() resolves
+			// these into quoted values that $whereClause() re-parameterizes via cfqueryparam.
+			local.scopeDef.where = "#arguments.property# = ?";
+			local.scopeDef.whereParams = [{
+				value: ToString(local.storedValue),
+				type: "CF_SQL_VARCHAR"
+			}];
 			variables.wheels.class.scopes[local.name] = local.scopeDef;
 		}
 	}

--- a/vendor/wheels/model/query/ScopeChain.cfc
+++ b/vendor/wheels/model/query/ScopeChain.cfc
@@ -29,10 +29,20 @@ component output="false" {
 		for (local.spec in variables.specs) {
 			// Merge WHERE clauses with AND
 			if (StructKeyExists(local.spec, "where") && Len(local.spec.where)) {
+				local.resolvedWhere = local.spec.where;
+				// If the scope carries whereParams, resolve ? placeholders into quoted values.
+				// The downstream SQL builder ($whereClause) will re-extract these via RESQLWhere
+				// regex and convert them into cfqueryparam parameters for true parameterized execution.
+				if (StructKeyExists(local.spec, "whereParams") && IsArray(local.spec.whereParams)) {
+					for (local.p in local.spec.whereParams) {
+						local.quotedVal = "'" & variables.modelReference.$escapeSqlValue(ToString(local.p.value)) & "'";
+						local.resolvedWhere = Replace(local.resolvedWhere, "?", local.quotedVal, "one");
+					}
+				}
 				if (StructKeyExists(local.merged, "where") && Len(local.merged.where)) {
-					local.merged.where = "(#local.merged.where#) AND (#local.spec.where#)";
+					local.merged.where = "(#local.merged.where#) AND (#local.resolvedWhere#)";
 				} else {
-					local.merged.where = local.spec.where;
+					local.merged.where = local.resolvedWhere;
 				}
 			}
 			// Append ORDER BY clauses

--- a/vendor/wheels/tests/specs/model/enumScopeEscapingSpec.cfc
+++ b/vendor/wheels/tests/specs/model/enumScopeEscapingSpec.cfc
@@ -2,48 +2,44 @@ component extends="wheels.WheelsTest" {
 
 	function run() {
 
-		g = application.wo
-
 		describe("Tests that enum scope WHERE clauses", () => {
 
-			beforeEach(() => {
-				g.$clearModelInitializationCache()
-			})
-
-			afterEach(() => {
-				g.$clearModelInitializationCache()
-			})
-
-			it("generates correct WHERE for simple string values", () => {
-				var m = g.model("post")
+			it("generates parameterized WHERE for simple string values", () => {
+				var m = application.wo.model("author")
 				m.enum(property="status", values="draft,published,archived")
 				var scopes = m.scopeInfo()
 
 				expect(scopes).toHaveKey("draft")
 				expect(scopes.draft).toHaveKey("where")
-				expect(scopes.draft.where).toBe("status = 'draft'")
+				expect(scopes.draft.where).toBe("status = ?")
+				expect(scopes.draft).toHaveKey("whereParams")
+				expect(scopes.draft.whereParams[1].value).toBe("draft")
 
 				expect(scopes).toHaveKey("published")
-				expect(scopes.published.where).toBe("status = 'published'")
+				expect(scopes.published.where).toBe("status = ?")
+				expect(scopes.published.whereParams[1].value).toBe("published")
 
 				expect(scopes).toHaveKey("archived")
-				expect(scopes.archived.where).toBe("status = 'archived'")
+				expect(scopes.archived.where).toBe("status = ?")
+				expect(scopes.archived.whereParams[1].value).toBe("archived")
 			})
 
-			it("generates correct WHERE for struct-mapped values", () => {
-				var m = g.model("post")
+			it("generates parameterized WHERE for struct-mapped values", () => {
+				var m = application.wo.model("author")
 				m.enum(property="priority", values={low: 0, medium: 1, high: 2})
 				var scopes = m.scopeInfo()
 
 				expect(scopes).toHaveKey("low")
-				expect(scopes.low.where).toBe("priority = '0'")
+				expect(scopes.low.where).toBe("priority = ?")
+				expect(scopes.low.whereParams[1].value).toBe("0")
 
 				expect(scopes).toHaveKey("high")
-				expect(scopes.high.where).toBe("priority = '2'")
+				expect(scopes.high.where).toBe("priority = ?")
+				expect(scopes.high.whereParams[1].value).toBe("2")
 			})
 
 			it("rejects enum values containing single quotes", () => {
-				var m = g.model("post")
+				var m = application.wo.model("author")
 
 				expect(function() {
 					m.enum(property="status", values={it_s_fine: "it's fine", normal: "normal"})
@@ -51,7 +47,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("rejects enum values containing SQL injection patterns", () => {
-				var m = g.model("post")
+				var m = application.wo.model("author")
 
 				expect(function() {
 					m.enum(property="status", values={dangerous: "'; DROP TABLE users; --"})
@@ -59,31 +55,36 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("allows enum values with hyphens spaces and dots", () => {
-				var m = g.model("post")
+				var m = application.wo.model("author")
 				m.enum(property="status", values={my_val: "some-value", other: "v1.0", spaced: "hello world"})
 				var scopes = m.scopeInfo()
 
 				expect(scopes).toHaveKey("my_val")
-				expect(scopes.my_val.where).toBe("status = 'some-value'")
+				expect(scopes.my_val.where).toBe("status = ?")
+				expect(scopes.my_val.whereParams[1].value).toBe("some-value")
 
 				expect(scopes).toHaveKey("other")
-				expect(scopes.other.where).toBe("status = 'v1.0'")
+				expect(scopes.other.where).toBe("status = ?")
+				expect(scopes.other.whereParams[1].value).toBe("v1.0")
 
 				expect(scopes).toHaveKey("spaced")
-				expect(scopes.spaced.where).toBe("status = 'hello world'")
+				expect(scopes.spaced.where).toBe("status = ?")
+				expect(scopes.spaced.whereParams[1].value).toBe("hello world")
 			})
 
 			it("allows numeric enum stored values", () => {
-				var m = g.model("post")
+				var m = application.wo.model("author")
 				m.enum(property="priority", values={low: 0, medium: 1, high: 2})
 				var scopes = m.scopeInfo()
 
 				expect(scopes).toHaveKey("low")
-				expect(scopes.low.where).toBe("priority = '0'")
+				expect(scopes.low.where).toBe("priority = ?")
+				expect(scopes.low.whereParams[1].value).toBe("0")
+				expect(scopes.low.whereParams[1].type).toBe("CF_SQL_VARCHAR")
 			})
 
 			it("rejects property names with invalid characters", () => {
-				var m = g.model("post")
+				var m = application.wo.model("author")
 
 				expect(function() {
 					m.enum(property="status; DROP TABLE", values="draft")
@@ -91,7 +92,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("rejects property names starting with a number", () => {
-				var m = g.model("post")
+				var m = application.wo.model("author")
 
 				expect(function() {
 					m.enum(property="1status", values="draft")
@@ -99,12 +100,13 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("allows property names with underscores", () => {
-				var m = g.model("post")
+				var m = application.wo.model("author")
 				m.enum(property="_my_status", values="draft,published")
 				var scopes = m.scopeInfo()
 
 				expect(scopes).toHaveKey("draft")
-				expect(scopes.draft.where).toBe("_my_status = 'draft'")
+				expect(scopes.draft.where).toBe("_my_status = ?")
+				expect(scopes.draft.whereParams[1].value).toBe("draft")
 			})
 		})
 	}

--- a/vendor/wheels/tests/specs/model/enumScopeEscapingSpec.cfc
+++ b/vendor/wheels/tests/specs/model/enumScopeEscapingSpec.cfc
@@ -2,10 +2,20 @@ component extends="wheels.WheelsTest" {
 
 	function run() {
 
+		g = application.wo
+
 		describe("Tests that enum scope WHERE clauses", () => {
 
+			beforeEach(() => {
+				g.$clearModelInitializationCache()
+			})
+
+			afterEach(() => {
+				g.$clearModelInitializationCache()
+			})
+
 			it("generates parameterized WHERE for simple string values", () => {
-				var m = application.wo.model("author")
+				var m = g.model("author")
 				m.enum(property="status", values="draft,published,archived")
 				var scopes = m.scopeInfo()
 
@@ -25,7 +35,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("generates parameterized WHERE for struct-mapped values", () => {
-				var m = application.wo.model("author")
+				var m = g.model("author")
 				m.enum(property="priority", values={low: 0, medium: 1, high: 2})
 				var scopes = m.scopeInfo()
 
@@ -39,7 +49,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("rejects enum values containing single quotes", () => {
-				var m = application.wo.model("author")
+				var m = g.model("author")
 
 				expect(function() {
 					m.enum(property="status", values={it_s_fine: "it's fine", normal: "normal"})
@@ -47,7 +57,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("rejects enum values containing SQL injection patterns", () => {
-				var m = application.wo.model("author")
+				var m = g.model("author")
 
 				expect(function() {
 					m.enum(property="status", values={dangerous: "'; DROP TABLE users; --"})
@@ -55,7 +65,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("allows enum values with hyphens spaces and dots", () => {
-				var m = application.wo.model("author")
+				var m = g.model("author")
 				m.enum(property="status", values={my_val: "some-value", other: "v1.0", spaced: "hello world"})
 				var scopes = m.scopeInfo()
 
@@ -73,7 +83,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("allows numeric enum stored values", () => {
-				var m = application.wo.model("author")
+				var m = g.model("author")
 				m.enum(property="priority", values={low: 0, medium: 1, high: 2})
 				var scopes = m.scopeInfo()
 
@@ -84,7 +94,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("rejects property names with invalid characters", () => {
-				var m = application.wo.model("author")
+				var m = g.model("author")
 
 				expect(function() {
 					m.enum(property="status; DROP TABLE", values="draft")
@@ -92,7 +102,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("rejects property names starting with a number", () => {
-				var m = application.wo.model("author")
+				var m = g.model("author")
 
 				expect(function() {
 					m.enum(property="1status", values="draft")
@@ -100,7 +110,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("allows property names with underscores", () => {
-				var m = application.wo.model("author")
+				var m = g.model("author")
 				m.enum(property="_my_status", values="draft,published")
 				var scopes = m.scopeInfo()
 

--- a/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
+++ b/vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc
@@ -145,6 +145,40 @@ component extends="wheels.WheelsTest" {
 				expect(result["1"]).toBe("val'' DROP TABLE x comment end");
 			});
 
+			it("strips UNION keyword from injection attempts", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "foo UNION SELECT password FROM users"});
+
+				expect(result["1"]).notToInclude("UNION");
+			});
+
+			it("strips EXEC and EXECUTE keywords", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "EXEC xp_cmdshell"});
+
+				expect(result["1"]).notToInclude("EXEC");
+				expect(result["1"]).notToInclude("xp_");
+			});
+
+			it("strips BENCHMARK and SLEEP keywords", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "BENCHMARK(10000000,SHA1('test'))"});
+
+				expect(result["1"]).notToInclude("BENCHMARK");
+
+				var result2 = m.$sanitizeScopeHandlerArgs({"1": "SLEEP(5)"});
+
+				expect(result2["1"]).notToInclude("SLEEP");
+			});
+
+			it("does not strip partial keyword matches in normal values", () => {
+				var m = application.wo.model("author");
+				var result = m.$sanitizeScopeHandlerArgs({"1": "executor"});
+
+				// "executor" should remain because EXEC is not a whole-word match
+				expect(result["1"]).toBe("executor");
+			});
+
 		});
 
 	}

--- a/vendor/wheels/tests/specs/security/EnumScopeEscapingSpec.cfc
+++ b/vendor/wheels/tests/specs/security/EnumScopeEscapingSpec.cfc
@@ -4,7 +4,7 @@ component extends="wheels.WheelsTest" {
 
 		g = application.wo
 
-		describe("Tests that enum scope WHERE clauses", () => {
+		describe("Tests that enum scope WHERE clauses use parameterized queries", () => {
 
 			beforeEach(() => {
 				g.$clearModelInitializationCache()
@@ -14,56 +14,83 @@ component extends="wheels.WheelsTest" {
 				g.$clearModelInitializationCache()
 			})
 
-			it("generates correct WHERE for simple string values", () => {
-				var m = g.model("post")
+			it("generates parameterized WHERE with placeholder for simple string values", () => {
+				var m = g.model("author")
 				m.enum(property="status", values="draft,published,archived")
 				var scopes = m.$classData().scopes
 
 				expect(scopes).toHaveKey("draft")
 				expect(scopes.draft).toHaveKey("where")
-				expect(scopes.draft.where).toBe("status = 'draft'")
+				expect(scopes.draft.where).toBe("status = ?")
+				expect(scopes.draft).toHaveKey("whereParams")
+				expect(scopes.draft.whereParams).toBeArray()
+				expect(scopes.draft.whereParams).toHaveLength(1)
+				expect(scopes.draft.whereParams[1].value).toBe("draft")
+				expect(scopes.draft.whereParams[1].type).toBe("CF_SQL_VARCHAR")
 
 				expect(scopes).toHaveKey("published")
-				expect(scopes.published.where).toBe("status = 'published'")
+				expect(scopes.published.where).toBe("status = ?")
+				expect(scopes.published.whereParams[1].value).toBe("published")
 
 				expect(scopes).toHaveKey("archived")
-				expect(scopes.archived.where).toBe("status = 'archived'")
+				expect(scopes.archived.where).toBe("status = ?")
+				expect(scopes.archived.whereParams[1].value).toBe("archived")
 			})
 
-			it("generates correct WHERE for struct-mapped values", () => {
-				var m = g.model("post")
+			it("generates parameterized WHERE for struct-mapped values", () => {
+				var m = g.model("author")
 				m.enum(property="priority", values={low: 0, medium: 1, high: 2})
 				var scopes = m.$classData().scopes
 
 				expect(scopes).toHaveKey("low")
-				expect(scopes.low.where).toBe("priority = '0'")
+				expect(scopes.low.where).toBe("priority = ?")
+				expect(scopes.low.whereParams[1].value).toBe("0")
 
 				expect(scopes).toHaveKey("high")
-				expect(scopes.high.where).toBe("priority = '2'")
+				expect(scopes.high.where).toBe("priority = ?")
+				expect(scopes.high.whereParams[1].value).toBe("2")
 			})
 
 			it("allows enum values with hyphens spaces and dots", () => {
-				var m = g.model("post")
+				var m = g.model("author")
 				m.enum(property="status", values={my_val: "some-value", other: "v1.0", spaced: "hello world"})
 				var scopes = m.$classData().scopes
 
 				expect(scopes).toHaveKey("my_val")
-				expect(scopes.my_val.where).toBe("status = 'some-value'")
+				expect(scopes.my_val.where).toBe("status = ?")
+				expect(scopes.my_val.whereParams[1].value).toBe("some-value")
 
 				expect(scopes).toHaveKey("other")
-				expect(scopes.other.where).toBe("status = 'v1.0'")
+				expect(scopes.other.where).toBe("status = ?")
+				expect(scopes.other.whereParams[1].value).toBe("v1.0")
 
 				expect(scopes).toHaveKey("spaced")
-				expect(scopes.spaced.where).toBe("status = 'hello world'")
+				expect(scopes.spaced.where).toBe("status = ?")
+				expect(scopes.spaced.whereParams[1].value).toBe("hello world")
 			})
 
 			it("allows numeric enum stored values", () => {
-				var m = g.model("post")
+				var m = g.model("author")
 				m.enum(property="priority", values={low: 0, medium: 1, high: 2})
 				var scopes = m.$classData().scopes
 
 				expect(scopes).toHaveKey("low")
-				expect(scopes.low.where).toBe("priority = '0'")
+				expect(scopes.low.where).toBe("priority = ?")
+				expect(scopes.low.whereParams[1].value).toBe("0")
+				expect(scopes.low.whereParams[1].type).toBe("CF_SQL_VARCHAR")
+			})
+
+			it("resolves whereParams into quoted values during scope merge", () => {
+				var m = g.model("author")
+				m.enum(property="status", values="draft,published")
+				var chain = new wheels.model.query.ScopeChain(
+					modelReference = m,
+					specs = [m.$classData().scopes["draft"]]
+				)
+				var merged = chain.$mergeSpecs()
+
+				expect(merged).toHaveKey("where")
+				expect(merged.where).toBe("status = 'draft'")
 			})
 
 		})

--- a/vendor/wheels/tests/specs/security/EnumScopeSqlSpec.cfc
+++ b/vendor/wheels/tests/specs/security/EnumScopeSqlSpec.cfc
@@ -1,0 +1,96 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("Enum scope SQL parameterization security", () => {
+
+			beforeEach(() => {
+				g.$clearModelInitializationCache()
+			})
+
+			afterEach(() => {
+				g.$clearModelInitializationCache()
+			})
+
+			it("stores whereParams with type metadata instead of interpolated values", () => {
+				var m = g.model("author")
+				m.enum(property="status", values="draft,published")
+				var scopes = m.$classData().scopes
+
+				expect(scopes.draft.where).toBe("status = ?")
+				expect(scopes.draft.whereParams).toBeArray()
+				expect(scopes.draft.whereParams[1]).toHaveKey("value")
+				expect(scopes.draft.whereParams[1]).toHaveKey("type")
+				expect(scopes.draft.whereParams[1].type).toBe("CF_SQL_VARCHAR")
+			})
+
+			it("rejects enum values containing SQL injection characters", () => {
+				var m = g.model("author")
+
+				expect(function() {
+					m.enum(property="status", values={bad: "'; DROP TABLE users; --"})
+				}).toThrow("Wheels.InvalidEnumValue")
+			})
+
+			it("rejects enum property names with SQL injection patterns", () => {
+				var m = g.model("author")
+
+				expect(function() {
+					m.enum(property="status; DROP TABLE", values="draft")
+				}).toThrow("Wheels.InvalidPropertyName")
+			})
+
+			it("scope merge resolves whereParams into quoted values for downstream parameterization", () => {
+				var m = g.model("author")
+				m.enum(property="status", values="active,inactive")
+				var chain = new wheels.model.query.ScopeChain(
+					modelReference = m,
+					specs = [m.$classData().scopes["active"]]
+				)
+				var merged = chain.$mergeSpecs()
+
+				// The merged where should have the value quoted for the RESQLWhere regex to extract
+				expect(merged.where).toBe("status = 'active'")
+			})
+
+			it("scope merge resolves multiple chained enum scopes correctly", () => {
+				var m = g.model("author")
+				m.enum(property="status", values="draft,published")
+				// Manually define a second parameterized scope for testing
+				m.scope(name="recent", where="createdAt > '2024-01-01'")
+				var specs = [
+					m.$classData().scopes["draft"],
+					m.$classData().scopes["recent"]
+				]
+				var chain = new wheels.model.query.ScopeChain(
+					modelReference = m,
+					specs = specs
+				)
+				var merged = chain.$mergeSpecs()
+
+				expect(merged.where).toInclude("status = 'draft'")
+				expect(merged.where).toInclude("AND")
+				expect(merged.where).toInclude("createdAt > '2024-01-01'")
+			})
+
+			it("sanitizes dangerous SQL keywords in scope handler arguments", () => {
+				var m = g.model("author")
+				var result = m.$sanitizeScopeHandlerArgs({"1": "admin' UNION SELECT password FROM users --"})
+
+				expect(result["1"]).notToInclude("UNION")
+				expect(result["1"]).notToInclude("--")
+			})
+
+			it("sanitizes SLEEP and BENCHMARK time-based injection in scope handler args", () => {
+				var m = g.model("author")
+				var result = m.$sanitizeScopeHandlerArgs({"1": "1 OR SLEEP(5)"})
+
+				expect(result["1"]).notToInclude("SLEEP")
+			})
+
+		})
+	}
+
+}


### PR DESCRIPTION
## Summary
- Enum scopes now use `whereParams` metadata with `?` placeholders instead of string-interpolated values. `ScopeChain.$mergeSpecs()` resolves these into quoted values that the downstream `$whereClause()` regex re-parameterizes via `cfqueryparam`, providing defense-in-depth.
- `$sanitizeScopeHandlerArgs()` now strips null bytes early and blocks dangerous SQL keywords (`UNION`, `EXEC`, `EXECUTE`, `BENCHMARK`, `SLEEP`, `xp_*`) via word-boundary regex.
- Added deprecation notice to `$escapeSqlValue()` directing new code toward parameterized queries.

## Test plan
- [x] `vendor/wheels/tests/specs/model/enumScopeEscapingSpec.cfc` — 9 tests covering parameterized WHERE generation, validation rejection, and edge cases
- [x] `vendor/wheels/tests/specs/model/scopeHandlerSanitizationSpec.cfc` — 23 tests including 4 new tests for UNION/EXEC/BENCHMARK/SLEEP/xp_ keyword stripping
- [x] `vendor/wheels/tests/specs/security/EnumScopeEscapingSpec.cfc` — 5 tests covering parameterization and scope merge resolution
- [x] `vendor/wheels/tests/specs/security/EnumScopeSqlSpec.cfc` — 7 new tests covering whereParams metadata, scope merge chaining, and sanitization of time-based injection patterns
- [ ] CI: Run full test matrix (Lucee + Adobe CF x SQLite/MySQL/PostgreSQL)