### PR TITLE
fix(controller): harden path traversal check against encoded bypass attempts

### DIFF
--- a/vendor/wheels/controller/rendering.cfc
+++ b/vendor/wheels/controller/rendering.cfc
@@ -497,12 +497,14 @@ component {
 		string $baseTemplatePath = $get("viewPath"),
 		boolean $prependWithUnderscore = true
 	) {
-		// Reject path traversal attempts in partial/template names
-		if (Find("..", arguments.$name) || Find(Chr(92), arguments.$name)) {
+		// Strip null bytes and URL-decode before traversal checks to prevent encoded bypasses
+		arguments.$name = Replace(arguments.$name, Chr(0), "", "all");
+		local.decoded = URLDecode(arguments.$name);
+		if (Find("..", local.decoded) || Find(Chr(92), local.decoded)) {
 			Throw(
 				type="Wheels.InvalidPartialPath",
 				message="The partial name `#EncodeForHTML(arguments.$name)#` contains invalid path characters.",
-				extendedInfo="Partial names must not contain '..' or backslashes."
+				extendedInfo="Partial names must not contain '..' or backslashes (including URL-encoded variants)."
 			);
 		}
 

--- a/vendor/wheels/tests/specs/security/PathTraversalSpec.cfc
+++ b/vendor/wheels/tests/specs/security/PathTraversalSpec.cfc
@@ -98,6 +98,24 @@ component extends="wheels.WheelsTest" {
 				}).notToThrow();
 			});
 
+			it("rejects URL-encoded dot-dot traversal attempts", () => {
+				expect(function() {
+					_controller.$generateIncludeTemplatePath($name="%2e%2e/%2e%2e/etc/passwd", $type="partial");
+				}).toThrow("Wheels.InvalidPartialPath");
+			});
+
+			it("rejects null bytes in partial names", () => {
+				expect(function() {
+					_controller.$generateIncludeTemplatePath($name="valid" & Chr(0) & "/../secret", $type="partial");
+				}).toThrow("Wheels.InvalidPartialPath");
+			});
+
+			it("rejects mixed URL-encoded backslash traversal", () => {
+				expect(function() {
+					_controller.$generateIncludeTemplatePath($name="%2e%2e%5csecret", $type="partial");
+				}).toThrow("Wheels.InvalidPartialPath");
+			});
+
 		});
 
 	}


### PR DESCRIPTION
## Summary
- Add URL-decode normalization and null-byte stripping before path traversal validation in `$generateIncludeTemplatePath()`
- Prevents bypasses using `%2e%2e` (URL-encoded `..`) or null byte injection in partial/template names
- Defense-in-depth improvement — the value is developer-controlled in practice, but this hardens the framework against edge cases

## Test plan
- [ ] Existing path traversal tests pass (normal partials still work)
- [ ] New tests verify URL-encoded traversal, null bytes, and mixed encoding are rejected
- [ ] Run `bash tools/test-local.sh security`

🤖 Generated with [Claude Code](https://claude.com/claude-code)