### PR TITLE
fix(middleware): default HSTS header in production

### DIFF
--- a/vendor/wheels/middleware/SecurityHeaders.cfc
+++ b/vendor/wheels/middleware/SecurityHeaders.cfc
@@ -16,8 +16,9 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	 * @xssProtection X-XSS-Protection value.
 	 * @referrerPolicy Referrer-Policy value.
 	 * @contentSecurityPolicy Content-Security-Policy value. Empty by default (opt-in) because a restrictive policy can break apps with inline scripts/styles.
-	 * @strictTransportSecurity Strict-Transport-Security value. Empty by default (opt-in) because it requires HTTPS to be configured.
+	 * @strictTransportSecurity Strict-Transport-Security value. Auto-defaults to `max-age=31536000; includeSubDomains` in production when not explicitly set.
 	 * @permissionsPolicy Permissions-Policy value. Empty by default (opt-in) because it is app-specific.
+	 * @environment Application environment (e.g. "production", "development"). When empty, falls back to application.$wheels.environment if available.
 	 */
 	public SecurityHeaders function init(
 		string frameOptions = "SAMEORIGIN",
@@ -26,9 +27,29 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		string referrerPolicy = "strict-origin-when-cross-origin",
 		string contentSecurityPolicy = "",
 		string strictTransportSecurity = "",
-		string permissionsPolicy = ""
+		string permissionsPolicy = "",
+		string environment = ""
 	) {
 		variables.headers = {};
+
+		// Resolve environment: explicit parameter > application.$wheels.environment
+		local.env = arguments.environment;
+		if (!Len(local.env)) {
+			try {
+				if (StructKeyExists(application, "$wheels") && StructKeyExists(application.$wheels, "environment")) {
+					local.env = application.$wheels.environment;
+				}
+			} catch (any e) {
+				// application scope may not be available during testing
+			}
+		}
+
+		// Default HSTS in production when not explicitly configured
+		local.hsts = arguments.strictTransportSecurity;
+		if (!Len(local.hsts) && local.env == "production") {
+			local.hsts = "max-age=31536000; includeSubDomains";
+		}
+
 		if (Len(arguments.frameOptions)) {
 			variables.headers["X-Frame-Options"] = arguments.frameOptions;
 		}
@@ -44,8 +65,8 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		if (Len(arguments.contentSecurityPolicy)) {
 			variables.headers["Content-Security-Policy"] = arguments.contentSecurityPolicy;
 		}
-		if (Len(arguments.strictTransportSecurity)) {
-			variables.headers["Strict-Transport-Security"] = arguments.strictTransportSecurity;
+		if (Len(local.hsts)) {
+			variables.headers["Strict-Transport-Security"] = local.hsts;
 		}
 		if (Len(arguments.permissionsPolicy)) {
 			variables.headers["Permissions-Policy"] = arguments.permissionsPolicy;

--- a/vendor/wheels/tests/specs/middleware/SecurityHeadersSpec.cfc
+++ b/vendor/wheels/tests/specs/middleware/SecurityHeadersSpec.cfc
@@ -29,7 +29,7 @@ component extends="wheels.WheelsTest" {
 					expect(local.mw.$headers()).notToHaveKey("Content-Security-Policy");
 				});
 
-				it("does not set HSTS by default", function() {
+				it("does not set HSTS by default when environment is not production", function() {
 					local.mw = new wheels.middleware.SecurityHeaders();
 					expect(local.mw.$headers()).notToHaveKey("Strict-Transport-Security");
 				});
@@ -86,9 +86,46 @@ component extends="wheels.WheelsTest" {
 					expect(local.mw.$headers()["Strict-Transport-Security"]).toBe(local.value);
 				});
 
-				it("does not set HSTS header when empty string", function() {
+				it("does not set HSTS header when empty string and not production", function() {
 					local.mw = new wheels.middleware.SecurityHeaders(
 						strictTransportSecurity = ""
+					);
+					expect(local.mw.$headers()).notToHaveKey("Strict-Transport-Security");
+				});
+
+				it("auto-defaults HSTS in production environment", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						environment = "production"
+					);
+					expect(local.mw.$headers()).toHaveKey("Strict-Transport-Security");
+					expect(local.mw.$headers()["Strict-Transport-Security"]).toBe("max-age=31536000; includeSubDomains");
+				});
+
+				it("does not auto-default HSTS in development environment", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						environment = "development"
+					);
+					expect(local.mw.$headers()).notToHaveKey("Strict-Transport-Security");
+				});
+
+				it("does not auto-default HSTS in testing environment", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						environment = "testing"
+					);
+					expect(local.mw.$headers()).notToHaveKey("Strict-Transport-Security");
+				});
+
+				it("uses explicit HSTS value even in production", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						strictTransportSecurity = "max-age=86400",
+						environment = "production"
+					);
+					expect(local.mw.$headers()["Strict-Transport-Security"]).toBe("max-age=86400");
+				});
+
+				it("does not set HSTS when environment is empty and no explicit value", function() {
+					local.mw = new wheels.middleware.SecurityHeaders(
+						environment = ""
 					);
 					expect(local.mw.$headers()).notToHaveKey("Strict-Transport-Security");
 				});


### PR DESCRIPTION
## Summary
- SecurityHeaders middleware now auto-defaults `Strict-Transport-Security: max-age=31536000; includeSubDomains` when environment is production and no explicit HSTS value is provided
- Adds `environment` parameter to `init()` with fallback to `application.$wheels.environment` so existing users get HSTS protection without config changes
- Fully backward compatible: non-production environments and empty environment continue to omit HSTS unless explicitly set

## Test plan
- [x] Verify HSTS auto-defaults when `environment="production"` and no explicit value
- [x] Verify HSTS is NOT set for development, testing, or empty environment
- [x] Verify explicit HSTS values override the auto-default in production
- [x] Verify backward compatibility: no HSTS when no environment param passed
- [x] All 2672 tests pass locally (Lucee 7 + SQLite), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)