### PR TITLE
fix(cli): suppress exception details in mcp error responses

### DIFF
--- a/vendor/wheels/public/views/mcp.cfm
+++ b/vendor/wheels/public/views/mcp.cfm
@@ -167,7 +167,7 @@ try {
 				"error": {
 					"code": -32700,
 					"message": "Parse error",
-					"data": e.message
+					"data": "Request body is not valid JSON"
 				}
 			};
 			local.errorResponse["id"] = javaCast("null", "");
@@ -197,13 +197,24 @@ try {
 	}));
 
 } catch (any e) {
-	// Handle unexpected errors
+	try {
+		writeLog(
+			file="wheels_mcp",
+			type="error",
+			text="MCP error: " & e.message & " | Detail: " & (structKeyExists(e, "detail") ? e.detail : "")
+		);
+	} catch (any logErr) {
+		// Fail silently if logging fails
+	}
 	cfheader(statusCode="500");
 	cfheader(name="Content-Type", value="application/json");
 	writeOutput(serializeJSON({
-		"error": "Internal server error",
-		"message": e.message,
-		"detail": structKeyExists(e, "detail") ? e.detail : ""
+		"jsonrpc": "2.0",
+		"error": {
+			"code": -32603,
+			"message": "Internal error"
+		},
+		"id": javaCast("null", "")
 	}));
 }
 </cfscript>


### PR DESCRIPTION
## Summary
- Replace leaked `e.message` and `e.detail` in MCP endpoint error responses with generic messages
- JSON parse errors now return static "Request body is not valid JSON" instead of exception details
- Top-level catch block logs exception details server-side to `wheels_mcp` log file and returns a proper JSON-RPC 2.0 error response with code `-32603`

## Test plan
- [x] Verified test suite passes (all failures are pre-existing, unrelated to MCP)
- [ ] Manual: send malformed JSON to `/wheels/mcp` — should get generic error, not exception details
- [ ] Manual: trigger a server error — should see `Internal error` response, details in `wheels_mcp.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)