### PR TITLE
fix(cli): use cryptographically secure random for mcp session tokens

### DIFF
--- a/vendor/wheels/public/mcp/SessionManager.cfc
+++ b/vendor/wheels/public/mcp/SessionManager.cfc
@@ -9,7 +9,7 @@ component output="false" displayName="MCP Session Manager" {
 	}
 
 	public string function createSession() {
-		local.sessionId = "mcp-" & createUUID();
+		local.sessionId = "mcp-" & LCase(CreateObject("java", "java.util.UUID").randomUUID().toString());
 		variables.sessions[local.sessionId] = {
 			"id": local.sessionId,
 			"created": now(),


### PR DESCRIPTION
## Summary
- Replace `createUUID()` (type-1, timestamp+MAC based, predictable) with `java.util.UUID.randomUUID()` (type-4, `SecureRandom`-backed) in MCP session ID generation
- Defense-in-depth hardening -- MCP endpoint is already localhost-restricted in dev mode, but session tokens should not be guessable regardless

## Test plan
- [x] Verified test suite results identical before/after (2448 pass, 9 fail, 208 errors -- all failures pre-existing `$SIMPLELOCK`/`GET` infrastructure issues)
- [x] Single-line change, no behavioral difference (still produces `mcp-<uuid>` format string)
- [x] `java.util.UUID.randomUUID()` is available on all CFML engines (Lucee, Adobe CF, BoxLang) via underlying JVM

🤖 Generated with [Claude Code](https://claude.com/claude-code)