### PR TITLE
commit: fix for navbar issue #2012

### DIFF
--- a/vendor/wheels/public/layout/_navigation.cfm
+++ b/vendor/wheels/public/layout/_navigation.cfm
@@ -2,7 +2,7 @@
 <cfoutput>
 <!--- cfformat-ignore-start --->
 <div class="sixteen wide column">
-	<nav class="ui pointing fluid eight stackable item  menu ">
+	<nav class="ui pointing fluid nine stackable item  menu ">
 		<a href="/" class="item">
 			<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="150px" height="18px" viewBox="0 0 153 18" version="1.1">
 				<g id="surface1">


### PR DESCRIPTION
The Wheels developer toolbar navigation menu was overflowing off-screen after adding the **Packages** tab.

Updated the menu layout from `eight` to `nine` columns so the `stackable` class can properly wrap items onto multiple rows on smaller screens, ensuring all navigation items remain visible.