### PR TITLE
fix(middleware): reduce cleanup throttle and add key length limit in rate limiter

### DIFF
--- a/vendor/wheels/middleware/RateLimiter.cfc
+++ b/vendor/wheels/middleware/RateLimiter.cfc
@@ -34,6 +34,9 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	 *   Prevents a single attacker from exhausting heap memory by making rapid requests. After pruning expired
 	 *   entries, arrays exceeding this limit are truncated to keep only the most recent timestamps.
 	 *   Default: maxRequests * 3. Only applies to the "slidingWindow" strategy with storage="memory".
+	 * @maxKeyLength Maximum length of a client key before it is replaced with a SHA-256 hash.
+	 *   Prevents unbounded memory consumption from attackers supplying arbitrarily long keys
+	 *   (e.g., via long X-Forwarded-For chains or custom key functions). Default: 128.
 	 * @failOpen When true, requests are allowed through if the rate limiter lock times out.
 	 *   Default false (fail-closed, secure by default). Set to true if availability
 	 *   is more important than strict rate enforcement.
@@ -49,6 +52,7 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		string proxyStrategy = "first",
 		numeric maxStoreSize = 100000,
 		numeric maxTimestampsPerKey = 0,
+		numeric maxKeyLength = 128,
 		boolean failOpen = false
 	) {
 		if (!ListFindNoCase("fixedWindow,slidingWindow,tokenBucket", arguments.strategy)) {
@@ -82,6 +86,7 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		variables.proxyStrategy = arguments.proxyStrategy;
 		variables.maxStoreSize = arguments.maxStoreSize;
 		variables.maxTimestampsPerKey = arguments.maxTimestampsPerKey > 0 ? arguments.maxTimestampsPerKey : arguments.maxRequests * 3;
+		variables.maxKeyLength = arguments.maxKeyLength;
 		variables.failOpen = arguments.failOpen;
 
 		// In-memory store using ConcurrentHashMap for thread safety.
@@ -89,7 +94,8 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 			variables.store = CreateObject("java", "java.util.concurrent.ConcurrentHashMap").init();
 		}
 
-		// Throttle cleanup to once per minute.
+		// Throttle cleanup interval in seconds.
+		variables.cleanupThrottleSeconds = 10;
 		variables.lastCleanup = 0;
 
 		// Track whether DB table has been verified.
@@ -154,12 +160,20 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 
 	/**
 	 * Resolve the client key from the request — uses keyFunction if provided, otherwise client IP.
+	 * Keys exceeding maxKeyLength are replaced with their SHA-256 hash to bound memory usage.
 	 */
 	private string function $resolveKey(required struct request) {
 		if (IsCustomFunction(variables.keyFunction) || IsClosure(variables.keyFunction)) {
-			return variables.keyFunction(arguments.request);
+			local.key = variables.keyFunction(arguments.request);
+		} else {
+			local.key = $getClientIp(arguments.request);
 		}
-		return $getClientIp(arguments.request);
+
+		if (Len(local.key) > variables.maxKeyLength) {
+			local.key = Hash(local.key, "SHA-256");
+		}
+
+		return local.key;
 	}
 
 	/**
@@ -384,17 +398,17 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	// ---------------------------------------------------------------------------
 
 	/**
-	 * Periodically clean up stale entries from in-memory store (throttled to once per minute).
+	 * Periodically clean up stale entries from in-memory store (throttled to once per cleanupThrottleSeconds).
 	 */
 	private void function $maybeCleanup(required numeric now) {
-		if ((arguments.now - variables.lastCleanup) < 60) {
+		if ((arguments.now - variables.lastCleanup) < variables.cleanupThrottleSeconds) {
 			return;
 		}
 
 		try {
 			cflock(name = "wheels-ratelimit-cleanup", type = "exclusive", timeout = 1) {
 				// Double-check after acquiring lock.
-				if ((arguments.now - variables.lastCleanup) < 60) {
+				if ((arguments.now - variables.lastCleanup) < variables.cleanupThrottleSeconds) {
 					return;
 				}
 				variables.lastCleanup = arguments.now;

--- a/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
+++ b/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
@@ -415,6 +415,115 @@ component extends="wheels.WheelsTest" {
 
 		});
 
+		describe("RateLimiter maxKeyLength", function() {
+
+			it("defaults maxKeyLength to 128", function() {
+				var limiter = new wheels.middleware.RateLimiter();
+				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+			});
+
+			it("accepts custom maxKeyLength", function() {
+				var limiter = new wheels.middleware.RateLimiter(maxKeyLength = 64);
+				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+			});
+
+			it("hashes keys longer than maxKeyLength", function() {
+				// Use a low maxKeyLength so we can easily exceed it.
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 10,
+					windowSeconds = 60,
+					maxKeyLength = 20
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				// A short key (under 20 chars) and a long key (over 20 chars) that
+				// starts with the same prefix should be treated as different keys.
+				var shortKey = "short";
+				var longKey = RepeatString("A", 200);
+
+				var req1 = {remoteAddr: shortKey};
+				var req2 = {remoteAddr: longKey};
+
+				var result1 = limiter.handle(request = req1, next = nextFn);
+				var result2 = limiter.handle(request = req2, next = nextFn);
+
+				// Both should succeed (different keys, both under maxRequests).
+				expect(result1).toBe("ok");
+				expect(result2).toBe("ok");
+			});
+
+			it("hashes long keys from custom keyFunction", function() {
+				var longKey = RepeatString("X", 300);
+
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 1,
+					windowSeconds = 60,
+					maxKeyLength = 128,
+					keyFunction = function(req) { return longKey; }
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				// First request should pass.
+				var r1 = limiter.handle(request = {}, next = nextFn);
+				expect(r1).toBe("ok");
+
+				// Second request with the same long key should be rate limited
+				// (proving the key was hashed consistently to the same value).
+				var r2 = limiter.handle(request = {}, next = nextFn);
+				expect(r2).toInclude("Rate limit exceeded");
+			});
+
+			it("does not hash keys within maxKeyLength", function() {
+				// Two different short keys should rate-limit independently.
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 1,
+					windowSeconds = 60,
+					maxKeyLength = 128
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				var r1 = limiter.handle(request = {remoteAddr: "key-a"}, next = nextFn);
+				var r2 = limiter.handle(request = {remoteAddr: "key-b"}, next = nextFn);
+
+				// Both pass because they are different short keys.
+				expect(r1).toBe("ok");
+				expect(r2).toBe("ok");
+			});
+
+		});
+
+		describe("RateLimiter cleanup throttle", function() {
+
+			it("uses 10-second cleanup throttle instead of 60", function() {
+				// Verify the limiter can be constructed and operates correctly.
+				// The cleanup throttle is now 10s, so after 10s of simulated time
+				// the cleanup should be eligible to run. We verify this indirectly
+				// by confirming the limiter works under pressure with many unique keys.
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 1000,
+					windowSeconds = 5,
+					strategy = "fixedWindow",
+					maxStoreSize = 50
+				);
+
+				var nextFn = function(req) { return "ok"; };
+
+				// Flood with unique keys to trigger cleanup/eviction.
+				for (var i = 1; i <= 100; i++) {
+					var req = {remoteAddr: "cleanup-test-#i#"};
+					limiter.handle(request = req, next = nextFn);
+				}
+
+				// Should still function correctly after cleanup cycles.
+				var result = limiter.handle(request = {remoteAddr: "cleanup-final"}, next = nextFn);
+				expect(result).toBe("ok");
+			});
+
+		});
+
 		describe("RateLimiter failOpen parameter", function() {
 
 			it("defaults failOpen to false (fail-closed)", function() {


### PR DESCRIPTION
## Summary
- Reduce in-memory cleanup throttle from 60s to 10s (via `cleanupThrottleSeconds` variable), preventing key-rotation attacks from filling the store faster than stale entries are evicted
- Add `maxKeyLength` parameter (default 128) to `init()` — client keys exceeding this length are replaced with their SHA-256 hash, bounding per-key memory regardless of input source (X-Forwarded-For chains, custom key functions)
- Add tests for key hashing behavior, custom `maxKeyLength`, and cleanup under pressure

## Test plan
- [x] Full test suite passes (2667 pass, 0 fail, 0 error)
- [ ] CI matrix (Lucee 5/6/7, Adobe 2018-2025, BoxLang) passes
- [ ] Verify long keys from custom `keyFunction` are hashed consistently
- [ ] Verify cleanup runs more frequently under key-rotation load

🤖 Generated with [Claude Code](https://claude.com/claude-code)