### PR TITLE
chore: ignore Claude Code runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ test-output/
 .worktrees/
 .grove/
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
 .DS_Store
 .superpowers/
 


### PR DESCRIPTION
## Summary
Adds \`.claude/scheduled_tasks.lock\` and \`.claude/worktrees/\` to \`.gitignore\`. These are created at runtime by Claude Code and should not be tracked.

## Test plan
- [ ] Verify \`git status\` is clean after Claude Code creates a scheduled task or worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)