### PR TITLE
fix(config): use constant-time comparison for JWT signature verification

### DIFF
--- a/vendor/wheels/auth/JwtService.cfc
+++ b/vendor/wheels/auth/JwtService.cfc
@@ -99,7 +99,10 @@ component output="false" {
 		local.signingInput = local.parts[1] & "." & local.parts[2];
 		local.expectedSig = $sign(local.signingInput);
 
-		if (local.expectedSig != local.parts[3]) {
+		if (!CreateObject("java", "java.security.MessageDigest").isEqual(
+			local.expectedSig.getBytes("UTF-8"),
+			local.parts[3].getBytes("UTF-8")
+		)) {
 			throw(
 				type = "Wheels.Auth.JWT.InvalidSignature",
 				message = "JWT signature verification failed"

--- a/vendor/wheels/tests/specs/auth/JwtServiceSpec.cfc
+++ b/vendor/wheels/tests/specs/auth/JwtServiceSpec.cfc
@@ -147,6 +147,19 @@ component extends="wheels.WheelsTest" {
 					expect(claims.sub).toBe(1);
 				});
 
+				it("rejects a token whose signature differs by a single character", function() {
+					var token = jwt.encode(claims = {sub = 99});
+					var parts = ListToArray(token, ".");
+					var sig = parts[3];
+					var lastChar = Right(sig, 1);
+					var flipped = lastChar == "A" ? "B" : "A";
+					parts[3] = Left(sig, Len(sig) - 1) & flipped;
+					var tampered = ArrayToList(parts, ".");
+					expect(function() {
+						jwt.decode(token = tampered);
+					}).toThrow("Wheels.Auth.JWT.InvalidSignature");
+				});
+
 				it("still validates signature when ignoreExpiry is true", function() {
 					var otherJwt = new wheels.auth.JwtService(secretKey = "wrong-key");
 					var now = Int(CreateObject("java", "java.lang.System").currentTimeMillis() / 1000);


### PR DESCRIPTION
## Summary
- Replace string `!=` operator with `MessageDigest.isEqual()` for JWT signature comparison to prevent timing attacks
- Adds test for single-character signature difference rejection
- Matches the constant-time pattern already used for reload password (`onapplicationstart.cfc:159`) and console eval (`consoleeval.cfm:116`)

## Test plan
- [ ] Existing JWT tests pass (encode/decode/expiry/signature rejection)
- [ ] New test verifies single-char signature diff is rejected
- [ ] Run `bash tools/test-local.sh` for full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)