### PR TITLE
fix(middleware): default rate limiter proxy strategy to last for security

### DIFF
--- a/vendor/wheels/middleware/RateLimiter.cfc
+++ b/vendor/wheels/middleware/RateLimiter.cfc
@@ -23,10 +23,10 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	 *   Without a proxy that sanitizes this header, any client can spoof arbitrary IPs to bypass rate
 	 *   limiting entirely. Your proxy MUST be configured to either: (a) drop incoming X-Forwarded-For and
 	 *   set it to the real client IP, or (b) append the client IP so the rightmost entry is trustworthy.
-	 *   If your proxy appends, set proxyStrategy="last" to use the rightmost (proxy-added) IP.
-	 * @proxyStrategy Which IP to extract from X-Forwarded-For: "first" (leftmost, client-supplied — default
-	 *   for backwards compatibility) or "last" (rightmost, added by the nearest trusted proxy — recommended
-	 *   when the proxy appends rather than overwrites the header).
+	 *   If your proxy appends, the default proxyStrategy="last" uses the rightmost (proxy-added) IP.
+	 * @proxyStrategy Which IP to extract from X-Forwarded-For: "last" (rightmost, added by the nearest
+	 *   trusted proxy — default, secure when the proxy appends the real client IP) or "first" (leftmost,
+	 *   client-supplied — available for backward compatibility but vulnerable to spoofing).
 	 * @maxStoreSize Maximum number of entries allowed in the in-memory store. When exceeded during cleanup,
 	 *   the oldest entries are evicted. Prevents unbounded memory growth from attackers rotating client keys.
 	 *   Only applies when storage="memory". Default: 100000.
@@ -46,7 +46,7 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		any keyFunction = "",
 		string headerPrefix = "X-RateLimit",
 		boolean trustProxy = false,
-		string proxyStrategy = "first",
+		string proxyStrategy = "last",
 		numeric maxStoreSize = 100000,
 		numeric maxTimestampsPerKey = 0,
 		boolean failOpen = false

--- a/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
+++ b/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
@@ -170,7 +170,7 @@ component extends="wheels.WheelsTest" {
 
 		describe("RateLimiter proxyStrategy", function() {
 
-			it("defaults to first IP in X-Forwarded-For chain", function() {
+			it("uses first IP in X-Forwarded-For chain when proxyStrategy is first", function() {
 				var limiter = new wheels.middleware.RateLimiter(
 					maxRequests = 1,
 					windowSeconds = 60,
@@ -273,6 +273,24 @@ component extends="wheels.WheelsTest" {
 				expect(result1).toBe("ok");
 				expect(result2).toBe("ok");
 				expect(result3).toInclude("Rate limit exceeded");
+			});
+
+			it("defaults to last proxy strategy when trustProxy is enabled", function() {
+				var limiter = new wheels.middleware.RateLimiter(
+					trustProxy = true,
+					maxRequests = 5,
+					windowSeconds = 60
+				);
+
+				// The rightmost IP should be used (proxy-appended)
+				var req = {
+					cgi: {
+						remote_addr: "10.0.0.1",
+						http_x_forwarded_for: "1.2.3.4, 5.6.7.8"
+					}
+				};
+				var clientKey = limiter.$getClientKey(req);
+				expect(clientKey).toBe("5.6.7.8");
 			});
 
 			it("throws on invalid proxyStrategy", function() {

--- a/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
+++ b/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
@@ -275,22 +275,36 @@ component extends="wheels.WheelsTest" {
 				expect(result3).toInclude("Rate limit exceeded");
 			});
 
-			it("defaults to last proxy strategy when trustProxy is enabled", function() {
+			it("defaults to last proxy strategy when trustProxy is enabled without explicit proxyStrategy", function() {
 				var limiter = new wheels.middleware.RateLimiter(
 					trustProxy = true,
-					maxRequests = 5,
+					maxRequests = 1,
 					windowSeconds = 60
 				);
 
-				// The rightmost IP should be used (proxy-appended)
-				var req = {
+				var nextFn = function(req) { return "ok"; };
+
+				// Two requests with different first IPs but same last IP should share a bucket
+				// (proving the default strategy is "last", not "first")
+				var req1 = {
 					cgi: {
-						remote_addr: "10.0.0.1",
-						http_x_forwarded_for: "1.2.3.4, 5.6.7.8"
+						remote_addr: "10.0.0.50",
+						http_x_forwarded_for: "1.1.1.1, 10.0.0.1"
 					}
 				};
-				var clientKey = limiter.$getClientKey(req);
-				expect(clientKey).toBe("5.6.7.8");
+				var req2 = {
+					cgi: {
+						remote_addr: "10.0.0.50",
+						http_x_forwarded_for: "2.2.2.2, 10.0.0.1"
+					}
+				};
+
+				var result1 = limiter.handle(request = req1, next = nextFn);
+				expect(result1).toBe("ok");
+
+				// Second request from "different" first IP but SAME last IP should be blocked
+				var result2 = limiter.handle(request = req2, next = nextFn);
+				expect(result2).toInclude("Rate limit exceeded");
 			});
 
 			it("throws on invalid proxyStrategy", function() {


### PR DESCRIPTION
## Summary
- Change `proxyStrategy` default from `"first"` (spoofable leftmost IP) to `"last"` (rightmost proxy-appended IP) when `trustProxy` is enabled
- Prevents attackers from bypassing rate limiting via X-Forwarded-For header spoofing
- Updates doc comments to reflect the new secure default

## Test plan
- [ ] Existing rate limiter tests pass (all use explicit proxyStrategy values)
- [ ] New test verifies default behavior uses rightmost IP
- [ ] Run `bash tools/test-local.sh middleware`

🤖 Generated with [Claude Code](https://claude.com/claude-code)