### PR TITLE
fix(controller): enforce csrf key in production and validate jwt algorithm claim

### DIFF
--- a/vendor/wheels/auth/JwtService.cfc
+++ b/vendor/wheels/auth/JwtService.cfc
@@ -95,6 +95,18 @@ component output="false" {
 			);
 		}
 
+		// Decode and validate header algorithm — prevent algorithm substitution attacks
+		local.headerJson = $base64UrlDecode(local.parts[1]);
+		local.header = DeserializeJSON(local.headerJson);
+		if (!StructKeyExists(local.header, "alg") || local.header.alg != "HS256") {
+			local.claimedAlg = StructKeyExists(local.header, "alg") ? local.header.alg : "none";
+			Throw(
+				type = "Wheels.Auth.JWT.InvalidAlgorithm",
+				message = "JWT algorithm mismatch.",
+				extendedInfo = "Expected algorithm HS256 but token header specifies '#EncodeForHTML(local.claimedAlg)#'. This may indicate an algorithm substitution attack."
+			);
+		}
+
 		// Verify signature
 		local.signingInput = local.parts[1] & "." & local.parts[2];
 		local.expectedSig = $sign(local.signingInput);

--- a/vendor/wheels/controller/csrf.cfc
+++ b/vendor/wheels/controller/csrf.cfc
@@ -151,12 +151,23 @@ component {
 	 */
 	public string function $ensureCsrfCookieEncryptionKey() {
 		if (!Len(application.wheels.csrfCookieEncryptionSecretKey)) {
+			// In production, require explicit configuration
+			if (application.wheels.environment == "production") {
+				Throw(
+					type = "Wheels.Security.MissingCsrfKey",
+					message = "csrfCookieEncryptionSecretKey must be configured in production.",
+					extendedInfo = "Set csrfCookieEncryptionSecretKey in your .env file or config/settings.cfm. Auto-generation is not allowed in production because the key is lost on application restart, invalidating all CSRF tokens."
+				);
+			}
+			// In non-production, auto-generate with warning
 			application.wheels.csrfCookieEncryptionSecretKey = GenerateSecretKey("AES");
-			writeLog(
-				text = "Wheels: csrfCookieEncryptionSecretKey was empty — auto-generated a temporary AES key. Set a persistent key via set(csrfCookieEncryptionSecretKey=""your-key"") in config/settings.cfm to prevent token invalidation on app restart.",
-				type = "warning",
-				file = "wheels_security"
-			);
+			try {
+				writeLog(
+					text = "Wheels WARNING: csrfCookieEncryptionSecretKey was empty — auto-generated a temporary AES key. Set this in config/settings.cfm for persistence across restarts.",
+					type = "warning",
+					file = "wheels_security"
+				);
+			} catch (any e) {}
 		}
 		return application.wheels.csrfCookieEncryptionSecretKey;
 	}

--- a/vendor/wheels/tests/specs/auth/JwtServiceSpec.cfc
+++ b/vendor/wheels/tests/specs/auth/JwtServiceSpec.cfc
@@ -302,6 +302,44 @@ component extends="wheels.WheelsTest" {
 
 			});
 
+			describe("algorithm validation", function() {
+
+				it("accepts tokens with HS256 algorithm", function() {
+					var token = jwt.encode(claims = {sub = 1});
+					var claims = jwt.decode(token);
+					expect(claims.sub).toBe(1);
+				});
+
+				it("rejects tokens with alg none", function() {
+					// Craft a token with alg: none header
+					var headerB64 = _base64UrlEncode('{"alg":"none","typ":"JWT"}');
+					var payloadB64 = _base64UrlEncode('{"sub":1,"iat":999999999,"exp":999999999}');
+					var fakeToken = headerB64 & "." & payloadB64 & ".fakesig";
+					expect(function() {
+						jwt.decode(fakeToken);
+					}).toThrow("Wheels.Auth.JWT.InvalidAlgorithm");
+				});
+
+				it("rejects tokens with alg RS256", function() {
+					var headerB64 = _base64UrlEncode('{"alg":"RS256","typ":"JWT"}');
+					var payloadB64 = _base64UrlEncode('{"sub":1,"iat":999999999,"exp":999999999}');
+					var fakeToken = headerB64 & "." & payloadB64 & ".fakesig";
+					expect(function() {
+						jwt.decode(fakeToken);
+					}).toThrow("Wheels.Auth.JWT.InvalidAlgorithm");
+				});
+
+				it("rejects tokens with missing alg claim", function() {
+					var headerB64 = _base64UrlEncode('{"typ":"JWT"}');
+					var payloadB64 = _base64UrlEncode('{"sub":1,"iat":999999999,"exp":999999999}');
+					var fakeToken = headerB64 & "." & payloadB64 & ".fakesig";
+					expect(function() {
+						jwt.decode(fakeToken);
+					}).toThrow("Wheels.Auth.JWT.InvalidAlgorithm");
+				});
+
+			});
+
 			describe("interoperability", function() {
 
 				it("produces tokens with lowercase JSON claim keys", function() {
@@ -327,6 +365,17 @@ component extends="wheels.WheelsTest" {
 
 		});
 
+	}
+
+	/**
+	 * Helper to base64url-encode a string for crafting test tokens.
+	 */
+	private string function _base64UrlEncode(required string value) {
+		var b64 = ToBase64(arguments.value);
+		b64 = Replace(b64, "+", "-", "all");
+		b64 = Replace(b64, "/", "_", "all");
+		b64 = REReplace(b64, "=+$", "");
+		return b64;
 	}
 
 }

--- a/vendor/wheels/tests/specs/security/CsrfCookieKeySpec.cfc
+++ b/vendor/wheels/tests/specs/security/CsrfCookieKeySpec.cfc
@@ -1,25 +1,40 @@
 /**
- * Tests that CSRF cookie encryption key is auto-generated when empty.
+ * Tests that CSRF cookie encryption key is enforced in production
+ * and auto-generated with a warning in non-production environments.
  */
 component extends="wheels.WheelsTest" {
 
 	function run() {
 
-		describe("CSRF cookie encryption key auto-generation", function() {
+		describe("CSRF cookie encryption key", function() {
 
 			beforeEach(function() {
 				$originalKey = application.wheels.csrfCookieEncryptionSecretKey;
 				$originalStore = application.wheels.csrfStore;
+				$originalEnv = application.wheels.environment;
 			});
 
 			afterEach(function() {
 				application.wheels.csrfCookieEncryptionSecretKey = $originalKey;
 				application.wheels.csrfStore = $originalStore;
+				application.wheels.environment = $originalEnv;
 			});
 
-			it("auto-generates a key when csrfStore is cookie and key is empty", function() {
+			it("throws in production when key is empty", function() {
 				application.wheels.csrfCookieEncryptionSecretKey = "";
 				application.wheels.csrfStore = "cookie";
+				application.wheels.environment = "production";
+
+				var _controller = application.wo.controller("dummy");
+				expect(function() {
+					_controller.$ensureCsrfCookieEncryptionKey();
+				}).toThrow("Wheels.Security.MissingCsrfKey");
+			});
+
+			it("auto-generates a key in development when key is empty", function() {
+				application.wheels.csrfCookieEncryptionSecretKey = "";
+				application.wheels.csrfStore = "cookie";
+				application.wheels.environment = "development";
 
 				var _controller = application.wo.controller("dummy");
 				var result = _controller.$ensureCsrfCookieEncryptionKey();
@@ -28,14 +43,25 @@ component extends="wheels.WheelsTest" {
 				expect(Len(application.wheels.csrfCookieEncryptionSecretKey)).toBeGT(0);
 			});
 
-			it("generates a valid AES key that works for encryption", function() {
+			it("auto-generates a key in testing when key is empty", function() {
 				application.wheels.csrfCookieEncryptionSecretKey = "";
 				application.wheels.csrfStore = "cookie";
+				application.wheels.environment = "testing";
 
 				var _controller = application.wo.controller("dummy");
 				var result = _controller.$ensureCsrfCookieEncryptionKey();
 
-				// Key must be non-empty (length varies by engine: 128-bit=24 chars, 256-bit=44 chars).
+				expect(Len(result)).toBeGT(0);
+			});
+
+			it("generates a valid AES key that works for encryption", function() {
+				application.wheels.csrfCookieEncryptionSecretKey = "";
+				application.wheels.csrfStore = "cookie";
+				application.wheels.environment = "development";
+
+				var _controller = application.wo.controller("dummy");
+				var result = _controller.$ensureCsrfCookieEncryptionKey();
+
 				expect(Len(result)).toBeGT(0);
 
 				// Verify the key actually works for encryption/decryption.
@@ -45,10 +71,11 @@ component extends="wheels.WheelsTest" {
 				expect(decrypted).toBe(plaintext);
 			});
 
-			it("preserves an explicitly set key", function() {
+			it("preserves an explicitly set key regardless of environment", function() {
 				var explicitKey = GenerateSecretKey("AES");
 				application.wheels.csrfCookieEncryptionSecretKey = explicitKey;
 				application.wheels.csrfStore = "cookie";
+				application.wheels.environment = "production";
 
 				var _controller = application.wo.controller("dummy");
 				var result = _controller.$ensureCsrfCookieEncryptionKey();
@@ -60,6 +87,7 @@ component extends="wheels.WheelsTest" {
 			it("only generates the key once across multiple calls", function() {
 				application.wheels.csrfCookieEncryptionSecretKey = "";
 				application.wheels.csrfStore = "cookie";
+				application.wheels.environment = "development";
 
 				var _controller = application.wo.controller("dummy");
 				var firstResult = _controller.$ensureCsrfCookieEncryptionKey();


### PR DESCRIPTION
## Summary
- **CSRF key enforcement**: `$ensureCsrfCookieEncryptionKey()` now throws `Wheels.Security.MissingCsrfKey` in production when the key is empty, instead of silently auto-generating a temporary key that would be lost on restart, invalidating all CSRF tokens. Non-production environments still auto-generate with a logged warning.
- **JWT algorithm validation**: `JwtService.decode()` now validates the `alg` header claim matches `HS256` before verifying the signature, rejecting tokens with `alg: none`, `RS256`, or missing algorithm claims. This prevents algorithm substitution attacks.

## Test plan
- [ ] CSRF: production environment + empty key throws `Wheels.Security.MissingCsrfKey`
- [ ] CSRF: development/testing environments auto-generate key without throwing
- [ ] CSRF: explicitly set key is preserved in any environment
- [ ] JWT: tokens with `HS256` are accepted normally
- [ ] JWT: tokens with `alg: none` are rejected with `Wheels.Auth.JWT.InvalidAlgorithm`
- [ ] JWT: tokens with `alg: RS256` are rejected
- [ ] JWT: tokens with missing `alg` claim are rejected
- [ ] CI passes across all engines (Lucee 5/6/7, Adobe 2018-2025)

🤖 Generated with [Claude Code](https://claude.com/claude-code)