### PR TITLE
fix(cli): remove unnecessary cors headers from mcp endpoint

### DIFF
--- a/vendor/wheels/public/views/mcp.cfm
+++ b/vendor/wheels/public/views/mcp.cfm
@@ -39,14 +39,11 @@ if (!listFind("127.0.0.1,::1,0:0:0:0:0:0:0:1", local.remoteAddr)) {
 	abort;
 }
 
-// Set CORS headers for localhost-only requests
-cfheader(name="Access-Control-Allow-Origin", value="http://localhost");
-cfheader(name="Access-Control-Allow-Methods", value="GET, POST, OPTIONS");
-cfheader(name="Access-Control-Allow-Headers", value="Content-Type, Accept, Mcp-Session-Id");
-
-// Handle OPTIONS preflight requests
+// Handle OPTIONS requests — CORS is unnecessary since endpoint is localhost-only
 if (cgi.request_method == "OPTIONS") {
-	cfheader(statusCode="200");
+	cfheader(statusCode="405");
+	cfheader(name="Content-Type", value="application/json");
+	writeOutput(serializeJSON({"error": "OPTIONS method not supported"}));
 	abort;
 }
 


### PR DESCRIPTION
## Summary
- Remove static CORS headers (`Access-Control-Allow-Origin`, `Allow-Methods`, `Allow-Headers`) from the MCP endpoint — they are redundant since the endpoint is already restricted to localhost via `cgi.REMOTE_ADDR` check
- Change OPTIONS handler from 200 OK (CORS preflight) to 405 Method Not Allowed since CORS is no longer supported

## Test plan
- [x] Verify CORS headers no longer appear on MCP responses
- [x] Verify OPTIONS requests return 405 with JSON error body
- [x] Run full test suite (2661 pass, 6 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)