### PR TITLE
fix(model): validate group by items with dot-notation like order by clause

### DIFF
--- a/vendor/wheels/model/sql.cfc
+++ b/vendor/wheels/model/sql.cfc
@@ -360,6 +360,39 @@ component {
 
 			local.rv = ArrayToList(local.groupByItems);
 		} else if (Len(arguments.group)) {
+			// Validate each GROUP BY item before passing to $createSQLFieldList (mirrors ORDER BY validation)
+			local.groupArray = ListToArray(arguments.group);
+			for (local.g = 1; local.g <= ArrayLen(local.groupArray); local.g++) {
+				local.gItem = Trim(local.groupArray[local.g]);
+				if (Find("(", local.gItem)) {
+					Throw(
+						type = "Wheels.InvalidGroupByClause",
+						message = "Invalid GROUP BY clause.",
+						extendedInfo = "Raw SQL expressions with parentheses are not allowed in the GROUP BY clause. Use only column names or table.column notation."
+					);
+				}
+				if (Find(";", local.gItem) || Find("--", local.gItem) || Find("/*", local.gItem)) {
+					Throw(
+						type = "Wheels.InvalidGroupByClause",
+						message = "Invalid GROUP BY clause.",
+						extendedInfo = "The GROUP BY item '#EncodeForHTML(local.gItem)#' contains invalid characters."
+					);
+				}
+				if (Find(".", local.gItem) && !REFind("^[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*$", local.gItem)) {
+					Throw(
+						type = "Wheels.InvalidGroupByClause",
+						message = "Invalid GROUP BY clause.",
+						extendedInfo = "The GROUP BY item '#EncodeForHTML(local.gItem)#' contains invalid characters. Only table.column notation is allowed."
+					);
+				}
+				if (Find(" AS ", local.gItem)) {
+					Throw(
+						type = "Wheels.InvalidGroupByClause",
+						message = "Invalid GROUP BY clause.",
+						extendedInfo = "Aliases (AS) are not allowed in the GROUP BY clause."
+					);
+				}
+			}
 			local.args.list = arguments.group;
 			local.rv = $createSQLFieldList(argumentCollection = local.args);
 		}

--- a/vendor/wheels/tests/specs/security/GroupByInjectionSpec.cfc
+++ b/vendor/wheels/tests/specs/security/GroupByInjectionSpec.cfc
@@ -1,0 +1,167 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("GROUP BY clause security", () => {
+
+			describe("valid GROUP BY usage", () => {
+
+				it("allows grouping by a valid property name", () => {
+					var result = g.model("author").$groupByClause(
+						select="lastName",
+						include="",
+						group="lastName",
+						distinct=false,
+						returnAs="query"
+					);
+					expect(result).toInclude("GROUP BY");
+				})
+
+				it("allows grouping by valid dot-notation", () => {
+					var result = g.model("author").$groupByClause(
+						select="lastName",
+						include="",
+						group="c_o_r_e_authors.lastName",
+						distinct=false,
+						returnAs="query"
+					);
+					expect(result).toInclude("GROUP BY");
+					expect(result).toInclude("c_o_r_e_authors.lastName");
+				})
+
+				it("allows grouping by multiple properties", () => {
+					var result = g.model("author").$groupByClause(
+						select="firstName,lastName",
+						include="",
+						group="firstName,lastName",
+						distinct=false,
+						returnAs="query"
+					);
+					expect(result).toInclude("GROUP BY");
+				})
+
+			})
+
+			describe("SQL injection prevention", () => {
+
+				it("rejects semicolon injection in group clause", () => {
+					expect(function() {
+						g.model("author").$groupByClause(
+							select="lastName",
+							include="",
+							group="lastName; DROP TABLE users",
+							distinct=false,
+							returnAs="query"
+						);
+					}).toThrow("Wheels.InvalidGroupByClause");
+				})
+
+				it("rejects SQL comment injection with double dash", () => {
+					expect(function() {
+						g.model("author").$groupByClause(
+							select="lastName",
+							include="",
+							group="lastName -- comment",
+							distinct=false,
+							returnAs="query"
+						);
+					}).toThrow("Wheels.InvalidGroupByClause");
+				})
+
+				it("rejects SQL comment injection with block comment", () => {
+					expect(function() {
+						g.model("author").$groupByClause(
+							select="lastName",
+							include="",
+							group="lastName /* comment */",
+							distinct=false,
+							returnAs="query"
+						);
+					}).toThrow("Wheels.InvalidGroupByClause");
+				})
+
+				it("rejects parenthesized expressions", () => {
+					expect(function() {
+						g.model("author").$groupByClause(
+							select="lastName",
+							include="",
+							group="(SELECT 1)",
+							distinct=false,
+							returnAs="query"
+						);
+					}).toThrow("Wheels.InvalidGroupByClause");
+				})
+
+				it("rejects raw SQL function calls", () => {
+					expect(function() {
+						g.model("author").$groupByClause(
+							select="lastName",
+							include="",
+							group="COUNT(id)",
+							distinct=false,
+							returnAs="query"
+						);
+					}).toThrow("Wheels.InvalidGroupByClause");
+				})
+
+			})
+
+			describe("dot-notation injection prevention", () => {
+
+				it("rejects SQL injection via dot-notation with semicolon", () => {
+					expect(function() {
+						g.model("author").$groupByClause(
+							select="lastName",
+							include="",
+							group="users.id; DROP TABLE users--",
+							distinct=false,
+							returnAs="query"
+						);
+					}).toThrow("Wheels.InvalidGroupByClause");
+				})
+
+				it("rejects dot-notation with special characters", () => {
+					expect(function() {
+						g.model("author").$groupByClause(
+							select="lastName",
+							include="",
+							group="ta'ble.col",
+							distinct=false,
+							returnAs="query"
+						);
+					}).toThrow("Wheels.InvalidGroupByClause");
+				})
+
+				it("rejects dot-notation with multiple dots", () => {
+					expect(function() {
+						g.model("author").$groupByClause(
+							select="lastName",
+							include="",
+							group="schema.table.column",
+							distinct=false,
+							returnAs="query"
+						);
+					}).toThrow("Wheels.InvalidGroupByClause");
+				})
+
+				it("rejects aliases in GROUP BY via dot-notation path", () => {
+					expect(function() {
+						g.model("author").$groupByClause(
+							select="lastName",
+							include="",
+							group="lastName AS ln",
+							distinct=false,
+							returnAs="query"
+						);
+					}).toThrow("Wheels.InvalidGroupByClause");
+				})
+
+			})
+
+		})
+
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds strict validation to GROUP BY clause items in `$groupByClause()`, matching ORDER BY's existing protections
- Rejects raw SQL expressions with parentheses, semicolons, SQL comments (`--`, `/*`)
- Validates dot-notation with strict regex `^[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*$`
- Adds `GroupByInjectionSpec.cfc` with injection attempt tests

## Test plan
- [ ] Verify normal GROUP BY queries still work (`group="email"`, `group="users.email"`)
- [ ] Verify SQL injection attempts in GROUP BY are rejected
- [ ] Run `bash tools/test-local.sh model`

🤖 Generated with [Claude Code](https://claude.com/claude-code)