### PR TITLE
fix(plugin): log package and plugin component paths on load

### DIFF
--- a/vendor/wheels/PackageLoader.cfc
+++ b/vendor/wheels/PackageLoader.cfc
@@ -304,6 +304,43 @@ component output="false" {
 			return;
 		}
 
+		try {
+			WriteLog(
+				text = "[Wheels] Loading package '##arguments.dirName##' from ##arguments.pkgDir##",
+				type = "information",
+				file = "wheels_security"
+			);
+		} catch (any e) {}
+
+		if (StructKeyExists(local.manifest, "checksums") && IsStruct(local.manifest.checksums)) {
+			local.checksumFailed = false;
+			for (local.cfcFile in local.manifest.checksums) {
+				local.expectedHash = local.manifest.checksums[local.cfcFile];
+				local.cfcFilePath = arguments.pkgDir & "/" & local.cfcFile;
+				if (FileExists(local.cfcFilePath)) {
+					local.actualHash = Hash(FileRead(local.cfcFilePath), "SHA-256");
+					if (CompareNoCase(local.actualHash, local.expectedHash) != 0) {
+						try {
+							WriteLog(
+								text = "[Wheels] SECURITY WARNING: Checksum mismatch for ##local.cfcFile## in package '##arguments.dirName##'. Expected: ##local.expectedHash##, Got: ##local.actualHash##",
+								type = "warning",
+								file = "wheels_security"
+							);
+						} catch (any e) {}
+						local.checksumFailed = true;
+					}
+				}
+			}
+			if (local.checksumFailed) {
+				ArrayAppend(variables.failedPackages, {
+					name = arguments.dirName,
+					error = "Checksum verification failed",
+					detail = "One or more CFC files did not match declared checksums in package.json"
+				});
+				return;
+			}
+		}
+
 		// Eager loading: instantiate CFC now
 		$instantiatePackage(arguments.dirName, arguments.pkgDir, local.mixinTargets, local.provides);
 	}

--- a/vendor/wheels/Plugins.cfc
+++ b/vendor/wheels/Plugins.cfc
@@ -139,6 +139,13 @@ component output="false" extends="wheels.Global"{
 		local.wheelsVersion = $normalizeWheelsVersion();
 		for (local.pluginKey in local.pluginKeys) {
 			local.pluginValue = local.plugins[local.pluginKey];
+			try {
+				WriteLog(
+					text = "[Wheels] Loading plugin '##local.pluginKey##' from ##local.pluginValue.folderPath##",
+					type = "information",
+					file = "wheels_security"
+				);
+			} catch (any e) {}
 			local.plugin = CreateObject("component", $componentPathToPlugin(local.pluginKey, local.pluginValue.name)).init();
 			// Determine the compatibility version list. If a plugin.json exists and
 			// declares wheelsVersion, use that instead of the CFC's this.version

--- a/vendor/wheels/tests/_assets/packages/badchecksumpkg/Badchecksumpkg.cfc
+++ b/vendor/wheels/tests/_assets/packages/badchecksumpkg/Badchecksumpkg.cfc
@@ -1,0 +1,10 @@
+component {
+	public any function init() {
+		this.version = "1.0.0";
+		return this;
+	}
+
+	public string function $badChecksumPkgTestHelper() {
+		return "badchecksumpkg-works";
+	}
+}

--- a/vendor/wheels/tests/_assets/packages/badchecksumpkg/package.json
+++ b/vendor/wheels/tests/_assets/packages/badchecksumpkg/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "wheels-badchecksumpkg",
+	"version": "1.0.0",
+	"description": "Test fixture: package with mismatched checksums",
+	"provides": {
+		"mixins": "controller",
+		"services": [],
+		"middleware": []
+	},
+	"checksums": {
+		"Badchecksumpkg.cfc": "0000000000000000000000000000000000000000000000000000000000000000"
+	}
+}

--- a/vendor/wheels/tests/_assets/packages/checksumpkg/Checksumpkg.cfc
+++ b/vendor/wheels/tests/_assets/packages/checksumpkg/Checksumpkg.cfc
@@ -1,0 +1,10 @@
+component {
+	public any function init() {
+		this.version = "1.0.0";
+		return this;
+	}
+
+	public string function $checksumPkgTestHelper() {
+		return "checksumpkg-works";
+	}
+}

--- a/vendor/wheels/tests/_assets/packages/checksumpkg/package.json
+++ b/vendor/wheels/tests/_assets/packages/checksumpkg/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "wheels-checksumpkg",
+	"version": "1.0.0",
+	"description": "Test fixture: valid package without checksums (backward compat)",
+	"provides": {
+		"mixins": "controller",
+		"services": [],
+		"middleware": []
+	}
+}

--- a/vendor/wheels/tests/specs/security/PackageLoadIntegritySpec.cfc
+++ b/vendor/wheels/tests/specs/security/PackageLoadIntegritySpec.cfc
@@ -1,0 +1,108 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("Package and plugin load integrity logging", () => {
+
+			beforeEach(() => {
+				fixturesPath = ExpandPath("/wheels/tests/_assets/packages");
+				componentPrefix = "wheels.tests._assets.packages";
+			});
+
+			describe("Package security logging", () => {
+
+				it("loads packages without checksums normally (backward compatible)", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = fixturesPath,
+						componentPrefix = componentPrefix
+					);
+					var pkgs = loader.getPackages();
+					// checksumpkg has no checksums field and should load fine
+					expect(pkgs).toHaveKey("checksumpkg");
+				});
+
+				it("skips packages with mismatched checksums", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = fixturesPath,
+						componentPrefix = componentPrefix
+					);
+					var pkgs = loader.getPackages();
+					var failed = loader.getFailedPackages();
+
+					// badchecksumpkg has a deliberately wrong checksum
+					expect(pkgs).notToHaveKey("badchecksumpkg");
+
+					// verify it was recorded as failed
+					var foundBadChecksum = false;
+					for (var f in failed) {
+						if (f.name == "badchecksumpkg" && FindNoCase("checksum", f.error)) {
+							foundBadChecksum = true;
+						}
+					}
+					expect(foundBadChecksum).toBeTrue();
+				});
+
+				it("records checksum failure detail in failedPackages", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = fixturesPath,
+						componentPrefix = componentPrefix
+					);
+					var failed = loader.getFailedPackages();
+
+					var foundEntry = false;
+					for (var f in failed) {
+						if (f.name == "badchecksumpkg") {
+							foundEntry = true;
+							expect(f.error).toBe("Checksum verification failed");
+							expect(f.detail).toInclude("checksums");
+						}
+					}
+					expect(foundEntry).toBeTrue();
+				});
+
+			});
+
+			describe("Checksum verification", () => {
+
+				it("accepts packages with valid checksums", () => {
+					// compute the actual hash of the checksumpkg CFC so we can
+					// write a matching manifest, then verify it loads
+					var cfcPath = fixturesPath & "/checksumpkg/Checksumpkg.cfc";
+					var actualHash = Hash(FileRead(cfcPath), "SHA-256");
+
+					// create a temporary manifest with correct checksums
+					var manifestPath = fixturesPath & "/checksumpkg/package.json";
+					var originalManifest = FileRead(manifestPath);
+
+					try {
+						var manifest = DeserializeJSON(originalManifest);
+						manifest["checksums"] = {"Checksumpkg.cfc" = actualHash};
+						FileWrite(manifestPath, SerializeJSON(manifest));
+
+						var loader = new wheels.PackageLoader(
+							vendorPath = fixturesPath,
+							componentPrefix = componentPrefix
+						);
+						var pkgs = loader.getPackages();
+						expect(pkgs).toHaveKey("checksumpkg");
+
+						// should not appear in failed packages
+						var failed = loader.getFailedPackages();
+						var foundChecksumFail = false;
+						for (var f in failed) {
+							if (f.name == "checksumpkg") foundChecksumFail = true;
+						}
+						expect(foundChecksumFail).toBeFalse();
+					} finally {
+						// restore original manifest
+						FileWrite(manifestPath, originalManifest);
+					}
+				});
+
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds security logging for all package and plugin CFC instantiation to `wheels_security` log file
- Supports optional SHA-256 checksum verification via `checksums` key in `package.json` manifests
- Follows error-isolation pattern: checksum mismatches log a warning and skip the package (don't throw)
- Adds `PackageLoadIntegritySpec.cfc` with test fixtures and integrity verification tests

## Test plan
- [ ] Verify packages still load normally (backward compatible — no checksums required)
- [ ] Verify `wheels_security` log receives loading entries
- [ ] Verify packages with bad checksums are skipped with warning
- [ ] Run `bash tools/test-local.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)