### PR TITLE
fix(config): add rate limiting and constant-time comparison to reload endpoint

### DIFF
--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -128,20 +128,70 @@ component {
 			application.$wheels.allowEnvironmentSwitchViaUrl = false;
 		}
 
+		// Rate limit reload attempts: 5 failed password attempts within 5 minutes locks the IP
+		if (!StructKeyExists(application, "$reloadRateLimit")) {
+			application.$reloadRateLimit = {};
+		}
+		local.reloadRateLimitKey = cgi.REMOTE_ADDR;
+		local.reloadRateLimited = false;
+		if (StructKeyExists(application.$reloadRateLimit, local.reloadRateLimitKey)) {
+			local.rl = application.$reloadRateLimit[local.reloadRateLimitKey];
+			if (local.rl.count >= 5 && DateDiff("n", local.rl.firstAttempt, Now()) < 5) {
+				local.reloadRateLimited = true;
+			}
+			if (DateDiff("n", local.rl.firstAttempt, Now()) >= 5) {
+				StructDelete(application.$reloadRateLimit, local.reloadRateLimitKey);
+			}
+		}
+
 		// Set environment either from the url or the developer's environment.cfm file.
+		local.reloadPasswordMatched = false;
 		if (
-			StructKeyExists(URL, "reload")
+			!local.reloadRateLimited
+			&& StructKeyExists(URL, "reload")
 			&& !IsBoolean(URL.reload)
 			&& Len(url.reload)
 			&& StructKeyExists(application.$wheels, "reloadPassword")
 			&& (
 				!Len(application.$wheels.reloadPassword)
-				|| (StructKeyExists(URL, "password") && Compare(Hash(URL.password, "SHA-256"), Hash(application.$wheels.reloadPassword, "SHA-256")) == 0)
+				|| (
+					StructKeyExists(URL, "password")
+					&& CreateObject("java", "java.security.MessageDigest").isEqual(
+						Hash(URL.password, "SHA-256").getBytes("UTF-8"),
+						Hash(application.$wheels.reloadPassword, "SHA-256").getBytes("UTF-8")
+					)
+				)
 			)
 		) {
+			local.reloadPasswordMatched = true;
 			application.$wheels.environment = URL.reload;
 		} else {
 			application.wo.$include(template = "/config/environment.cfm");
+		}
+
+		// Track failed reload password attempts
+		if (
+			StructKeyExists(URL, "reload")
+			&& StructKeyExists(URL, "password")
+			&& !local.reloadRateLimited
+			&& !local.reloadPasswordMatched
+		) {
+			if (!StructKeyExists(application.$reloadRateLimit, local.reloadRateLimitKey)) {
+				application.$reloadRateLimit[local.reloadRateLimitKey] = {count: 0, firstAttempt: Now()};
+			}
+			application.$reloadRateLimit[local.reloadRateLimitKey].count++;
+			try {
+				writeLog(file="wheels_security", type="warning", text="Reload password rejected from #cgi.REMOTE_ADDR#");
+			} catch (any e) {
+			}
+		}
+
+		// Log successful reload
+		if (local.reloadPasswordMatched) {
+			try {
+				writeLog(file="wheels_security", type="information", text="Reload accepted from #cgi.REMOTE_ADDR# (environment: #URL.reload#)");
+			} catch (any e) {
+			}
 		}
 
 		// If we're not allowed to switch, override and replace with the old environment


### PR DESCRIPTION
## Summary
- Add IP-based rate limiting to the reload endpoint (`?reload=true&password=xxx`): 5 failed attempts within 5 minutes locks out the IP
- Replace `Compare(Hash(...), Hash(...))` password check with `MessageDigest.isEqual()` for constant-time comparison, preventing timing attacks
- Log successful and failed reload attempts to `wheels_security` log file

Replicates the same proven pattern already used by the console eval endpoint (`consoleeval.cfm`).

## Test plan
- [x] Full test suite passes (2667 pass, 0 fail, 0 error on Lucee 7 + SQLite)
- [x] Reload endpoint still works with correct password
- [ ] CI matrix validates across all engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)