### PR TITLE
commit: fix for issue #2107

### DIFF
--- a/vendor/wheels/public/views/congratulations.cfm
+++ b/vendor/wheels/public/views/congratulations.cfm
@@ -3,10 +3,10 @@
 <cfscript>
 	// Runtime info
 	local.wheelsVersion = get("version");
-	local.engineName = application.$wheels.serverName;
-	local.engineVersion = ListFirst(application.$wheels.serverVersion, ".");
-	if (ListLen(application.$wheels.serverVersion, ".") > 1) {
-		local.engineVersion &= "." & ListGetAt(application.$wheels.serverVersion, 2, ".");
+	local.engineName = application.wheels.serverName;
+	local.engineVersion = ListFirst(application.wheels.serverVersion, ".");
+	if (ListLen(application.wheels.serverVersion, ".") > 1) {
+		local.engineVersion &= "." & ListGetAt(application.wheels.serverVersion, 2, ".");
 	}
 	local.dbName = application.wheels.dataSourceName;
 	local.environment = get("environment");


### PR DESCRIPTION
## Summary:
The Landing Page (congratulations page) for wheels 4.0.0 was using application.$wheels to access server info, but during initialization $wheels is renamed to wheels (see onapplicationstart.cfc:346-347). This caused a "key doesn't exist" error when visiting the root URL after application startup.

## Changes:
- **vendor/wheels/public/views/congratulations.cfm**: Changed application.$wheels to application.wheels for serverName and serverVersion access (lines 6-9)