### PR TITLE
feat(test): browser testing foundation (PR 1 of 4) [WIP]

### DIFF
--- a/.ai/wheels/testing/browser-testing.md
+++ b/.ai/wheels/testing/browser-testing.md
@@ -1,0 +1,247 @@
+# Browser Testing (`wheels.wheelstest.BrowserTest`)
+
+Native browser testing added in Wheels v4.0 via Playwright Java. Specs extend `wheels.wheelstest.BrowserTest` and drive a real Chromium browser through a fluent DSL that mirrors the shape of `wheels.wheelstest.TestClient` (HTTP integration testing): chainable actions return `this`, terminals return values.
+
+## Status (v4.0 PR 1 of 4 — foundation)
+
+This PR lands the plumbing. CLI, dogfood specs, and CI matrix integration come in PRs 2-4.
+
+**What works:** navigation, interaction, keyboard, waiting (default timeout), scoping, viewport, script evaluation, most assertions, most terminals, lifecycle via `browserDescribe`.
+
+**What's deferred:** `loginAs`/`logout` (needs test-only route + fixture server), dialogs, cookies, configurable timeouts, auto-screenshot-on-failure, viewport at `BrowserTest` level. All share one root blocker: Playwright's Java API uses inner classes (`Page$GetByRoleOptions`, `Locator$WaitForOptions`, `Browser$NewContextOptions`, `Cookie`, …) that Lucee's `createObject("java", ...)` path can't build when those classes live inside a URLClassLoader. A reflection-based helper (planned follow-up) unblocks all of them.
+
+## Installation
+
+Before first use:
+
+```bash
+bash tools/install-playwright.sh
+```
+
+Idempotent. Downloads seven JARs totalling ~192 MB (client + driver + driver-bundle + gson + Java-WebSocket + slf4j-api + slf4j-simple) from Maven Central, SHA-verifies each, then runs `playwright install chromium` which drops ~170 MB of Chromium under `~/Library/Caches/ms-playwright/` (macOS) or `~/.cache/ms-playwright/` (Linux). Re-running is a no-op once the SHAs match.
+
+**PR 2 replaces this with `wheels browser:install`.**
+
+## Architecture
+
+Three CFCs under `vendor/wheels/wheelstest/`:
+
+1. **`BrowserLauncher.cfc`** — process-level owner of the Playwright instance. Reads `vendor/wheels/browser-manifest.json`, walks the `classpath[]` array to compute JAR paths, loads them into a `URLClassLoader` with `PlatformClassLoader` as parent (critical — see Gotchas below), acquires one `Browser` per engine, caches it. State machine: `uninitialized → ready → shut-down`.
+2. **`BrowserClient.cfc`** — the DSL. Takes a `Page`, a `BrowserContext`, and a base URL; wraps Playwright's locator/page APIs with the ~40 chainable methods enumerated below.
+3. **`BrowserTest.cfc`** — TestBox BDD base class. `beforeAll` lazy-initializes an application-scoped launcher so all spec CFCs in a test run share one Chromium startup (~1.7 s). Provides `browserDescribe(title, body)` which wraps `describe()` with per-`it` beforeEach/afterEach that create a fresh `BrowserContext` and inject it as `this.browser`.
+
+## Spec structure
+
+```cfm
+component extends="wheels.wheelstest.BrowserTest" {
+
+    this.browserEngine = "chromium";   // chromium is the only engine in PR 1
+
+    function run() {
+        // browserDescribe === describe + per-it browser lifecycle.
+        // Mix with plain describe() blocks for non-browser tests.
+        browserDescribe("My feature", () => {
+
+            it("renders the welcome page", () => {
+                if (this.browserTestSkipped) return;  // see "CI / skip logic"
+                this.browser
+                    .visitUrl("data:text/html,<h1>Hello</h1>")
+                    .assertSee("Hello");
+            });
+        });
+    }
+}
+```
+
+### Why `browserDescribe` instead of `beforeEach` on the class
+
+TestBox BDD treats `beforeAll`/`afterAll` as class-level lifecycle hooks but `beforeEach`/`afterEach` as *registration* functions that must be called from inside a `describe` body. So the natural "add a method named `beforeEach` to the parent class and let inheritance do its thing" pattern doesn't work. `browserDescribe` sidesteps this by calling `describe(...)` internally and registering the hooks from within the suite body.
+
+## CI / skip logic
+
+`beforeAll` calls `$ensureLauncher()`, which throws `Wheels.BrowserNotInstalled` when any classpath JAR is missing. `BrowserTest` catches that and sets `this.browserTestSkipped = true`; `browserDescribe`'s hooks then short-circuit. Every `it` should start with:
+
+```cfm
+if (this.browserTestSkipped) return;
+```
+
+so CI (which doesn't run `install-playwright.sh`) stays green. Counts the skipped tests as passing, which is consistent with TestBox's "return early = pass" semantics.
+
+## Implemented DSL methods
+
+### Navigation
+
+```cfm
+this.browser
+    .visit("/login")                  // baseUrl + path; requires leading slash
+    .visitUrl("data:text/html,<h1/>") // absolute URL; any scheme
+    .back()
+    .forward()
+    .refresh();
+
+this.browser.currentUrl();  // terminal → string
+```
+
+`visitRoute(name, params)` is **deferred** (depends on Wheels `urlFor()` framework context, which isn't available outside a controller).
+
+### Interaction
+
+```cfm
+this.browser
+    .click("##signin-button")            // CSS selector
+    .press("Sign in")                    // visible text (getByText().first())
+    .fill("##email", "alice@example.com")
+    .type("##search", "wheels")          // char-by-char (triggers autocomplete handlers)
+    .clear("##email")
+    .select("##country", "US")
+    .check("##terms")
+    .uncheck("##newsletter")
+    .attach("##upload", "/path/to/file.txt")
+    .dragAndDrop("##source", "##target");
+```
+
+`press()` matches by visible text (Playwright `getByText(...).first()`). If you need role-specific matching (e.g., button-only, ignoring same-text headings), use `click("button:has-text('Save')")` instead.
+
+### Keyboard
+
+```cfm
+this.browser
+    .keys("##email", "Control+A")       // any key combination
+    .pressEnter("##password")            // shorthand; selector optional
+    .pressTab()                          // no selector → sends to focused element
+    .pressEscape();
+```
+
+### Waiting
+
+```cfm
+this.browser
+    .waitFor("##late-loaded-element")   // waits up to Playwright's default (30s)
+    .waitForText("Loading complete");
+```
+
+`waitForUrl` and configurable timeouts are **deferred** (need URLClassLoader-constructed option objects).
+
+### Scoping
+
+```cfm
+// Same `#email` selector in two different forms — within() disambiguates.
+this.browser.within("form##signin", (scoped) => {
+    scoped.fill("##email", "alice@example.com")
+          .fill("##password", "secret")
+          .click("button[type=submit]");
+});
+```
+
+Inside the callback, `scoped` is a BrowserClient whose selectors resolve relative to the `form#signin` subtree.
+
+### Viewport
+
+```cfm
+this.browser
+    .resize(1024, 768)
+    .resizeToMobile()      // 375 x 667
+    .resizeToTablet()      // 768 x 1024
+    .resizeToDesktop();    // 1440 x 900
+```
+
+### Script + Pause
+
+```cfm
+var title = this.browser.script("() => document.title");
+var count = this.browser.script("() => document.querySelectorAll('li').length");
+this.browser.pause(500);  // prints a warning; use waitFor instead for sync
+```
+
+### Assertions
+
+All throw `Wheels.BrowserAssertionFailed` on mismatch and return `this` on success.
+
+**Text / visibility / presence:**
+- `assertSee(text)` / `assertDontSee(text)` — page-wide substring (case-insensitive)
+- `assertSeeIn(selector, text)` — scoped substring
+- `assertVisible(selector)` — rendered + not `display:none`
+- `assertMissing(selector)` / `assertPresent(selector)` / `assertNotPresent(selector)` — DOM count checks
+
+**URL / title / query:**
+- `assertUrlIs(expected)` — path-only compare when arg starts with `/`, otherwise full URL
+- `assertUrlContains(substring)` — substring check (more forgiving for dynamic URLs)
+- `assertTitleContains(text)` — case-insensitive
+- `assertQueryStringHas(key [, value])` / `assertQueryStringMissing(key)`
+
+**Form:**
+- `assertInputValue(selector, value)`
+- `assertChecked(selector)`
+- `assertHasClass(selector, class)` — space-separated list match
+
+### Terminals
+
+```cfm
+this.browser.currentUrl();           // string
+this.browser.title();                // <title> content
+this.browser.pageSource();           // full HTML
+this.browser.text("h1");             // textContent of first match
+this.browser.value("##email");       // input/textarea/select value
+this.browser.screenshot("/tmp/x.png"); // writes PNG; returns this for chaining
+```
+
+## Gotchas (keep these in working memory when writing browser specs)
+
+### `##` in CFML strings
+
+CFML treats `#` as an expression delimiter inside double-quoted strings. To emit a literal `#` (for CSS ID selectors), escape as `##`. So `"##email"` compiles to the runtime string `"#email"`.
+
+### `client` is a reserved Lucee scope
+
+Declaring `var client = ...` inside a closure throws "client scope is not enabled". Use `var c`, `var bc`, or `variables.bc` instead. Same goes for `session`, `application`, `request`, `form`, `url`, `arguments`, `local`, `variables`, `this` — avoid as local variable names.
+
+### Data URLs for most tests
+
+Many DSL methods can be tested against inline `data:text/html,...` URLs without any server running. This is the pattern used throughout `BrowserIntegrationSpec.cfc`. Data URLs can carry query strings (`data:text/html,<h1/>?foo=bar`) and fragments, but **cannot set HTTP cookies or localStorage** — Chromium treats them as opaque origins. For anything involving cookies or server-driven redirects, you need a real fixture server running at `baseUrl`.
+
+### URLClassLoader + Playwright's inner-class options
+
+`createObject("java", "com.microsoft.playwright.Locator$WaitForOptions")` fails under Lucee when the class lives inside a URLClassLoader — Lucee's class-resolver tries to treat the loader as an OSGi bundle and can't. Workaround (not yet implemented as a DSL helper; apply by hand if you need a specific option):
+
+```cfm
+var cl = variables.$browser.getClass().getClassLoader();
+var klass = cl.loadClass("com.microsoft.playwright.Locator$WaitForOptions");
+var opts = klass.getDeclaredConstructor().newInstance();
+opts.setTimeout(javaCast("double", 5000));
+```
+
+A `$buildOption(className, ...)` helper on `BrowserLauncher` is planned — when it lands, configurable-timeout `waitFor`, `waitForUrl`, full screenshot options, and cookie manipulation all unblock.
+
+### `PlatformClassLoader` as parent
+
+If you're building another URLClassLoader-backed Java library on top of the manifest install, parent it to `ClassLoader.getPlatformClassLoader()` rather than `getSystemClassLoader()` / TCCL. AppClassLoader-as-parent causes cross-JAR superclass resolution to fail at `defineClass` time with `NoClassDefFoundError` — even when the superclass IS on the URLClassLoader's own URLs. This was the most painful trap in the Task 4 implementation.
+
+### Thread context classloader during Playwright calls
+
+Playwright's `DriverJar.getDriverResourceURI()` uses `Thread.currentThread().getContextClassLoader()` to locate the bundled Node runtime inside `driver-bundle.jar`. Default TCCL is the AppClassLoader, which doesn't see our JARs — so the lookup returns null and `Playwright.create()` fails with an NPE that Lucee swallows silently (looks like a hang — it's not). `BrowserLauncher.acquireBrowser()` swaps TCCL to our URLClassLoader for the duration of the Playwright call chain. If you call Playwright methods outside the DSL (directly via `this.browser.getPage()`), you may need `$pushTCCL()` / `$popTCCL()` manually.
+
+## Deferred functionality
+
+Tracked as follow-ups to this PR:
+
+| Category | What's missing | Unblocked by |
+|---|---|---|
+| Auth | `loginAs(identifier)`, `logout()`, `keepSignedInAs` | Test-only route (`POST /_browser/login-as`) + running fixture server |
+| Dialogs | `acceptDialog`, `dismissDialog`, `typeInDialog` | `createDynamicProxy` → `Consumer<Dialog>` via URLClassLoader |
+| Cookies | `setCookie`, `deleteCookie`, `cookie` | Cookie option object |
+| Timeouts | Configurable timeout on `waitFor` / `waitForText` | `Locator$WaitForOptions` |
+| Routes | `visitRoute`, `assertRouteIs` | Wheels `urlFor()` outside controller context |
+| URL waiting | `waitForUrl` | `Page$WaitForURLOptions` + baseUrl wiring |
+| Viewport config | `this.browserViewport = "mobile"` on `BrowserTest` | `ViewportSize` + `Browser$NewContextOptions` |
+| Screenshot options | `clip`, `fullPage`, `quality` | `Page$ScreenshotOptions` |
+| Auto-artifact dump | screenshot + HTML on failure | TestBox `aroundEach` hook + failure detection |
+| Fixture app integration | End-to-end flow through Wheels HTTP pipeline | Dedicated fixture-server bootstrap |
+
+Most share the same root blocker (URLClassLoader + OSGi bundle resolver). A single `$buildOption(className, …)` reflection helper unblocks cookies, dialogs, timeouts, waitForUrl, viewport config, and screenshot options in one shot.
+
+## PR roadmap
+
+- **PR 1 (this PR):** Foundation — launcher, client, base class, install bootstrap, core DSL.
+- **PR 2:** `wheels browser:install` + `wheels browser:test` CLI + MCP tools.
+- **PR 3:** `packages/hotwire/` dogfood browser specs against a real app.
+- **PR 4:** CI workflow integration + reference docs promotion from draft.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -762,6 +762,79 @@ if (isSSERequest()) { renderSSE(data="..."); }
 
 Client-side: `const es = new EventSource('/controller/notifications');`
 
+## Browser Testing Quick Reference
+
+Foundation landed in v4.0 (PR 1 of 4). Specs extend `wheels.wheelstest.BrowserTest` and drive a real Chromium through `this.browser` — a fluent DSL wrapping Playwright Java.
+
+```cfm
+// vendor/wheels/tests/specs/browser/LoginBrowserSpec.cfc
+component extends="wheels.wheelstest.BrowserTest" {
+
+    this.browserEngine = "chromium";   // chromium only in PR 1
+
+    function run() {
+        // browserDescribe() wraps describe() with beforeEach/afterEach that
+        // create a fresh Page per `it`. TestBox's BDD lifecycle only treats
+        // beforeAll/afterAll as class-level, so we register per-it hooks
+        // from inside the suite body via this helper.
+        browserDescribe("Login flow", () => {
+            it("can load a page and read its title", () => {
+                if (this.browserTestSkipped) return;
+                this.browser.visitUrl("data:text/html,<title>Hi</title><h1>x</h1>")
+                            .assertTitleContains("Hi");
+            });
+        });
+    }
+}
+```
+
+Install Playwright locally before first run (~370MB download: JARs + Chromium):
+
+```bash
+bash tools/install-playwright.sh    # temp bootstrap; replaced by `wheels browser:install` in PR 2
+```
+
+Then run browser specs via the normal test suite:
+```bash
+bash tools/test-local.sh                    # skips browser specs if JARs missing
+```
+
+### Implemented DSL methods
+
+- **Navigation:** visit, visitUrl, back, forward, refresh
+- **Interaction:** click, press, fill, type, clear, select, check, uncheck, attach, dragAndDrop
+- **Keyboard:** keys, pressEnter, pressTab, pressEscape
+- **Waiting:** waitFor, waitForText
+- **Scoping:** within(selector, callback)
+- **Viewport:** resize, resizeToMobile, resizeToTablet, resizeToDesktop
+- **Script:** script (returns `page.evaluate` result), pause
+- **Assertions (text/vis/presence):** assertSee, assertDontSee, assertSeeIn, assertVisible, assertMissing, assertPresent, assertNotPresent
+- **Assertions (URL/title/query):** assertUrlIs, assertUrlContains, assertTitleContains, assertQueryStringHas, assertQueryStringMissing
+- **Assertions (form):** assertInputValue, assertChecked, assertHasClass
+- **Terminals:** currentUrl, title, pageSource, text, value, screenshot
+
+### Deferred to follow-up PRs
+
+These need a reflection-based Playwright option-object builder (URLClassLoader + Lucee OSGi trap), a running fixture-app server, or `createDynamicProxy` plumbing — each worth its own focused pass:
+
+- Auth: `loginAs(identifier)`, `logout()` — test-only route + fixture server
+- Cookies: `setCookie`, `deleteCookie`, `cookie` — needs `options.Cookie`
+- Dialogs: `acceptDialog`, `dismissDialog`, `typeInDialog` — needs `createDynamicProxy` → `Consumer<Dialog>`
+- `waitForUrl`, `assertRouteIs` — depend on baseUrl concat + Wheels `urlFor` context
+- Configurable timeouts on `waitFor` — needs `Locator$WaitForOptions`
+- `visitRoute` — depends on controller-context `urlFor`
+- Viewport configuration at `BrowserTest` level — needs `ViewportSize` + `Browser$NewContextOptions`
+- Auto screenshot on failure — needs TestBox aroundEach + failure hook
+
+### Key gotchas
+
+- **`##` in selectors** — CFML requires `##` to emit literal `#`. `"##email"` → `"#email"` at runtime.
+- **`client` is a Lucee reserved scope.** `var client = ...` in a closure throws "client scope is not enabled". Use `var c = ...` or `var bc = ...`.
+- **Data URLs work for most tests** — no server needed for ~95% of DSL coverage. Full HTTP integration (cookies, form submits, redirects) needs a running fixture app; that wiring is the same as Wheels Web app bootstrap (separate server + baseUrl).
+- **`this.browserTestSkipped`** — when Playwright JARs aren't installed (fresh CI, clean machine), `beforeAll` sets this flag and `browserDescribe`'s hooks short-circuit. All `it`s should check `if (this.browserTestSkipped) return;` to stay green on CI.
+
+Full reference: `.ai/wheels/testing/browser-testing.md`.
+
 ## Reference Docs
 
 Deeper documentation lives in `.ai/` — Claude will search it automatically when needed:

--- a/docs/superpowers/plans/2026-04-15-browser-testing-foundation.md
+++ b/docs/superpowers/plans/2026-04-15-browser-testing-foundation.md
@@ -430,13 +430,15 @@ git commit -m "feat(test): add temporary Playwright install bootstrap"
 
 ## Task 4: `BrowserLauncher` — Playwright instance + Browser acquisition
 
-**⚠ Manifest amended in Task 3:** The original plan assumed two JARs (client + driver-bundle). Task 3 discovered Playwright's full runtime set is seven JARs and restructured the manifest to a `classpath` array. That invalidates the `$jarPath` + `$driverBundlePath` helpers and the integration-test skip logic shown below. Before implementing, replace the two-helper pattern with:
+**⚠ Amended from original plan.** Task 3 discovered Playwright's full runtime set is seven JARs and restructured the manifest to a `classpath` array. Task 4's implementation diverges from the original plan as follows:
 
-- **`$classpathJarPaths(installDir) → array`** — reads `variables.$manifest.classpath` and returns `[installDir & "/lib/" & entry.filename, …]` for every entry.
-- **Skip logic** — `ArrayEvery(paths, fileExists)` rather than two individual `fileExists` checks.
-- **`$loadJars(jarPaths)`** — unchanged; already takes an array. Just pass it all seven paths.
+- **Added: `$classpathJarPaths(installDir) → array`** — reads `variables.$manifest.classpath` and returns `[installDir & "/lib/" & entry.filename, …]` for every entry.
+- **Added: `getManifest()`, `getClassLoader()`, `getState()`** — accessors for the private `variables.$*` scope, needed by tests (CFML `variables` scope isn't externally accessible).
+- **Added: `$findZeroArgMethod()`** — Lucee's Java-varargs bridge can't reliably express an empty `Class<?>[]` to `Class.getMethod(String, Class<?>...)`, so locate zero-arg methods by iterating `getMethods()`.
+- **Dropped: `$driverBundlePath()`** — no longer a meaningful notion once the manifest drives everything through `classpath[]`.
+- **`$loadJars(jarPaths)`** — unchanged from original design. Just pass it all seven paths from `$classpathJarPaths()`.
 
-The `$jarPath()` helper written in Task 2 still works for the client JAR specifically (used in unit tests), so it does not need to be removed.
+**⚠ Known blocker — browser launch path hangs.** `acquireBrowser()` is implemented but the full `Playwright.create() → chromium() → launch()` path hangs when invoked through the URLClassLoader on Lucee 7 + OpenJDK 21. The Node driver process spawns (`~/.lucli/servers/wheels/temp/playwright-java-*/node cli.js run-driver`) but the Java side blocks on IPC read indefinitely. Tests in this PR verify the foundation layer (classpath walker + URLClassLoader loading + state machine + class-resolution through the loader); full browser integration is deferred to a follow-up debug pass. Hypothesis: Lucee's method-call interception on URLClassLoader-loaded classes interferes with the node process's stdin/stdout inheritance.
 
 **Files:**
 - Modify: `vendor/wheels/wheelstest/BrowserLauncher.cfc`

--- a/docs/superpowers/plans/2026-04-15-browser-testing-foundation.md
+++ b/docs/superpowers/plans/2026-04-15-browser-testing-foundation.md
@@ -435,10 +435,12 @@ git commit -m "feat(test): add temporary Playwright install bootstrap"
 - **Added: `$classpathJarPaths(installDir) → array`** — reads `variables.$manifest.classpath` and returns `[installDir & "/lib/" & entry.filename, …]` for every entry.
 - **Added: `getManifest()`, `getClassLoader()`, `getState()`** — accessors for the private `variables.$*` scope, needed by tests (CFML `variables` scope isn't externally accessible).
 - **Added: `$findZeroArgMethod()`** — Lucee's Java-varargs bridge can't reliably express an empty `Class<?>[]` to `Class.getMethod(String, Class<?>...)`, so locate zero-arg methods by iterating `getMethods()`.
+- **Added: `$pushTCCL()` / `$popTCCL()`** — Playwright's `DriverJar` uses `Thread.currentThread().getContextClassLoader()` to find bundled-driver resources. Default TCCL (AppClassLoader) doesn't see our JARs, so every call into Playwright runtime code must swap TCCL for the duration.
 - **Dropped: `$driverBundlePath()`** — no longer a meaningful notion once the manifest drives everything through `classpath[]`.
+- **URLClassLoader parent = `PlatformClassLoader`** (not `SystemClassLoader` / TCCL). With AppClassLoader as parent, URLClassLoader fails to resolve cross-JAR superclass references (e.g. `driver-bundle`'s `DriverJar extends driver.jar`'s `Driver`) with `NoClassDefFoundError` at `defineClass` time. PlatformClassLoader only exposes the JDK stdlib, giving our JARs a self-contained layer.
 - **`$loadJars(jarPaths)`** — unchanged from original design. Just pass it all seven paths from `$classpathJarPaths()`.
 
-**⚠ Known blocker — browser launch path hangs.** `acquireBrowser()` is implemented but the full `Playwright.create() → chromium() → launch()` path hangs when invoked through the URLClassLoader on Lucee 7 + OpenJDK 21. The Node driver process spawns (`~/.lucli/servers/wheels/temp/playwright-java-*/node cli.js run-driver`) but the Java side blocks on IPC read indefinitely. Tests in this PR verify the foundation layer (classpath walker + URLClassLoader loading + state machine + class-resolution through the loader); full browser integration is deferred to a follow-up debug pass. Hypothesis: Lucee's method-call interception on URLClassLoader-loaded classes interferes with the node process's stdin/stdout inheritance.
+Two non-obvious Playwright+Lucee integration traps were resolved during implementation (see commit body for the full debug trail): cross-JAR class resolution required dropping the AppClassLoader from the parent chain, and resource lookup required swapping TCCL during every call that reaches into Playwright runtime code.
 
 **Files:**
 - Modify: `vendor/wheels/wheelstest/BrowserLauncher.cfc`

--- a/docs/superpowers/plans/2026-04-15-browser-testing-foundation.md
+++ b/docs/superpowers/plans/2026-04-15-browser-testing-foundation.md
@@ -1,0 +1,3189 @@
+# Browser Testing — Foundation (PR 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the foundation layer for native browser testing in Wheels — `BrowserClient.cfc` (fluent DSL over Playwright Java), `BrowserLauncher.cfc` (Playwright singleton + JAR loading), `BrowserTest.cfc` (TestBox base class with per-`it` context lifecycle), test-only login route, and integration tests. CLI, dogfood specs, and CI wiring are deferred to PRs 2-4.
+
+**Architecture:** `BrowserClient` wraps one Playwright `BrowserContext` + `Page` with a fluent DSL that mirrors `TestClient.cfc`'s shape (chainable methods return `this`, terminals return values). `BrowserLauncher` is a process-level singleton that holds one `Playwright` instance per test run, discovered via JAR path lookup. `BrowserTest` extends `wheels.WheelsTest` and manages the per-`it` context/page lifecycle via TestBox hooks. A test-only `POST /_browser/login-as` route lets specs authenticate without going through the UI.
+
+**Tech Stack:** CFML (Lucee 7 primary), Playwright Java 1.45.0, TestBox BDD, Wheels Testing (`wheels.WheelsTest`).
+
+**Spec:** `docs/superpowers/specs/2026-04-15-browser-testing-design.md`
+
+**Follow-up plans (not in this one):**
+- Plan 2: `wheels browser:install` + `wheels browser:test` CLI + MCP tools
+- Plan 3: `packages/hotwire/` dogfood browser specs
+- Plan 4: CI workflow + reference docs
+
+---
+
+## File Map
+
+**Create:**
+- `vendor/wheels/browser-manifest.json` — pinned versions + SHA256s
+- `vendor/wheels/wheelstest/BrowserLauncher.cfc` — Playwright singleton + JAR loader
+- `vendor/wheels/wheelstest/BrowserClient.cfc` — fluent DSL (~35 methods)
+- `vendor/wheels/wheelstest/BrowserTest.cfc` — TestBox base class
+- `vendor/wheels/wheelstest/BrowserTestLoginController.cfc` — test-only auth endpoint
+- `vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc` — path discovery unit tests
+- `vendor/wheels/tests/specs/wheelstest/BrowserTestLoginControllerSpec.cfc` — route guard tests
+- `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc` — real Chromium end-to-end
+- `vendor/wheels/tests/fixtures/browserapp/` — minimal Wheels app for integration testing
+- `tools/install-playwright.sh` — bootstrap script (temporary; replaced by `wheels browser:install` in PR 2)
+
+**Modify:**
+- `vendor/wheels/routes.cfm` — register test-only login route (env-guarded)
+
+**Responsibility split:**
+- `BrowserLauncher.cfc`: JVM-side concerns only — JAR path resolution, `Playwright.create()` caching, `Browser` acquisition per engine. No DSL knowledge.
+- `BrowserClient.cfc`: DSL only — every method maps to a Playwright call. No TestBox, no lifecycle.
+- `BrowserTest.cfc`: TestBox lifecycle glue — wires BrowserLauncher → BrowserClient, injects into spec, dumps artifacts on failure.
+- `BrowserTestLoginController.cfc`: one action, one responsibility — delegate to app's `$signInAsForBrowserTest` hook.
+
+---
+
+## Task 1: Pin Playwright Java version in `browser-manifest.json`
+
+**Files:**
+- Create: `vendor/wheels/browser-manifest.json`
+
+- [ ] **Step 1: Fetch the current Playwright Java release info**
+
+Run:
+```bash
+curl -s "https://search.maven.org/solrsearch/select?q=g:com.microsoft.playwright+AND+a:playwright&rows=1&wt=json" | python3 -m json.tool
+```
+Expected: JSON with `response.docs[0].latestVersion` field. Record this version (the plan uses `1.45.0` as a placeholder; substitute the actual latest).
+
+- [ ] **Step 2: Compute the JAR's SHA256**
+
+Run:
+```bash
+VERSION="1.45.0"  # substitute with value from step 1
+curl -sSL -o /tmp/playwright-${VERSION}.jar \
+  "https://repo1.maven.org/maven2/com/microsoft/playwright/playwright/${VERSION}/playwright-${VERSION}.jar"
+shasum -a 256 /tmp/playwright-${VERSION}.jar
+```
+Expected: 64-char hex SHA256. Record it.
+
+- [ ] **Step 3: Write `vendor/wheels/browser-manifest.json`**
+
+```json
+{
+    "schemaVersion": 1,
+    "playwrightJavaVersion": "1.45.0",
+    "playwrightJavaJar": {
+        "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/playwright/1.45.0/playwright-1.45.0.jar",
+        "sha256": "REPLACE_WITH_SHA256_FROM_STEP_2",
+        "size": 51380224
+    },
+    "browsers": {
+        "chromium": "1124",
+        "firefox": "1440",
+        "webkit": "2033"
+    },
+    "minJavaVersion": 21,
+    "installDir": "~/.wheels/browser"
+}
+```
+
+Substitute `REPLACE_WITH_SHA256_FROM_STEP_2` and `"1.45.0"` with the real values from steps 1-2.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vendor/wheels/browser-manifest.json
+git commit -m "feat(test): pin Playwright Java version for browser testing"
+```
+
+---
+
+## Task 2: `BrowserLauncher.cfc` — JAR path discovery
+
+**Files:**
+- Create: `vendor/wheels/wheelstest/BrowserLauncher.cfc`
+- Create: `vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc`
+
+- [ ] **Step 1: Write failing tests for path discovery**
+
+Create `vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc`:
+
+```cfm
+component extends="wheels.WheelsTest" {
+
+    function beforeAll() {
+        variables.launcher = CreateObject("component", "wheels.wheelstest.BrowserLauncher");
+    }
+
+    function run() {
+        describe("BrowserLauncher path discovery", () => {
+
+            it("resolveInstallDir() returns WHEELS_BROWSER_HOME env var when set", () => {
+                var stubbed = variables.launcher.$resolveInstallDir(
+                    envVar="/tmp/custom-browser-home",
+                    homeDir="/Users/someone"
+                );
+                expect(stubbed).toBe("/tmp/custom-browser-home");
+            });
+
+            it("resolveInstallDir() falls back to ~/.wheels/browser when env var empty", () => {
+                var resolved = variables.launcher.$resolveInstallDir(
+                    envVar="",
+                    homeDir="/Users/someone"
+                );
+                expect(resolved).toBe("/Users/someone/.wheels/browser");
+            });
+
+            it("resolveInstallDir() handles home dir with trailing slash", () => {
+                var resolved = variables.launcher.$resolveInstallDir(
+                    envVar="",
+                    homeDir="/Users/someone/"
+                );
+                expect(resolved).toBe("/Users/someone/.wheels/browser");
+            });
+
+            it("jarPath() returns installDir + /lib/playwright-VERSION.jar", () => {
+                var p = variables.launcher.$jarPath(
+                    installDir="/tmp/browser",
+                    version="1.45.0"
+                );
+                expect(p).toBe("/tmp/browser/lib/playwright-1.45.0.jar");
+            });
+
+            it("verifyInstall() throws when JAR missing", () => {
+                expect(() => {
+                    variables.launcher.$verifyInstall(jarPath="/does/not/exist.jar");
+                }).toThrow(type="Wheels.BrowserNotInstalled");
+            });
+
+            it("verifyInstall() returns true when JAR exists", () => {
+                var tmpJar = getTempDirectory() & "dummy-" & createUUID() & ".jar";
+                fileWrite(tmpJar, "");
+                try {
+                    expect(variables.launcher.$verifyInstall(jarPath=tmpJar)).toBeTrue();
+                } finally {
+                    fileDelete(tmpJar);
+                }
+            });
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserLauncher
+```
+Expected: FAIL with "component not found" or similar — `BrowserLauncher.cfc` doesn't exist yet.
+
+- [ ] **Step 3: Implement path discovery in `BrowserLauncher.cfc`**
+
+Create `vendor/wheels/wheelstest/BrowserLauncher.cfc`:
+
+```cfm
+/**
+ * Process-level singleton that owns the Playwright instance + Browser
+ * for browser-driven tests. Not instantiated per-spec; the BrowserTest
+ * base class uses the application-scoped instance.
+ *
+ * Responsibilities (split by stage):
+ *   1. JAR path resolution (this task)
+ *   2. Playwright lazy init + Browser acquisition (next task)
+ *   3. Release/shutdown
+ *
+ * Not responsible for: DSL, lifecycle hooks, artifact dumping.
+ */
+component {
+
+    variables.$manifest = "";
+    variables.$playwright = "";        // Java Playwright instance (lazy)
+    variables.$browsers = {};           // cache: engine => Java Browser instance
+    variables.$state = "uninitialized"; // uninitialized | ready | shut-down
+
+    public BrowserLauncher function init() {
+        variables.$manifest = $loadManifest();
+        return this;
+    }
+
+    /**
+     * Reads vendor/wheels/browser-manifest.json.
+     */
+    public struct function $loadManifest() {
+        var manifestPath = expandPath("/wheels/browser-manifest.json");
+        if (!fileExists(manifestPath)) {
+            throw(
+                type="Wheels.BrowserManifestMissing",
+                message="Expected vendor/wheels/browser-manifest.json to exist."
+            );
+        }
+        return deserializeJSON(fileRead(manifestPath));
+    }
+
+    /**
+     * Resolves the install directory based on env var or home dir fallback.
+     * Pure function — passed-in args make it unit-testable.
+     */
+    public string function $resolveInstallDir(
+        required string envVar,
+        required string homeDir
+    ) {
+        if (len(trim(arguments.envVar)) > 0) {
+            return arguments.envVar;
+        }
+        var home = arguments.homeDir;
+        if (right(home, 1) == "/") {
+            home = left(home, len(home) - 1);
+        }
+        return home & "/.wheels/browser";
+    }
+
+    /**
+     * Default entry point — reads env var + home dir from the runtime.
+     */
+    public string function resolveInstallDir() {
+        var envVar = server.system.environment["WHEELS_BROWSER_HOME"] ?: "";
+        return $resolveInstallDir(envVar=envVar, homeDir=getUserHome());
+    }
+
+    public string function $jarPath(
+        required string installDir,
+        required string version
+    ) {
+        return arguments.installDir & "/lib/playwright-" & arguments.version & ".jar";
+    }
+
+    public boolean function $verifyInstall(required string jarPath) {
+        if (!fileExists(arguments.jarPath)) {
+            throw(
+                type="Wheels.BrowserNotInstalled",
+                message="Playwright JAR not found at " & arguments.jarPath
+                    & ". Run `wheels browser:install` to set up browser testing."
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Returns the path to the user's home directory. Override-friendly for tests.
+     */
+    public string function getUserHome() {
+        return createObject("java", "java.lang.System").getProperty("user.home");
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserLauncher
+```
+Expected: PASS — all 6 specs pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserLauncher.cfc \
+        vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
+git commit -m "feat(test): add BrowserLauncher JAR path discovery"
+```
+
+---
+
+## Task 3: Write `tools/install-playwright.sh` bootstrap script
+
+Integration tests in subsequent tasks require Playwright installed locally. This is a temporary bootstrap script; PR 2 will replace it with `wheels browser:install`.
+
+**Files:**
+- Create: `tools/install-playwright.sh`
+
+- [ ] **Step 1: Write the script**
+
+Create `tools/install-playwright.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Temporary bootstrap for browser testing. Replaced by `wheels browser:install`
+# once PR 2 lands. Reads vendor/wheels/browser-manifest.json for pinned versions.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST="$REPO_ROOT/vendor/wheels/browser-manifest.json"
+INSTALL_DIR="${WHEELS_BROWSER_HOME:-$HOME/.wheels/browser}"
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: $MANIFEST not found" >&2
+    exit 1
+fi
+
+VERSION=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['playwrightJavaVersion'])")
+JAR_URL=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['playwrightJavaJar']['url'])")
+JAR_SHA=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['playwrightJavaJar']['sha256'])")
+JAR_PATH="$INSTALL_DIR/lib/playwright-$VERSION.jar"
+
+mkdir -p "$INSTALL_DIR/lib"
+
+if [[ -f "$JAR_PATH" ]]; then
+    ACTUAL_SHA=$(shasum -a 256 "$JAR_PATH" | awk '{print $1}')
+    if [[ "$ACTUAL_SHA" == "$JAR_SHA" ]]; then
+        echo "✓ Playwright JAR already installed at $JAR_PATH"
+    else
+        echo "! JAR exists but SHA mismatch; re-downloading"
+        rm -f "$JAR_PATH"
+    fi
+fi
+
+if [[ ! -f "$JAR_PATH" ]]; then
+    echo "Downloading Playwright Java $VERSION..."
+    curl -sSL -o "$JAR_PATH" "$JAR_URL"
+    ACTUAL_SHA=$(shasum -a 256 "$JAR_PATH" | awk '{print $1}')
+    if [[ "$ACTUAL_SHA" != "$JAR_SHA" ]]; then
+        echo "ERROR: SHA mismatch. Expected $JAR_SHA, got $ACTUAL_SHA" >&2
+        rm -f "$JAR_PATH"
+        exit 1
+    fi
+    echo "✓ Downloaded and verified"
+fi
+
+echo "Installing Chromium via Playwright CLI..."
+java -cp "$JAR_PATH" com.microsoft.playwright.CLI install chromium
+
+echo "Done. Install dir: $INSTALL_DIR"
+```
+
+- [ ] **Step 2: Make executable and test it runs**
+
+```bash
+chmod +x tools/install-playwright.sh
+bash tools/install-playwright.sh
+```
+Expected: downloads JAR, verifies SHA, installs Chromium. `~/.wheels/browser/lib/playwright-1.45.0.jar` and `~/.wheels/browser/browsers/chromium-*/` exist afterward.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/install-playwright.sh
+git commit -m "feat(test): add temporary Playwright install bootstrap"
+```
+
+---
+
+## Task 4: `BrowserLauncher` — Playwright instance + Browser acquisition
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserLauncher.cfc`
+- Modify: `vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc` (add integration tests)
+
+- [ ] **Step 1: Write failing integration test for browser acquisition**
+
+Append to `vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc`, inside `run()` after the existing `describe`:
+
+```cfm
+describe("BrowserLauncher integration (requires Playwright install)", () => {
+
+    it("acquireBrowser('chromium') returns a Java Browser instance", () => {
+        // skip if JAR missing — will be loud in unit-test CI but silent locally
+        // when developer hasn't run install-playwright.sh yet
+        var installDir = variables.launcher.resolveInstallDir();
+        var jarPath = variables.launcher.$jarPath(
+            installDir=installDir,
+            version=variables.launcher.$manifest.playwrightJavaVersion
+        );
+        if (!fileExists(jarPath)) {
+            debug("Skipping: Playwright JAR not installed. Run tools/install-playwright.sh");
+            return;
+        }
+
+        variables.launcher.$loadJar(jarPath=jarPath);
+        var browser = variables.launcher.acquireBrowser(engine="chromium");
+
+        expect(browser).notToBeNull();
+        expect(isObject(browser)).toBeTrue();
+
+        // Must be callable — ensures we got a real Browser, not a stub
+        var contexts = browser.contexts();
+        expect(contexts).notToBeNull();
+
+        variables.launcher.release();
+    });
+
+    it("acquireBrowser() returns the same Browser across calls (singleton per engine)", () => {
+        var installDir = variables.launcher.resolveInstallDir();
+        var jarPath = variables.launcher.$jarPath(
+            installDir=installDir,
+            version=variables.launcher.$manifest.playwrightJavaVersion
+        );
+        if (!fileExists(jarPath)) {
+            return;
+        }
+
+        variables.launcher.$loadJar(jarPath=jarPath);
+        var b1 = variables.launcher.acquireBrowser(engine="chromium");
+        var b2 = variables.launcher.acquireBrowser(engine="chromium");
+
+        expect(b1).toBe(b2);
+        variables.launcher.release();
+    });
+});
+```
+
+- [ ] **Step 2: Run test — expect fail on missing `acquireBrowser` method**
+
+Run:
+```bash
+bash tools/install-playwright.sh    # ensures JAR exists
+bash tools/test-local.sh --filter=wheelstest.BrowserLauncher
+```
+Expected: FAIL — `acquireBrowser` doesn't exist on BrowserLauncher yet.
+
+- [ ] **Step 3: Implement Playwright loading + browser acquisition**
+
+Append to `vendor/wheels/wheelstest/BrowserLauncher.cfc` (before the closing `}`):
+
+```cfm
+/**
+ * Dynamically loads the Playwright JAR into the current ClassLoader so
+ * CreateObject("java", ...) can find Playwright classes. Lucee-specific;
+ * Adobe CF support deferred.
+ *
+ * Must be called before any acquireBrowser() call.
+ */
+public void function $loadJar(required string jarPath) {
+    if (variables.$state != "uninitialized") {
+        return;  // idempotent
+    }
+
+    // Use Lucee's JavaLoader equivalent — application scope javaSettings
+    var jarDir = getDirectoryFromPath(arguments.jarPath);
+    application.$wheelsBrowserJarDir = jarDir;
+
+    // Lucee 7: reload the classloader by touching Application.cfc settings
+    // Alternative: use the java.net.URLClassLoader directly
+    var urlClass = createObject("java", "java.net.URL");
+    var jarFile = createObject("java", "java.io.File").init(arguments.jarPath);
+    var jarUrl = jarFile.toURI().toURL();
+    var urls = [jarUrl];
+
+    var parentLoader = createObject("java", "java.lang.Thread")
+        .currentThread()
+        .getContextClassLoader();
+    var classLoader = createObject("java", "java.net.URLClassLoader")
+        .init(urls, parentLoader);
+
+    variables.$classLoader = classLoader;
+    variables.$state = "ready";
+}
+
+/**
+ * Returns the Browser for the given engine, creating and caching it on first call.
+ *
+ * @engine One of: chromium, firefox, webkit
+ */
+public any function acquireBrowser(string engine = "chromium") {
+    if (variables.$state != "ready") {
+        throw(
+            type="Wheels.BrowserLauncherNotReady",
+            message="Call $loadJar() first. State: " & variables.$state
+        );
+    }
+
+    if (structKeyExists(variables.$browsers, arguments.engine)) {
+        return variables.$browsers[arguments.engine];
+    }
+
+    if (!isObject(variables.$playwright)) {
+        var playwrightClass = variables.$classLoader.loadClass("com.microsoft.playwright.Playwright");
+        variables.$playwright = playwrightClass.getMethod("create", javaCast("null", "")).invoke(javaCast("null", ""), javaCast("null", ""));
+    }
+
+    var browserType = $getBrowserType(engine=arguments.engine);
+    var launchOptions = variables.$classLoader
+        .loadClass("com.microsoft.playwright.BrowserType$LaunchOptions")
+        .getDeclaredConstructor().newInstance();
+    launchOptions.setHeadless(javaCast("boolean", true));
+
+    var browser = browserType.launch(launchOptions);
+    variables.$browsers[arguments.engine] = browser;
+    return browser;
+}
+
+private any function $getBrowserType(required string engine) {
+    switch (arguments.engine) {
+        case "chromium":
+            return variables.$playwright.chromium();
+        case "firefox":
+            return variables.$playwright.firefox();
+        case "webkit":
+            return variables.$playwright.webkit();
+        default:
+            throw(
+                type="Wheels.BrowserEngineInvalid",
+                message="Unknown engine: " & arguments.engine
+                    & ". Valid: chromium, firefox, webkit."
+            );
+    }
+}
+
+/**
+ * Closes all acquired browsers and the Playwright instance. Call once per
+ * test run (not per spec CFC).
+ */
+public void function release() {
+    for (var engine in variables.$browsers) {
+        try {
+            variables.$browsers[engine].close();
+        } catch (any e) {
+            // best-effort cleanup
+        }
+    }
+    variables.$browsers = {};
+
+    if (isObject(variables.$playwright)) {
+        try {
+            variables.$playwright.close();
+        } catch (any e) {
+        }
+        variables.$playwright = "";
+    }
+
+    variables.$state = "shut-down";
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run:
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserLauncher
+```
+Expected: PASS on all specs including the two integration ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserLauncher.cfc \
+        vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
+git commit -m "feat(test): BrowserLauncher Playwright instance and browser acquisition"
+```
+
+---
+
+## Task 5: Minimal fixture app for integration tests
+
+Subsequent tasks need a real Wheels app running to point the browser at. Build a skeletal app under `vendor/wheels/tests/fixtures/browserapp/`.
+
+**Files:**
+- Create: `vendor/wheels/tests/fixtures/browserapp/config/routes.cfm`
+- Create: `vendor/wheels/tests/fixtures/browserapp/config/settings.cfm`
+- Create: `vendor/wheels/tests/fixtures/browserapp/app/controllers/Home.cfc`
+- Create: `vendor/wheels/tests/fixtures/browserapp/app/controllers/Sessions.cfc`
+- Create: `vendor/wheels/tests/fixtures/browserapp/app/views/home/index.cfm`
+- Create: `vendor/wheels/tests/fixtures/browserapp/app/views/sessions/new.cfm`
+- Create: `vendor/wheels/tests/fixtures/browserapp/app/views/home/dashboard.cfm`
+
+- [ ] **Step 1: Create routes**
+
+Create `vendor/wheels/tests/fixtures/browserapp/config/routes.cfm`:
+
+```cfm
+<cfscript>
+mapper()
+    .root(to="home##index", method="get")
+    .get(name="login", pattern="/login", to="sessions##new")
+    .post(name="authenticate", pattern="/login", to="sessions##create")
+    .get(name="dashboard", pattern="/dashboard", to="home##dashboard")
+    .post(name="logout", pattern="/logout", to="sessions##destroy")
+    .wildcard()
+.end();
+</cfscript>
+```
+
+- [ ] **Step 2: Create settings**
+
+Create `vendor/wheels/tests/fixtures/browserapp/config/settings.cfm`:
+
+```cfm
+<cfscript>
+set(environment="testing");
+set(dataSourceName="wheelstestdb");
+</cfscript>
+```
+
+- [ ] **Step 3: Create Home controller**
+
+Create `vendor/wheels/tests/fixtures/browserapp/app/controllers/Home.cfc`:
+
+```cfm
+component extends="Controller" {
+
+    function init() {
+        filters(through="$requireLogin", except="index");
+    }
+
+    function index() {
+    }
+
+    function dashboard() {
+        user = { email: session.userEmail ?: "" };
+    }
+
+    private function $requireLogin() {
+        if (!structKeyExists(session, "userId")) {
+            redirectTo(route="login");
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Create Sessions controller**
+
+Create `vendor/wheels/tests/fixtures/browserapp/app/controllers/Sessions.cfc`:
+
+```cfm
+component extends="Controller" {
+
+    function new() {
+        flashError = flash("error") ?: "";
+    }
+
+    function create() {
+        if (params.email == "alice@example.com" && params.password == "secret") {
+            session.userId = 1;
+            session.userEmail = params.email;
+            redirectTo(route="dashboard");
+        } else {
+            flashInsert(error="Invalid credentials");
+            redirectTo(route="login");
+        }
+    }
+
+    function destroy() {
+        structClear(session);
+        redirectTo(route="login");
+    }
+}
+```
+
+- [ ] **Step 5: Create views**
+
+Create `vendor/wheels/tests/fixtures/browserapp/app/views/home/index.cfm`:
+
+```cfm
+<cfoutput>
+<h1>Home</h1>
+<p>Welcome to the browser test fixture app.</p>
+<a href="#urlFor(route='login')#">Log in</a>
+</cfoutput>
+```
+
+Create `vendor/wheels/tests/fixtures/browserapp/app/views/sessions/new.cfm`:
+
+```cfm
+<cfparam name="flashError" default="">
+<cfoutput>
+<h1>Log in</h1>
+<cfif len(flashError)>
+    <div class="error">#flashError#</div>
+</cfif>
+<form method="post" action="#urlFor(route='authenticate')#">
+    <input type="email" name="email" id="email">
+    <input type="password" name="password" id="password">
+    <button type="submit">Sign in</button>
+</form>
+</cfoutput>
+```
+
+Create `vendor/wheels/tests/fixtures/browserapp/app/views/home/dashboard.cfm`:
+
+```cfm
+<cfparam name="user" default="#{}#">
+<cfoutput>
+<h1>Dashboard</h1>
+<p>Welcome, #encodeForHTML(user.email)#</p>
+<form method="post" action="#urlFor(route='logout')#">
+    <button type="submit">Log out</button>
+</form>
+</cfoutput>
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vendor/wheels/tests/fixtures/browserapp/
+git commit -m "feat(test): minimal fixture app for browser integration tests"
+```
+
+---
+
+## Task 6: `BrowserClient` — init + navigation methods
+
+**Files:**
+- Create: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Create: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+- [ ] **Step 1: Write failing integration test**
+
+Create `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`:
+
+```cfm
+component extends="wheels.WheelsTest" {
+
+    function beforeAll() {
+        variables.launcher = CreateObject("component", "wheels.wheelstest.BrowserLauncher");
+        var installDir = variables.launcher.resolveInstallDir();
+        var jarPath = variables.launcher.$jarPath(
+            installDir=installDir,
+            version=variables.launcher.$manifest.playwrightJavaVersion
+        );
+        if (!fileExists(jarPath)) {
+            variables.skipBrowserTests = true;
+            return;
+        }
+        variables.skipBrowserTests = false;
+        variables.launcher.$loadJar(jarPath=jarPath);
+        variables.browser = variables.launcher.acquireBrowser(engine="chromium");
+        variables.baseUrl = "http://localhost:8080";
+    }
+
+    function afterAll() {
+        if (!(variables.skipBrowserTests ?: false)) {
+            variables.launcher.release();
+        }
+    }
+
+    function run() {
+        describe("BrowserClient navigation", () => {
+
+            beforeEach(() => {
+                if (variables.skipBrowserTests) { return; }
+                variables.context = variables.browser.newContext();
+                variables.page = variables.context.newPage();
+                variables.client = CreateObject("component", "wheels.wheelstest.BrowserClient")
+                    .init(page=variables.page, context=variables.context, baseUrl=variables.baseUrl);
+            });
+
+            afterEach(() => {
+                if (variables.skipBrowserTests) { return; }
+                variables.context.close();
+            });
+
+            it("visit(path) navigates to baseUrl + path and returns this for chaining", () => {
+                if (variables.skipBrowserTests) { return; }
+                var result = variables.client.visit("/");
+                expect(result).toBe(variables.client);
+                expect(variables.client.currentUrl()).toInclude("/");
+            });
+
+            it("visit() rejects non-leading-slash paths with clear error", () => {
+                if (variables.skipBrowserTests) { return; }
+                expect(() => {
+                    variables.client.visit("no-leading-slash");
+                }).toThrow(type="Wheels.BrowserInvalidPath");
+            });
+
+            it("currentUrl() returns page.url() from Playwright", () => {
+                if (variables.skipBrowserTests) { return; }
+                variables.client.visit("/");
+                expect(variables.client.currentUrl()).toInclude(variables.baseUrl);
+            });
+        });
+    }
+}
+```
+
+Note: tests assume a LuCLI server is running on :8080 with the fixture app mounted. Subsequent tasks will wire that up properly; for now, run `wheels server start` manually before running these specs.
+
+- [ ] **Step 2: Run test — expect fail**
+
+Start a server pointed at the fixture app and run tests:
+```bash
+cd /Users/peter/GitHub/wheels-dev/wheels && lucli server run --port=8080 &
+sleep 5
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+Expected: FAIL — `BrowserClient.cfc` doesn't exist.
+
+- [ ] **Step 3: Implement `BrowserClient.cfc` init + navigation**
+
+Create `vendor/wheels/wheelstest/BrowserClient.cfc`:
+
+```cfm
+/**
+ * Fluent DSL wrapping a Playwright BrowserContext + Page for browser tests.
+ * Mirrors TestClient.cfc's shape: chainable methods return `this`,
+ * terminals return values.
+ *
+ * Instantiation: typically done by BrowserTest.cfc's beforeEach hook.
+ * For manual use, pass Playwright objects directly.
+ */
+component {
+
+    variables.page = "";
+    variables.context = "";
+    variables.baseUrl = "";
+
+    public BrowserClient function init(
+        required any page,
+        required any context,
+        required string baseUrl
+    ) {
+        variables.page = arguments.page;
+        variables.context = arguments.context;
+        variables.baseUrl = arguments.baseUrl;
+        return this;
+    }
+
+    // ─── Navigation ──────────────────────────────────────────────────
+
+    public BrowserClient function visit(required string path) {
+        $requireLeadingSlash(arguments.path);
+        variables.page.navigate(variables.baseUrl & arguments.path);
+        return this;
+    }
+
+    public BrowserClient function visitRoute(
+        required string name,
+        struct params = {}
+    ) {
+        // Delegates to Wheels urlFor() which is available because the app
+        // is running. When used outside a controller context, callers must
+        // wire baseUrl + expected path; visitRoute here requires app context.
+        var url = urlFor(argumentCollection=arguments);
+        return visit(url);
+    }
+
+    public BrowserClient function back() {
+        variables.page.goBack();
+        return this;
+    }
+
+    public BrowserClient function forward() {
+        variables.page.goForward();
+        return this;
+    }
+
+    public BrowserClient function refresh() {
+        variables.page.reload();
+        return this;
+    }
+
+    // ─── Terminals ───────────────────────────────────────────────────
+
+    public string function currentUrl() {
+        return variables.page.url();
+    }
+
+    // ─── Internal helpers ────────────────────────────────────────────
+
+    private void function $requireLeadingSlash(required string path) {
+        if (left(arguments.path, 1) != "/") {
+            throw(
+                type="Wheels.BrowserInvalidPath",
+                message="BrowserClient paths must start with '/': " & arguments.path
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc \
+        vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): BrowserClient navigation methods"
+```
+
+---
+
+## Task 7: `BrowserClient` — interaction methods
+
+Adds: `click`, `press`, `fill`, `type`, `clear`, `select`, `check`, `uncheck`, `attach`, `dragAndDrop`.
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Modify: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+- [ ] **Step 1: Add failing tests for interaction methods**
+
+Inside the `run()` block in `BrowserIntegrationSpec.cfc`, add a new `describe`:
+
+```cfm
+describe("BrowserClient interaction", () => {
+
+    beforeEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context = variables.browser.newContext();
+        variables.page = variables.context.newPage();
+        variables.client = CreateObject("component", "wheels.wheelstest.BrowserClient")
+            .init(page=variables.page, context=variables.context, baseUrl=variables.baseUrl);
+    });
+
+    afterEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context.close();
+    });
+
+    it("fill() sets input value instantly", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login").fill("##email", "alice@example.com");
+        var val = variables.page.locator("##email").inputValue();
+        expect(val).toBe("alice@example.com");
+    });
+
+    it("type() sends keystrokes character-by-character", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login").type("##email", "bob@example.com");
+        var val = variables.page.locator("##email").inputValue();
+        expect(val).toBe("bob@example.com");
+    });
+
+    it("clear() empties an input", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client
+            .visit("/login")
+            .fill("##email", "alice@example.com")
+            .clear("##email");
+        var val = variables.page.locator("##email").inputValue();
+        expect(val).toBe("");
+    });
+
+    it("click() triggers button click and waits for navigation", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client
+            .visit("/login")
+            .fill("##email", "alice@example.com")
+            .fill("##password", "secret")
+            .click("button[type=submit]");
+        expect(variables.client.currentUrl()).toInclude("/dashboard");
+    });
+
+    it("press() finds button by visible text and clicks", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client
+            .visit("/login")
+            .fill("##email", "alice@example.com")
+            .fill("##password", "secret")
+            .press("Sign in");
+        expect(variables.client.currentUrl()).toInclude("/dashboard");
+    });
+});
+```
+
+- [ ] **Step 2: Run tests — expect fail**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+Expected: FAIL — `fill`, `type`, `clear`, `click`, `press` don't exist.
+
+- [ ] **Step 3: Implement interaction methods**
+
+Append to `vendor/wheels/wheelstest/BrowserClient.cfc` before the `// ─── Terminals ───` block:
+
+```cfm
+// ─── Interaction ─────────────────────────────────────────────────
+
+public BrowserClient function click(required string selector) {
+    variables.page.locator(arguments.selector).click();
+    return this;
+}
+
+public BrowserClient function press(required string buttonText) {
+    // Matches button by visible text; Playwright has native support
+    variables.page.getByRole("button", $jNameOpts(name=arguments.buttonText)).click();
+    return this;
+}
+
+public BrowserClient function fill(
+    required string selector,
+    required string value
+) {
+    variables.page.locator(arguments.selector).fill(arguments.value);
+    return this;
+}
+
+public BrowserClient function type(
+    required string selector,
+    required string value
+) {
+    // Playwright Java uses pressSequentially for keystroke simulation
+    variables.page.locator(arguments.selector).pressSequentially(arguments.value);
+    return this;
+}
+
+public BrowserClient function clear(required string selector) {
+    variables.page.locator(arguments.selector).clear();
+    return this;
+}
+
+public BrowserClient function select(
+    required string selector,
+    required string value
+) {
+    variables.page.locator(arguments.selector).selectOption(arguments.value);
+    return this;
+}
+
+public BrowserClient function check(required string selector) {
+    variables.page.locator(arguments.selector).check();
+    return this;
+}
+
+public BrowserClient function uncheck(required string selector) {
+    variables.page.locator(arguments.selector).uncheck();
+    return this;
+}
+
+public BrowserClient function attach(
+    required string selector,
+    required string filePath
+) {
+    variables.page.locator(arguments.selector).setInputFiles(
+        createObject("java", "java.nio.file.Paths").get(arguments.filePath, [])
+    );
+    return this;
+}
+
+public BrowserClient function dragAndDrop(
+    required string fromSelector,
+    required string toSelector
+) {
+    variables.page.locator(arguments.fromSelector)
+        .dragTo(variables.page.locator(arguments.toSelector));
+    return this;
+}
+```
+
+Also add this helper at the bottom of the file (before the final `}`):
+
+```cfm
+// ─── Java option-object helpers ──────────────────────────────────
+
+/**
+ * Builds a Playwright Page$GetByRoleOptions with a name filter.
+ * Java API: page.getByRole("button", new Page.GetByRoleOptions().setName("Save"))
+ */
+private any function $jNameOpts(required string name) {
+    var opts = createObject("java", "com.microsoft.playwright.Page$GetByRoleOptions").init();
+    opts.setName(arguments.name);
+    return opts;
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+Expected: PASS on all interaction specs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc \
+        vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): BrowserClient interaction methods"
+```
+
+---
+
+## Task 8: `BrowserClient` — keyboard + dialogs + waiting + scoping
+
+Adds: `keys`, `pressEnter`, `pressTab`, `pressEscape`, `acceptDialog`, `dismissDialog`, `typeInDialog`, `waitFor`, `waitForText`, `waitForUrl`, `within`.
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Modify: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+- [ ] **Step 1: Add tests**
+
+Append a new `describe` block inside `run()`:
+
+```cfm
+describe("BrowserClient keyboard, dialogs, waiting, scoping", () => {
+
+    beforeEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context = variables.browser.newContext();
+        variables.page = variables.context.newPage();
+        variables.client = CreateObject("component", "wheels.wheelstest.BrowserClient")
+            .init(page=variables.page, context=variables.context, baseUrl=variables.baseUrl);
+    });
+
+    afterEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context.close();
+    });
+
+    it("pressEnter() submits form via enter key", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client
+            .visit("/login")
+            .fill("##email", "alice@example.com")
+            .fill("##password", "secret")
+            .pressEnter("##password");
+        expect(variables.client.currentUrl()).toInclude("/dashboard");
+    });
+
+    it("waitFor(selector) waits for element to appear", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login");
+        var result = variables.client.waitFor("##email", 5);
+        expect(result).toBe(variables.client);
+    });
+
+    it("waitForText() waits for text to appear on page", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login");
+        var result = variables.client.waitForText("Log in", 5);
+        expect(result).toBe(variables.client);
+    });
+
+    it("waitForUrl() waits until page URL matches", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client
+            .visit("/login")
+            .fill("##email", "alice@example.com")
+            .fill("##password", "secret")
+            .click("button[type=submit]")
+            .waitForUrl("/dashboard", 5);
+        expect(variables.client.currentUrl()).toInclude("/dashboard");
+    });
+
+    it("within(selector, callback) scopes subsequent selectors to subtree", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client
+            .visit("/login")
+            .within("form", function(scoped) {
+                scoped.fill("##email", "alice@example.com");
+            });
+        var val = variables.page.locator("##email").inputValue();
+        expect(val).toBe("alice@example.com");
+    });
+});
+```
+
+- [ ] **Step 2: Run tests — expect fail**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+Expected: FAIL — none of these methods exist yet.
+
+- [ ] **Step 3: Implement keyboard + dialogs + waiting + scoping**
+
+Append to `BrowserClient.cfc` after the interaction methods:
+
+```cfm
+// ─── Keyboard ────────────────────────────────────────────────────
+
+public BrowserClient function keys(
+    required string selector,
+    required string key
+) {
+    variables.page.locator(arguments.selector).press(arguments.key);
+    return this;
+}
+
+public BrowserClient function pressEnter(string selector = "") {
+    return $pressSpecial(selector=arguments.selector, key="Enter");
+}
+
+public BrowserClient function pressTab(string selector = "") {
+    return $pressSpecial(selector=arguments.selector, key="Tab");
+}
+
+public BrowserClient function pressEscape(string selector = "") {
+    return $pressSpecial(selector=arguments.selector, key="Escape");
+}
+
+private BrowserClient function $pressSpecial(
+    required string selector,
+    required string key
+) {
+    if (len(arguments.selector) > 0) {
+        variables.page.locator(arguments.selector).press(arguments.key);
+    } else {
+        variables.page.keyboard().press(arguments.key);
+    }
+    return this;
+}
+
+// ─── Dialogs ─────────────────────────────────────────────────────
+
+public BrowserClient function acceptDialog() {
+    // Playwright Java: page.onDialog(Consumer<Dialog>). Use createDynamicProxy
+    // to bridge a CFC implementing the Consumer interface (accept method).
+    // We track a one-shot flag via state on the handler CFC itself.
+    var handler = createObject("component", "wheels.wheelstest.dialogs.AcceptHandler");
+    variables.page.onDialog(createDynamicProxy(handler, ["java.util.function.Consumer"]));
+    return this;
+}
+
+public BrowserClient function dismissDialog() {
+    var handler = createObject("component", "wheels.wheelstest.dialogs.DismissHandler");
+    variables.page.onDialog(createDynamicProxy(handler, ["java.util.function.Consumer"]));
+    return this;
+}
+
+public BrowserClient function typeInDialog(required string text) {
+    var handler = createObject("component", "wheels.wheelstest.dialogs.PromptHandler")
+        .init(text=arguments.text);
+    variables.page.onDialog(createDynamicProxy(handler, ["java.util.function.Consumer"]));
+    return this;
+}
+
+// ─── Waiting ─────────────────────────────────────────────────────
+
+public BrowserClient function waitFor(
+    required string selector,
+    numeric seconds = 5
+) {
+    var opts = createObject("java", "com.microsoft.playwright.Locator$WaitForOptions").init();
+    opts.setTimeout(javaCast("double", arguments.seconds * 1000));
+    variables.page.locator(arguments.selector).waitFor(opts);
+    return this;
+}
+
+public BrowserClient function waitForText(
+    required string text,
+    numeric seconds = 5
+) {
+    var opts = createObject("java", "com.microsoft.playwright.Locator$WaitForOptions").init();
+    opts.setTimeout(javaCast("double", arguments.seconds * 1000));
+    variables.page.getByText(arguments.text).waitFor(opts);
+    return this;
+}
+
+public BrowserClient function waitForUrl(
+    required string path,
+    numeric seconds = 5
+) {
+    var opts = createObject("java", "com.microsoft.playwright.Page$WaitForURLOptions").init();
+    opts.setTimeout(javaCast("double", arguments.seconds * 1000));
+    variables.page.waitForURL(variables.baseUrl & arguments.path, opts);
+    return this;
+}
+
+// ─── Scoping ─────────────────────────────────────────────────────
+
+public BrowserClient function within(
+    required string selector,
+    required any callback
+) {
+    var scoped = CreateObject("component", "wheels.wheelstest.BrowserClient")
+        .init(
+            page=variables.page,
+            context=variables.context,
+            baseUrl=variables.baseUrl
+        );
+    scoped.$setScope(variables.page.locator(arguments.selector));
+    arguments.callback(scoped);
+    return this;
+}
+
+/**
+ * Used by within() to restrict subsequent selectors to a subtree.
+ * Implementation detail: scoped client overrides the locator resolver.
+ */
+public void function $setScope(required any rootLocator) {
+    variables.$scope = arguments.rootLocator;
+}
+```
+
+Now also add scope-aware locator resolution. Update the private locator helpers — replace direct `variables.page.locator(selector)` calls inside interaction methods with a helper. Add this helper near `$jNameOpts`:
+
+```cfm
+private any function $locator(required string selector) {
+    if (structKeyExists(variables, "$scope")) {
+        return variables.$scope.locator(arguments.selector);
+    }
+    return variables.page.locator(arguments.selector);
+}
+```
+
+Then replace all occurrences of `variables.page.locator(arguments.selector)` with `$locator(arguments.selector)` inside the methods added in Task 7 (click, fill, type, clear, select, check, uncheck, attach, dragAndDrop, keys).
+
+- [ ] **Step 4: Create dialog handler CFCs**
+
+These CFCs implement `java.util.function.Consumer<Dialog>` — single
+method `accept(Object)`. CFML's `createDynamicProxy` bridges the CFC's
+`accept` method to the Java interface.
+
+Create `vendor/wheels/wheelstest/dialogs/AcceptHandler.cfc`:
+
+```cfm
+component {
+    public void function accept(required any dialog) {
+        arguments.dialog.accept();
+    }
+}
+```
+
+Create `vendor/wheels/wheelstest/dialogs/DismissHandler.cfc`:
+
+```cfm
+component {
+    public void function accept(required any dialog) {
+        arguments.dialog.dismiss();
+    }
+}
+```
+
+Create `vendor/wheels/wheelstest/dialogs/PromptHandler.cfc`:
+
+```cfm
+component {
+    variables.text = "";
+
+    public PromptHandler function init(required string text) {
+        variables.text = arguments.text;
+        return this;
+    }
+
+    public void function accept(required any dialog) {
+        arguments.dialog.accept(variables.text);
+    }
+}
+```
+
+- [ ] **Step 5: Run tests — expect pass**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+Expected: PASS on keyboard, waiting, and scoping specs. (Dialog specs come in Task 9 integration test — dialog handlers require a page that actually triggers dialogs.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc \
+        vendor/wheels/wheelstest/dialogs/ \
+        vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): BrowserClient keyboard, dialogs, waiting, scoping"
+```
+
+---
+
+## Task 9: `BrowserClient` — viewport, cookies, script, pause
+
+Adds: `resize`, `resizeToMobile`, `resizeToTablet`, `resizeToDesktop`, `setCookie`, `deleteCookie`, `cookie`, `script`, `pause`.
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Modify: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+- [ ] **Step 1: Add tests**
+
+Append a new `describe` block inside `run()`:
+
+```cfm
+describe("BrowserClient viewport + cookies + script", () => {
+
+    beforeEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context = variables.browser.newContext();
+        variables.page = variables.context.newPage();
+        variables.client = CreateObject("component", "wheels.wheelstest.BrowserClient")
+            .init(page=variables.page, context=variables.context, baseUrl=variables.baseUrl);
+    });
+
+    afterEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context.close();
+    });
+
+    it("resize(w, h) sets viewport size", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/").resize(800, 600);
+        var size = variables.page.viewportSize();
+        expect(size.width).toBe(800);
+        expect(size.height).toBe(600);
+    });
+
+    it("resizeToMobile() sets 375x667", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/").resizeToMobile();
+        var size = variables.page.viewportSize();
+        expect(size.width).toBe(375);
+        expect(size.height).toBe(667);
+    });
+
+    it("setCookie() and cookie() round-trip", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/").setCookie("foo", "bar");
+        expect(variables.client.cookie("foo")).toBe("bar");
+    });
+
+    it("deleteCookie() removes named cookie", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/").setCookie("tmp", "xyz").deleteCookie("tmp");
+        expect(variables.client.cookie("tmp")).toBe("");
+    });
+
+    it("script(js) executes JS and returns result", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/");
+        var result = variables.client.script("() => 2 + 2");
+        expect(result).toBe(4);
+    });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Append to `BrowserClient.cfc`:
+
+```cfm
+// ─── Viewport ────────────────────────────────────────────────────
+
+public BrowserClient function resize(
+    required numeric width,
+    required numeric height
+) {
+    variables.page.setViewportSize(
+        javaCast("int", arguments.width),
+        javaCast("int", arguments.height)
+    );
+    return this;
+}
+
+public BrowserClient function resizeToMobile() {
+    return resize(375, 667);
+}
+
+public BrowserClient function resizeToTablet() {
+    return resize(768, 1024);
+}
+
+public BrowserClient function resizeToDesktop() {
+    return resize(1440, 900);
+}
+
+// ─── Cookies ─────────────────────────────────────────────────────
+
+public BrowserClient function setCookie(
+    required string name,
+    required string value
+) {
+    var cookieOpts = createObject("java", "com.microsoft.playwright.options.Cookie")
+        .init(arguments.name, arguments.value);
+
+    // Extract host from current URL so cookie has a domain
+    var url = variables.page.url();
+    var host = $extractHost(url);
+    cookieOpts.setDomain(host);
+    cookieOpts.setPath("/");
+
+    var cookies = [cookieOpts];
+    variables.context.addCookies(cookies);
+    return this;
+}
+
+public BrowserClient function deleteCookie(required string name) {
+    // Playwright has no single-cookie delete; clear all and re-add everything
+    // except the target. For test use, this is acceptable.
+    var allCookies = variables.context.cookies();
+    variables.context.clearCookies();
+    for (var c in allCookies) {
+        if (c.name() != arguments.name) {
+            var opts = createObject("java", "com.microsoft.playwright.options.Cookie")
+                .init(c.name(), c.value());
+            opts.setDomain(c.domain());
+            opts.setPath(c.path());
+            variables.context.addCookies([opts]);
+        }
+    }
+    return this;
+}
+
+public string function cookie(required string name) {
+    var cookies = variables.context.cookies();
+    for (var c in cookies) {
+        if (c.name() == arguments.name) {
+            return c.value();
+        }
+    }
+    return "";
+}
+
+// ─── Script + Pause ──────────────────────────────────────────────
+
+public any function script(required string js) {
+    return variables.page.evaluate(arguments.js);
+}
+
+public BrowserClient function pause(required numeric milliseconds) {
+    var pauseWarningOff = (server.system.environment.BROWSER_TEST_PAUSE_WARNING ?: "on") == "off";
+    if (!pauseWarningOff) {
+        writeOutput("⚠ BrowserClient.pause() called for " & arguments.milliseconds
+            & "ms. Remove before committing or set BROWSER_TEST_PAUSE_WARNING=off.\n");
+    }
+    sleep(arguments.milliseconds);
+    return this;
+}
+
+private string function $extractHost(required string url) {
+    // Simple parse; good enough for test contexts
+    var noScheme = reReplace(arguments.url, "^https?://", "");
+    var firstSlash = find("/", noScheme);
+    if (firstSlash == 0) {
+        return noScheme;
+    }
+    var hostPort = left(noScheme, firstSlash - 1);
+    var colonIdx = find(":", hostPort);
+    if (colonIdx > 0) {
+        return left(hostPort, colonIdx - 1);
+    }
+    return hostPort;
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc \
+        vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): BrowserClient viewport, cookies, script, pause"
+```
+
+---
+
+## Task 10: Test-only login route + controller
+
+This provides the infrastructure for `loginAs()` in Task 11.
+
+**Files:**
+- Create: `vendor/wheels/wheelstest/BrowserTestLoginController.cfc`
+- Modify: `vendor/wheels/routes.cfm`
+- Create: `vendor/wheels/tests/specs/wheelstest/BrowserTestLoginControllerSpec.cfc`
+
+- [ ] **Step 1: Write failing test for the route guard**
+
+Create `vendor/wheels/tests/specs/wheelstest/BrowserTestLoginControllerSpec.cfc`:
+
+```cfm
+component extends="wheels.WheelsTest" {
+
+    function run() {
+        describe("BrowserTestLogin route registration", () => {
+
+            it("registers POST /_browser/login-as only when environment is 'testing'", () => {
+                var routes = $collectRoutes("testing");
+                var hasRoute = false;
+                for (var r in routes) {
+                    if ((r.pattern ?: "") == "/_browser/login-as" && r.methods contains "post") {
+                        hasRoute = true;
+                    }
+                }
+                expect(hasRoute).toBeTrue();
+            });
+
+            it("does NOT register the route when environment is 'production'", () => {
+                var routes = $collectRoutes("production");
+                for (var r in routes) {
+                    if ((r.pattern ?: "") == "/_browser/login-as") {
+                        fail("Route should not exist in production");
+                    }
+                }
+                expect(true).toBeTrue();
+            });
+        });
+
+        describe("BrowserTestLoginController", () => {
+
+            it("loginAs() returns 501 when app has not defined $signInAsForBrowserTest", () => {
+                var controller = CreateObject("component", "wheels.wheelstest.BrowserTestLoginController");
+                var mockParams = { identifier: "42" };
+                var response = controller.$invokeLoginAs(params=mockParams, hookDefined=false);
+                expect(response.status).toBe(501);
+                expect(response.body).toInclude("signInAsForBrowserTest");
+            });
+
+            it("loginAs() delegates to $signInAsForBrowserTest(identifier) when defined", () => {
+                var controller = CreateObject("component", "wheels.wheelstest.BrowserTestLoginController");
+                var capturedId = "";
+                var mockParams = { identifier: "alice@example.com" };
+                var response = controller.$invokeLoginAs(
+                    params=mockParams,
+                    hookDefined=true,
+                    hookFn=function(identifier) {
+                        capturedId = arguments.identifier;
+                    }
+                );
+                expect(capturedId).toBe("alice@example.com");
+                expect(response.status).toBe(204);
+            });
+        });
+    }
+
+    private array function $collectRoutes(required string environment) {
+        // Build a mapper() under the given environment and collect registered routes
+        var origEnv = get("environment") ?: "";
+        application.wheels.environment = arguments.environment;
+        try {
+            // Re-source routes.cfm under the target environment
+            savecontent variable="out" {
+                include template="/wheels/routes.cfm";
+            }
+            return application.wheels.mapper.getRoutes() ?: [];
+        } finally {
+            application.wheels.environment = origEnv;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserTestLoginController
+```
+Expected: FAIL — controller doesn't exist; route isn't registered.
+
+- [ ] **Step 3: Create the controller**
+
+Create `vendor/wheels/wheelstest/BrowserTestLoginController.cfc`:
+
+```cfm
+/**
+ * Test-only controller for browser authentication. Only instantiated when
+ * the app's routes.cfm registers `/_browser/login-as` — which itself is
+ * environment-gated to testing.
+ *
+ * Flow:
+ *   1. Request arrives with `identifier` in body
+ *   2. Controller checks the app has defined $signInAsForBrowserTest
+ *   3. Calls the hook with the identifier
+ *   4. Returns 204 (No Content) on success, 501 if hook undefined
+ */
+component extends="Controller" {
+
+    function loginAs() {
+        var result = $invokeLoginAs(
+            params=params,
+            hookDefined=$hookDefined(),
+            hookFn=$hookDefined() ? variables.$hookRef : function() {}
+        );
+        renderText(text=result.body, status=result.status);
+    }
+
+    /**
+     * Separated for unit testing — no framework coupling.
+     */
+    public struct function $invokeLoginAs(
+        required struct params,
+        required boolean hookDefined,
+        function hookFn
+    ) {
+        if (!structKeyExists(arguments.params, "identifier")) {
+            return {
+                status: 400,
+                body: "Missing 'identifier' in request body"
+            };
+        }
+
+        if (!arguments.hookDefined) {
+            return {
+                status: 501,
+                body: "Not implemented: app must define $signInAsForBrowserTest("
+                    & "identifier) in app/events/browsertest.cfm or equivalent."
+            };
+        }
+
+        arguments.hookFn(arguments.params.identifier);
+        return {
+            status: 204,
+            body: ""
+        };
+    }
+
+    private boolean function $hookDefined() {
+        // The app defines this function in its event scope; look it up there
+        if (structKeyExists(application, "$signInAsForBrowserTest")) {
+            variables.$hookRef = application.$signInAsForBrowserTest;
+            return true;
+        }
+        return false;
+    }
+}
+```
+
+- [ ] **Step 4: Register the route**
+
+In `vendor/wheels/routes.cfm`, add inside the mapper() chain, BEFORE `.wildcard()`:
+
+```cfm
+// Test-only browser login route. Registered only when environment is "testing".
+// Delegates to app-defined $signInAsForBrowserTest(identifier) hook.
+if ((get("environment") ?: "") == "testing") {
+    mapper.post(
+        name="wheelsBrowserTestLogin",
+        pattern="/_browser/login-as",
+        to="wheels.wheelstest.BrowserTestLoginController##loginAs"
+    );
+}
+```
+
+Note: adjust the insertion point based on the actual structure of `routes.cfm` — this block needs to be inside the mapper chain or as a sibling call that references the same mapper instance. Read the existing file before editing.
+
+- [ ] **Step 5: Run — expect pass**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserTestLoginController
+```
+Expected: PASS on all specs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserTestLoginController.cfc \
+        vendor/wheels/routes.cfm \
+        vendor/wheels/tests/specs/wheelstest/BrowserTestLoginControllerSpec.cfc
+git commit -m "feat(test): test-only browser login route with environment guard"
+```
+
+---
+
+## Task 11: `BrowserClient` — auth methods (`loginAs`, `logout`)
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Modify: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+- Modify: `vendor/wheels/tests/fixtures/browserapp/app/events/onapplicationstart.cfm` (create if missing)
+
+- [ ] **Step 1: Register the `$signInAsForBrowserTest` hook in fixture app**
+
+Create `vendor/wheels/tests/fixtures/browserapp/app/events/onapplicationstart.cfm`:
+
+```cfm
+<cfscript>
+application.$signInAsForBrowserTest = function(required any identifier) {
+    session.userId = arguments.identifier;
+    session.userEmail = arguments.identifier & "@example.com";
+};
+</cfscript>
+```
+
+- [ ] **Step 2: Add failing test**
+
+Append to `BrowserIntegrationSpec.cfc`:
+
+```cfm
+describe("BrowserClient auth", () => {
+
+    beforeEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context = variables.browser.newContext();
+        variables.page = variables.context.newPage();
+        variables.client = CreateObject("component", "wheels.wheelstest.BrowserClient")
+            .init(page=variables.page, context=variables.context, baseUrl=variables.baseUrl);
+    });
+
+    afterEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context.close();
+    });
+
+    it("loginAs(identifier) sets session cookie via test-only route", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.loginAs("42").visit("/dashboard");
+        // If loginAs worked, /dashboard doesn't redirect to /login
+        expect(variables.client.currentUrl()).toInclude("/dashboard");
+    });
+
+    it("logout() clears session cookies", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client
+            .loginAs("42")
+            .visit("/dashboard");
+        expect(variables.client.currentUrl()).toInclude("/dashboard");
+
+        variables.client.logout().visit("/dashboard");
+        expect(variables.client.currentUrl()).toInclude("/login");
+    });
+});
+```
+
+- [ ] **Step 3: Run — expect fail**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+Expected: FAIL — `loginAs`, `logout` don't exist.
+
+- [ ] **Step 4: Implement auth methods**
+
+Append to `BrowserClient.cfc`:
+
+```cfm
+// ─── Auth ────────────────────────────────────────────────────────
+
+public BrowserClient function loginAs(required any identifier) {
+    // POST to test-only login route via the browser context's request API,
+    // so cookies flow through the same jar the page uses.
+    var reqCtx = variables.context.request();
+    var body = {};
+    body["identifier"] = toString(arguments.identifier);
+
+    var postOpts = createObject("java", "com.microsoft.playwright.APIRequestContext$RequestOptions")
+        .init();
+    postOpts.setData(serializeJSON(body));
+    postOpts.setHeader("Content-Type", "application/json");
+
+    var response = reqCtx.post(variables.baseUrl & "/_browser/login-as", postOpts);
+
+    if (response.status() == 501) {
+        throw(
+            type="Wheels.BrowserTestLoginHookMissing",
+            message="App has not defined $signInAsForBrowserTest(identifier). "
+                & "Define it in app/events/onapplicationstart.cfm or app/events/browsertest.cfm."
+        );
+    }
+
+    if (response.status() != 204) {
+        throw(
+            type="Wheels.BrowserTestLoginFailed",
+            message="Test-only login endpoint returned " & response.status()
+                & ": " & response.text()
+        );
+    }
+
+    return this;
+}
+
+public BrowserClient function logout() {
+    variables.context.clearCookies();
+    return this;
+}
+```
+
+- [ ] **Step 5: Run — expect pass**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc \
+        vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc \
+        vendor/wheels/tests/fixtures/browserapp/app/events/onapplicationstart.cfm
+git commit -m "feat(test): BrowserClient loginAs and logout"
+```
+
+---
+
+## Task 12: `BrowserClient` — text + visibility + presence assertions
+
+Adds: `assertSee`, `assertDontSee`, `assertSeeIn`, `assertVisible`, `assertMissing`, `assertPresent`, `assertNotPresent`.
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Modify: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+- [ ] **Step 1: Add tests**
+
+Append to `BrowserIntegrationSpec.cfc`:
+
+```cfm
+describe("BrowserClient text/visibility assertions", () => {
+
+    beforeEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context = variables.browser.newContext();
+        variables.page = variables.context.newPage();
+        variables.client = CreateObject("component", "wheels.wheelstest.BrowserClient")
+            .init(page=variables.page, context=variables.context, baseUrl=variables.baseUrl);
+    });
+
+    afterEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context.close();
+    });
+
+    it("assertSee(text) passes when text is on page", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login").assertSee("Log in");
+    });
+
+    it("assertSee(text) throws when text is absent", () => {
+        if (variables.skipBrowserTests) { return; }
+        expect(() => {
+            variables.client.visit("/login").assertSee("Nonexistent content");
+        }).toThrow(type="Wheels.BrowserAssertionFailed");
+    });
+
+    it("assertDontSee(text) passes when text is absent", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login").assertDontSee("Nonexistent content");
+    });
+
+    it("assertSeeIn(selector, text) scopes to element", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login").assertSeeIn("h1", "Log in");
+    });
+
+    it("assertVisible(selector) passes when element is rendered", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login").assertVisible("##email");
+    });
+
+    it("assertMissing(selector) passes when element not in DOM", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login").assertMissing("##nonexistent-element");
+    });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+
+- [ ] **Step 3: Implement assertions**
+
+Append to `BrowserClient.cfc`:
+
+```cfm
+// ─── Assertions: text + visibility ───────────────────────────────
+
+public BrowserClient function assertSee(required string text) {
+    var content = variables.page.content();
+    if (!findNoCase(arguments.text, content)) {
+        $assertFail("Expected page to contain '" & arguments.text & "'");
+    }
+    return this;
+}
+
+public BrowserClient function assertDontSee(required string text) {
+    var content = variables.page.content();
+    if (findNoCase(arguments.text, content)) {
+        $assertFail("Expected page NOT to contain '" & arguments.text & "'");
+    }
+    return this;
+}
+
+public BrowserClient function assertSeeIn(
+    required string selector,
+    required string text
+) {
+    var elementText = $locator(arguments.selector).textContent();
+    if (!findNoCase(arguments.text, elementText)) {
+        $assertFail("Expected '" & arguments.selector & "' to contain '"
+            & arguments.text & "', got '" & elementText & "'");
+    }
+    return this;
+}
+
+public BrowserClient function assertVisible(required string selector) {
+    if (!$locator(arguments.selector).isVisible()) {
+        $assertFail("Expected '" & arguments.selector & "' to be visible");
+    }
+    return this;
+}
+
+public BrowserClient function assertMissing(required string selector) {
+    var count = $locator(arguments.selector).count();
+    if (count > 0) {
+        $assertFail("Expected '" & arguments.selector & "' to be missing, found "
+            & count & " elements");
+    }
+    return this;
+}
+
+public BrowserClient function assertPresent(required string selector) {
+    var count = $locator(arguments.selector).count();
+    if (count == 0) {
+        $assertFail("Expected '" & arguments.selector & "' to be present in DOM");
+    }
+    return this;
+}
+
+public BrowserClient function assertNotPresent(required string selector) {
+    var count = $locator(arguments.selector).count();
+    if (count > 0) {
+        $assertFail("Expected '" & arguments.selector & "' to be absent from DOM");
+    }
+    return this;
+}
+
+// ─── Assertion internals ─────────────────────────────────────────
+
+private void function $assertFail(required string message) {
+    throw(
+        type="Wheels.BrowserAssertionFailed",
+        message=arguments.message
+    );
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc \
+        vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): BrowserClient text and visibility assertions"
+```
+
+---
+
+## Task 13: `BrowserClient` — URL, query, title assertions
+
+Adds: `assertUrlIs`, `assertRouteIs`, `assertQueryStringHas`, `assertQueryStringMissing`, `assertTitleContains`.
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Modify: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+- [ ] **Step 1: Add tests**
+
+Append:
+
+```cfm
+describe("BrowserClient URL/title assertions", () => {
+
+    beforeEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context = variables.browser.newContext();
+        variables.page = variables.context.newPage();
+        variables.client = CreateObject("component", "wheels.wheelstest.BrowserClient")
+            .init(page=variables.page, context=variables.context, baseUrl=variables.baseUrl);
+    });
+
+    afterEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context.close();
+    });
+
+    it("assertUrlIs('/login') passes on matching path", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login").assertUrlIs("/login");
+    });
+
+    it("assertUrlIs throws on mismatch", () => {
+        if (variables.skipBrowserTests) { return; }
+        expect(() => {
+            variables.client.visit("/login").assertUrlIs("/wrong");
+        }).toThrow(type="Wheels.BrowserAssertionFailed");
+    });
+
+    it("assertQueryStringHas(key, value) passes when param present", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/?foo=bar").assertQueryStringHas("foo", "bar");
+    });
+
+    it("assertQueryStringHas(key) with no value asserts presence only", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/?foo=bar").assertQueryStringHas("foo");
+    });
+
+    it("assertQueryStringMissing(key) passes when param absent", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/").assertQueryStringMissing("baz");
+    });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+
+- [ ] **Step 3: Implement**
+
+Append to `BrowserClient.cfc`:
+
+```cfm
+// ─── Assertions: URL + query + title ─────────────────────────────
+
+public BrowserClient function assertUrlIs(required string path) {
+    var current = $pathFromUrl(variables.page.url());
+    if (current != arguments.path) {
+        $assertFail("Expected URL path '" & arguments.path & "', got '" & current & "'");
+    }
+    return this;
+}
+
+public BrowserClient function assertRouteIs(
+    required string name,
+    struct params = {}
+) {
+    var expectedUrl = urlFor(argumentCollection=arguments);
+    return assertUrlIs(expectedUrl);
+}
+
+public BrowserClient function assertQueryStringHas(
+    required string key,
+    string value = ""
+) {
+    var query = $queryParamsFromUrl(variables.page.url());
+    if (!structKeyExists(query, arguments.key)) {
+        $assertFail("Expected query string to contain '" & arguments.key
+            & "', current params: " & serializeJSON(query));
+    }
+    if (len(arguments.value) > 0 && query[arguments.key] != arguments.value) {
+        $assertFail("Expected '" & arguments.key & "' = '" & arguments.value
+            & "', got '" & query[arguments.key] & "'");
+    }
+    return this;
+}
+
+public BrowserClient function assertQueryStringMissing(required string key) {
+    var query = $queryParamsFromUrl(variables.page.url());
+    if (structKeyExists(query, arguments.key)) {
+        $assertFail("Expected query string to NOT contain '" & arguments.key & "'");
+    }
+    return this;
+}
+
+public BrowserClient function assertTitleContains(required string text) {
+    var title = variables.page.title();
+    if (!findNoCase(arguments.text, title)) {
+        $assertFail("Expected title to contain '" & arguments.text
+            & "', got '" & title & "'");
+    }
+    return this;
+}
+
+// ─── URL parsing helpers ─────────────────────────────────────────
+
+private string function $pathFromUrl(required string url) {
+    var noScheme = reReplace(arguments.url, "^https?://", "");
+    var firstSlash = find("/", noScheme);
+    if (firstSlash == 0) {
+        return "/";
+    }
+    var pathPlusQuery = mid(noScheme, firstSlash, len(noScheme));
+    var qIdx = find("?", pathPlusQuery);
+    if (qIdx > 0) {
+        return left(pathPlusQuery, qIdx - 1);
+    }
+    return pathPlusQuery;
+}
+
+private struct function $queryParamsFromUrl(required string url) {
+    var result = {};
+    var qIdx = find("?", arguments.url);
+    if (qIdx == 0) {
+        return result;
+    }
+    var queryString = mid(arguments.url, qIdx + 1, len(arguments.url));
+    var pairs = listToArray(queryString, "&");
+    for (var p in pairs) {
+        var parts = listToArray(p, "=", false, true);
+        if (arrayLen(parts) == 2) {
+            result[parts[1]] = urlDecode(parts[2]);
+        } else if (arrayLen(parts) == 1) {
+            result[parts[1]] = "";
+        }
+    }
+    return result;
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc \
+        vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): BrowserClient URL and query assertions"
+```
+
+---
+
+## Task 14: `BrowserClient` — form/attr assertions + terminals
+
+Adds: `assertInputValue`, `assertChecked`, `assertHasClass`, `title`, `pageSource`, `text`, `value`, `screenshot`.
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Modify: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+- [ ] **Step 1: Add tests**
+
+Append:
+
+```cfm
+describe("BrowserClient form assertions + terminals", () => {
+
+    beforeEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context = variables.browser.newContext();
+        variables.page = variables.context.newPage();
+        variables.client = CreateObject("component", "wheels.wheelstest.BrowserClient")
+            .init(page=variables.page, context=variables.context, baseUrl=variables.baseUrl);
+    });
+
+    afterEach(() => {
+        if (variables.skipBrowserTests) { return; }
+        variables.context.close();
+    });
+
+    it("assertInputValue(selector, value) passes on matching value", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client
+            .visit("/login")
+            .fill("##email", "foo@example.com")
+            .assertInputValue("##email", "foo@example.com");
+    });
+
+    it("value(selector) returns current input value", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login").fill("##email", "x@y.com");
+        expect(variables.client.value("##email")).toBe("x@y.com");
+    });
+
+    it("text(selector) returns element text content", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login");
+        expect(variables.client.text("h1")).toBe("Log in");
+    });
+
+    it("title() returns page title", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login");
+        expect(len(variables.client.title())).toBeGT(0);
+    });
+
+    it("pageSource() returns full HTML", () => {
+        if (variables.skipBrowserTests) { return; }
+        variables.client.visit("/login");
+        expect(variables.client.pageSource()).toInclude("<form");
+    });
+
+    it("screenshot(path) writes PNG file", () => {
+        if (variables.skipBrowserTests) { return; }
+        var path = getTempDirectory() & "wheels-test-" & createUUID() & ".png";
+        variables.client.visit("/login").screenshot(path);
+        try {
+            expect(fileExists(path)).toBeTrue();
+            expect(getFileInfo(path).size).toBeGT(0);
+        } finally {
+            if (fileExists(path)) {
+                fileDelete(path);
+            }
+        }
+    });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+
+- [ ] **Step 3: Implement**
+
+Append to `BrowserClient.cfc`:
+
+```cfm
+// ─── Assertions: form + attributes ───────────────────────────────
+
+public BrowserClient function assertInputValue(
+    required string selector,
+    required string value
+) {
+    var actual = $locator(arguments.selector).inputValue();
+    if (actual != arguments.value) {
+        $assertFail("Expected input '" & arguments.selector & "' value '"
+            & arguments.value & "', got '" & actual & "'");
+    }
+    return this;
+}
+
+public BrowserClient function assertChecked(required string selector) {
+    if (!$locator(arguments.selector).isChecked()) {
+        $assertFail("Expected '" & arguments.selector & "' to be checked");
+    }
+    return this;
+}
+
+public BrowserClient function assertHasClass(
+    required string selector,
+    required string class
+) {
+    var classAttr = $locator(arguments.selector).getAttribute("class") ?: "";
+    var classes = listToArray(classAttr, " ");
+    if (!arrayContainsNoCase(classes, arguments.class)) {
+        $assertFail("Expected '" & arguments.selector & "' to have class '"
+            & arguments.class & "', got '" & classAttr & "'");
+    }
+    return this;
+}
+
+// ─── Terminals ───────────────────────────────────────────────────
+
+public string function title() {
+    return variables.page.title();
+}
+
+public string function pageSource() {
+    return variables.page.content();
+}
+
+public string function text(required string selector) {
+    return $locator(arguments.selector).textContent();
+}
+
+public string function value(required string selector) {
+    return $locator(arguments.selector).inputValue();
+}
+
+public BrowserClient function screenshot(required string path) {
+    var opts = createObject("java", "com.microsoft.playwright.Page$ScreenshotOptions").init();
+    opts.setPath(createObject("java", "java.nio.file.Paths").get(arguments.path, []));
+    variables.page.screenshot(opts);
+    return this;
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserIntegration
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc \
+        vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): BrowserClient form assertions and terminals"
+```
+
+---
+
+## Task 15: `BrowserTest` base class — properties + beforeAll/afterAll
+
+**Files:**
+- Create: `vendor/wheels/wheelstest/BrowserTest.cfc`
+- Create: `vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc`
+
+- [ ] **Step 1: Write failing test**
+
+Create `vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc`:
+
+```cfm
+/**
+ * Self-test: exercises BrowserTest base class by creating a minimal
+ * spec that extends it and verifying the lifecycle hooks fire in order.
+ */
+component extends="wheels.BrowserTest" {
+
+    this.browserEngine = "chromium";
+    this.keepSignedInAs = "";          // start with no auto-login
+    this.browserViewport = "desktop";
+    this.screenshotOnFailure = false;  // keep the spec clean
+
+    function run() {
+        describe("BrowserTest lifecycle", () => {
+
+            it("this.browser is populated before each it block", () => {
+                if (!isObject(this.browser)) {
+                    fail("Expected this.browser to be populated");
+                }
+                expect(isObject(this.browser)).toBeTrue();
+            });
+
+            it("this.browser has visit() method", () => {
+                expect(structKeyExists(this.browser, "visit")).toBeTrue();
+            });
+
+            it("successive it blocks get fresh contexts (cookies reset)", () => {
+                // Set a cookie in this test; next test should not see it
+                this.browser.visit("/").setCookie("leaky", "yes");
+                expect(this.browser.cookie("leaky")).toBe("yes");
+                variables.$leakCheck = "set";
+            });
+
+            it("cookies from previous it block are gone", () => {
+                this.browser.visit("/");
+                expect(this.browser.cookie("leaky")).toBe("");
+            });
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserTestLifecycle
+```
+Expected: FAIL — `wheels.BrowserTest` doesn't exist.
+
+- [ ] **Step 3: Create `BrowserTest.cfc`**
+
+Create `vendor/wheels/wheelstest/BrowserTest.cfc`:
+
+```cfm
+/**
+ * TestBox base class for browser-driven specs.
+ *
+ * Usage:
+ *   component extends="wheels.BrowserTest" {
+ *       this.keepSignedInAs = "alice@example.com";  // optional
+ *       this.browserEngine = "chromium";            // optional
+ *       this.browserViewport = "desktop";           // optional
+ *
+ *       function run() {
+ *           describe("...", () => {
+ *               it("...", () => {
+ *                   this.browser.visit("/...")...
+ *               });
+ *           });
+ *       }
+ *   }
+ *
+ * Lifecycle:
+ *   beforeAll  — acquire Browser singleton; if keepSignedInAs set, capture storageState
+ *   beforeEach — create fresh context + page; wire into new BrowserClient; inject as this.browser
+ *   afterEach  — dump artifacts on failure; close context
+ *   afterAll   — release browser handle (Playwright stays alive for next spec)
+ */
+component extends="wheels.WheelsTest" {
+
+    this.keepSignedInAs = "";
+    this.browserViewport = "desktop";
+    this.browserEngine = "chromium";
+    this.screenshotOnFailure = true;
+    this.traceOnFailure = false;
+    this.browser = "";
+
+    // Internal
+    variables.$launcher = "";
+    variables.$browser = "";
+    variables.$context = "";
+    variables.$page = "";
+    variables.$savedState = "";
+    variables.$baseUrl = "";
+
+    function beforeAll() {
+        variables.$launcher = $ensureLauncher();
+        variables.$browser = variables.$launcher.acquireBrowser(engine=this.browserEngine);
+        variables.$baseUrl = $resolveBaseUrl();
+
+        if (len(this.keepSignedInAs) > 0) {
+            variables.$savedState = $captureStorageState(
+                identifier=this.keepSignedInAs,
+                browser=variables.$browser,
+                baseUrl=variables.$baseUrl
+            );
+        }
+    }
+
+    function afterAll() {
+        // The launcher + browser are process-scoped; don't close them here.
+        // Only null our refs.
+        variables.$browser = "";
+    }
+
+    /**
+     * Locates or creates the shared BrowserLauncher. Stored in application
+     * scope so one Playwright instance serves all specs in a run.
+     */
+    private any function $ensureLauncher() {
+        if (!structKeyExists(application, "$wheelsBrowserLauncher")) {
+            var l = CreateObject("component", "wheels.wheelstest.BrowserLauncher");
+            var installDir = l.resolveInstallDir();
+            var jarPath = l.$jarPath(installDir=installDir, version=l.$manifest.playwrightJavaVersion);
+            l.$verifyInstall(jarPath=jarPath);
+            l.$loadJar(jarPath=jarPath);
+            application.$wheelsBrowserLauncher = l;
+        }
+        return application.$wheelsBrowserLauncher;
+    }
+
+    private string function $resolveBaseUrl() {
+        return server.system.environment.WHEELS_BROWSER_TEST_BASE_URL
+            ?: "http://localhost:8080";
+    }
+
+    /**
+     * Logs in as the given identifier via the test-only route, captures
+     * the context's storage state (cookies + localStorage), returns a JSON
+     * string that can be replayed via newContext(storageState=...).
+     */
+    private string function $captureStorageState(
+        required any identifier,
+        required any browser,
+        required string baseUrl
+    ) {
+        var tmpContext = arguments.browser.newContext();
+        var tmpPage = tmpContext.newPage();
+        var tmpClient = CreateObject("component", "wheels.wheelstest.BrowserClient")
+            .init(page=tmpPage, context=tmpContext, baseUrl=arguments.baseUrl);
+        tmpClient.loginAs(arguments.identifier);
+
+        var state = tmpContext.storageState();
+        tmpContext.close();
+        return state;
+    }
+}
+```
+
+- [ ] **Step 4: Add beforeEach + afterEach (covered in next task — for now stub them)**
+
+Append to `BrowserTest.cfc` above the final `}`:
+
+```cfm
+    /**
+     * Creates a fresh context + page per it block. Replays storageState
+     * if keepSignedInAs is set.
+     */
+    function beforeEach() {
+        var newContextOpts = createObject("java", "com.microsoft.playwright.Browser$NewContextOptions").init();
+
+        if (len(variables.$savedState) > 0) {
+            newContextOpts.setStorageState(variables.$savedState);
+        }
+
+        $applyViewport(contextOpts=newContextOpts);
+
+        variables.$context = variables.$browser.newContext(newContextOpts);
+        variables.$page = variables.$context.newPage();
+
+        this.browser = CreateObject("component", "wheels.wheelstest.BrowserClient")
+            .init(
+                page=variables.$page,
+                context=variables.$context,
+                baseUrl=variables.$baseUrl
+            );
+    }
+
+    function afterEach() {
+        if (isObject(variables.$context)) {
+            try {
+                variables.$context.close();
+            } catch (any e) {
+                // best-effort
+            }
+            variables.$context = "";
+            variables.$page = "";
+            this.browser = "";
+        }
+    }
+
+    private void function $applyViewport(required any contextOpts) {
+        var vp = this.browserViewport;
+        var w = 1440;
+        var h = 900;
+        if (isStruct(vp)) {
+            w = vp.w ?: 1440;
+            h = vp.h ?: 900;
+        } else {
+            switch (vp) {
+                case "mobile":  w = 375;  h = 667;  break;
+                case "tablet":  w = 768;  h = 1024; break;
+                case "desktop": w = 1440; h = 900;  break;
+            }
+        }
+        var vpSize = createObject("java", "com.microsoft.playwright.options.ViewportSize")
+            .init(javaCast("int", w), javaCast("int", h));
+        arguments.contextOpts.setViewportSize(vpSize);
+    }
+```
+
+- [ ] **Step 5: Run — expect pass**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserTestLifecycle
+```
+Expected: PASS on all 4 lifecycle specs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserTest.cfc \
+        vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc
+git commit -m "feat(test): BrowserTest base class with per-it context lifecycle"
+```
+
+---
+
+## Task 16: `BrowserTest` — artifact dumping on failure
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserTest.cfc`
+- Create: `vendor/wheels/tests/specs/wheelstest/BrowserArtifactsSpec.cfc`
+
+- [ ] **Step 1: Write failing test**
+
+Create `vendor/wheels/tests/specs/wheelstest/BrowserArtifactsSpec.cfc`:
+
+```cfm
+component extends="wheels.BrowserTest" {
+
+    this.screenshotOnFailure = true;
+    this.traceOnFailure = false;
+    this.$artifactRoot = expandPath("/tests/_artifacts/");
+
+    function beforeAll() {
+        super.beforeAll();
+        if (directoryExists(this.$artifactRoot)) {
+            directoryDelete(this.$artifactRoot, true);
+        }
+    }
+
+    function run() {
+        describe("Artifact dumping", () => {
+
+            it("dumps screenshot + HTML on intentionally-failing assertion", () => {
+                // Intentionally fail, but catch it so the spec itself passes
+                var failed = false;
+                try {
+                    this.browser.visit("/login").assertSee("Nonexistent text");
+                } catch (Wheels.BrowserAssertionFailed e) {
+                    failed = true;
+                }
+
+                expect(failed).toBeTrue();
+
+                // Now manually trigger artifact dump — normally this would be in afterEach
+                // For this test, we simulate the failure hook
+                $dumpArtifactsForSpec(
+                    specName="BrowserArtifactsSpec",
+                    itName="dumps-screenshot-html"
+                );
+
+                var screenshotGlob = directoryList(
+                    this.$artifactRoot,
+                    true,
+                    "path",
+                    "*.png"
+                );
+                expect(arrayLen(screenshotGlob)).toBeGT(0);
+
+                var htmlGlob = directoryList(
+                    this.$artifactRoot,
+                    true,
+                    "path",
+                    "*.html"
+                );
+                expect(arrayLen(htmlGlob)).toBeGT(0);
+            });
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserArtifacts
+```
+Expected: FAIL — `$dumpArtifactsForSpec` doesn't exist.
+
+- [ ] **Step 3: Add artifact dumping to `BrowserTest.cfc`**
+
+In `vendor/wheels/wheelstest/BrowserTest.cfc`, update `afterEach` to detect failures and dump artifacts. Replace the existing `afterEach()`:
+
+```cfm
+    function afterEach() {
+        // TestBox exposes the current spec result via variables.currentSpec
+        // after the it() callback completes. Dump artifacts if failed.
+        var specFailed = $currentSpecFailed();
+
+        if (specFailed && this.screenshotOnFailure && isObject(variables.$page)) {
+            $dumpArtifactsForSpec(
+                specName=$specComponentName(),
+                itName=$currentSpecItName()
+            );
+        }
+
+        if (isObject(variables.$context)) {
+            try {
+                variables.$context.close();
+            } catch (any e) {
+            }
+            variables.$context = "";
+            variables.$page = "";
+            this.browser = "";
+        }
+    }
+
+    /**
+     * Dumps PNG + HTML + optional trace to tests/_artifacts/<run>/<spec>/<it>.*
+     * The run dir is created once per test session.
+     */
+    public void function $dumpArtifactsForSpec(
+        required string specName,
+        required string itName
+    ) {
+        if (!structKeyExists(application, "$wheelsBrowserRunDir")) {
+            var ts = dateTimeFormat(now(), "yyyy-MM-dd-HHmmss");
+            var runDir = (this.$artifactRoot ?: expandPath("/tests/_artifacts/")) & ts & "/";
+            directoryCreate(runDir, true, true);
+            application.$wheelsBrowserRunDir = runDir;
+        }
+        var base = application.$wheelsBrowserRunDir & arguments.specName & "/";
+        if (!directoryExists(base)) {
+            directoryCreate(base);
+        }
+
+        var safeIt = reReplace(arguments.itName, "[^a-zA-Z0-9-]", "-", "all");
+
+        // Screenshot
+        try {
+            var shot = createObject("java", "com.microsoft.playwright.Page$ScreenshotOptions").init();
+            shot.setPath(
+                createObject("java", "java.nio.file.Paths").get(base & safeIt & ".png", [])
+            );
+            variables.$page.screenshot(shot);
+        } catch (any e) {
+        }
+
+        // HTML source
+        try {
+            var html = variables.$page.content();
+            fileWrite(base & safeIt & ".html", html);
+        } catch (any e) {
+        }
+
+        // Trace (if enabled)
+        if (this.traceOnFailure) {
+            try {
+                var traceOpts = createObject("java", "com.microsoft.playwright.Tracing$StopOptions").init();
+                traceOpts.setPath(
+                    createObject("java", "java.nio.file.Paths").get(base & safeIt & ".trace.zip", [])
+                );
+                variables.$context.tracing().stop(traceOpts);
+            } catch (any e) {
+            }
+        }
+    }
+
+    private boolean function $currentSpecFailed() {
+        // TestBox stores current spec results on the testResult struct.
+        // Fall back to false if not accessible (keeps spec resilient).
+        try {
+            var tr = variables.testResults ?: "";
+            if (isStruct(tr) && structKeyExists(tr, "currentSpec")) {
+                return (tr.currentSpec.status ?: "") == "failed";
+            }
+        } catch (any e) {
+        }
+        return false;
+    }
+
+    private string function $specComponentName() {
+        var meta = getMetadata(this);
+        var parts = listToArray(meta.name, ".");
+        return parts[arrayLen(parts)];
+    }
+
+    private string function $currentSpecItName() {
+        try {
+            return variables.testResults.currentSpec.name ?: "unknown";
+        } catch (any e) {
+            return "unknown";
+        }
+    }
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserArtifacts
+```
+Expected: PASS. Artifact dir `tests/_artifacts/<timestamp>/BrowserArtifactsSpec/` exists with `.png` and `.html`.
+
+- [ ] **Step 5: Add `tests/_artifacts/` to `.gitignore`**
+
+Edit `.gitignore` and append:
+
+```
+# Browser test artifacts (screenshots, HTML dumps, traces)
+tests/_artifacts/
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserTest.cfc \
+        vendor/wheels/tests/specs/wheelstest/BrowserArtifactsSpec.cfc \
+        .gitignore
+git commit -m "feat(test): BrowserTest artifact dumping on failure"
+```
+
+---
+
+## Task 17: End-to-end spec using `BrowserTest` against the fixture app
+
+Final integration test that exercises the whole foundation end-to-end.
+
+**Files:**
+- Create: `vendor/wheels/tests/specs/wheelstest/BrowserEndToEndSpec.cfc`
+
+- [ ] **Step 1: Write end-to-end spec**
+
+Create `vendor/wheels/tests/specs/wheelstest/BrowserEndToEndSpec.cfc`:
+
+```cfm
+component extends="wheels.BrowserTest" {
+
+    this.browserEngine = "chromium";
+    this.keepSignedInAs = "";
+    this.browserViewport = "desktop";
+    this.screenshotOnFailure = true;
+
+    function run() {
+        describe("End-to-end login flow", () => {
+
+            it("signs in successfully with valid credentials", () => {
+                this.browser
+                    .visit("/login")
+                    .assertSee("Log in")
+                    .fill("##email", "alice@example.com")
+                    .fill("##password", "secret")
+                    .click("button[type=submit]")
+                    .assertUrlIs("/dashboard")
+                    .assertSee("Welcome, alice@example.com");
+            });
+
+            it("rejects invalid credentials with flash error", () => {
+                this.browser
+                    .visit("/login")
+                    .fill("##email", "alice@example.com")
+                    .fill("##password", "wrong")
+                    .click("button[type=submit]")
+                    .assertUrlIs("/login")
+                    .assertSee("Invalid credentials");
+            });
+
+            it("logout clears session and redirects to login", () => {
+                this.browser
+                    .visit("/login")
+                    .fill("##email", "alice@example.com")
+                    .fill("##password", "secret")
+                    .click("button[type=submit]")
+                    .assertUrlIs("/dashboard")
+                    .click("button:has-text('Log out')")
+                    .assertUrlIs("/login");
+            });
+
+            it("loginAs() bypasses form, sets session directly", () => {
+                this.browser
+                    .loginAs("99")
+                    .visit("/dashboard")
+                    .assertUrlIs("/dashboard");
+            });
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect pass**
+
+Make sure fixture app server is running:
+```bash
+cd /Users/peter/GitHub/wheels-dev/wheels && lucli server run --port=8080 &
+sleep 5
+bash tools/test-local.sh --filter=wheelstest.BrowserEndToEnd
+```
+Expected: PASS on all 4 end-to-end specs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add vendor/wheels/tests/specs/wheelstest/BrowserEndToEndSpec.cfc
+git commit -m "test(test): end-to-end browser spec against fixture app"
+```
+
+---
+
+## Task 18: Document the foundation in CLAUDE.md + create `.ai` reference
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Create: `.ai/wheels/testing/browser-testing.md`
+
+- [ ] **Step 1: Add a brief "Browser Testing" section to CLAUDE.md**
+
+In `CLAUDE.md`, after the "Testing Quick Reference" section (around line 450 based on typical layout), add:
+
+```markdown
+## Browser Testing Quick Reference
+
+Foundation landed in v4.0 (PR 1 of 4). Specs extend `wheels.BrowserTest`
+and use `this.browser` — a fluent DSL that wraps Playwright Java.
+
+```cfm
+// tests/specs/browser/LoginBrowserSpec.cfc
+component extends="wheels.BrowserTest" {
+    this.keepSignedInAs = "";      // or "alice@example.com" for auto-login
+    this.browserEngine = "chromium";
+
+    function run() {
+        describe("Login flow", () => {
+            it("signs in", () => {
+                this.browser
+                    .visit("/login")
+                    .fill("##email", "alice@example.com")
+                    .fill("##password", "secret")
+                    .click("button[type=submit]")
+                    .assertUrlIs("/dashboard")
+                    .assertSee("Welcome");
+            });
+        });
+    }
+}
+```
+
+Install Playwright locally before first run:
+```bash
+bash tools/install-playwright.sh    # PR 1; replaced by `wheels browser:install` in PR 2
+```
+
+Then run browser specs:
+```bash
+bash tools/test-local.sh --filter=wheelstest.BrowserEndToEnd
+```
+
+Failure artifacts (screenshots, HTML) dumped to `tests/_artifacts/<timestamp>/`.
+
+Full reference: `.ai/wheels/testing/browser-testing.md`.
+```
+
+- [ ] **Step 2: Create the `.ai` reference doc**
+
+Create `.ai/wheels/testing/browser-testing.md`:
+
+```markdown
+# Browser Testing (`wheels.BrowserTest`)
+
+Native browser testing added in Wheels v4.0 via Playwright Java. Specs
+extend `wheels.BrowserTest` and drive a real Chromium/Firefox/WebKit
+browser through a fluent DSL.
+
+## Installation
+
+Before first use, install Playwright:
+
+    bash tools/install-playwright.sh
+
+This downloads the Playwright Java JAR and Chromium into
+`~/.wheels/browser/`. Runs idempotent; re-run to update.
+
+For CI, cache `~/.wheels/browser/` by the SHA of
+`vendor/wheels/browser-manifest.json`.
+
+## Spec structure
+
+    component extends="wheels.BrowserTest" {
+
+        // Optional — all with sensible defaults
+        this.browserEngine = "chromium";        // chromium | firefox | webkit
+        this.keepSignedInAs = "";               // identifier for storageState replay
+        this.browserViewport = "desktop";       // desktop | tablet | mobile | struct{w,h}
+        this.screenshotOnFailure = true;
+        this.traceOnFailure = false;
+
+        function run() {
+            describe("My feature", () => {
+                it("does the thing", () => {
+                    this.browser.visit("/").assertSee("Hello");
+                });
+            });
+        }
+    }
+
+## Method catalog
+
+Navigation: visit, visitRoute, back, forward, refresh
+Interaction: click, press, fill, type, clear, select, check, uncheck,
+             attach, dragAndDrop
+Keyboard: keys, pressEnter, pressTab, pressEscape
+Dialogs: acceptDialog, dismissDialog, typeInDialog
+Waiting: waitFor, waitForText, waitForUrl
+Scoping: within(selector, callback)
+Viewport: resize, resizeToMobile, resizeToTablet, resizeToDesktop
+Auth: loginAs, logout
+Cookies: setCookie, deleteCookie, cookie
+Script: script, pause
+Assertions (text): assertSee, assertDontSee, assertSeeIn
+Assertions (visibility): assertVisible, assertMissing, assertPresent, assertNotPresent
+Assertions (URL): assertUrlIs, assertRouteIs, assertQueryStringHas,
+                  assertQueryStringMissing, assertTitleContains
+Assertions (form): assertInputValue, assertChecked, assertHasClass
+Terminals: currentUrl, title, pageSource, text, value, screenshot
+
+## `loginAs` contract
+
+For `this.browser.loginAs(identifier)` and `this.keepSignedInAs` to work,
+the app must define:
+
+    // app/events/onapplicationstart.cfm
+    application.$signInAsForBrowserTest = function(required any identifier) {
+        session.userId = arguments.identifier;
+    };
+
+The hook receives whatever the test passed (number, email, UUID). App
+decides how to resolve it.
+
+Without the hook defined, `loginAs()` throws `Wheels.BrowserTestLoginHookMissing`.
+
+## Failure artifacts
+
+On any assertion failure, `afterEach` dumps to:
+
+    tests/_artifacts/<timestamp>/<SpecName>/<it-name>.png
+    tests/_artifacts/<timestamp>/<SpecName>/<it-name>.html
+    tests/_artifacts/<timestamp>/<SpecName>/<it-name>.trace.zip  (if traceOnFailure)
+
+Paths are clickable in modern terminals (iTerm2, VS Code).
+
+Set `this.screenshotOnFailure = false` to opt out.
+
+## Common pitfalls
+
+- **`Wheels.BrowserNotInstalled`**: Run `bash tools/install-playwright.sh`
+  (v4.0) or `wheels browser:install` (v4.1+).
+- **Tests hang**: server not running. Browser tests need a live app at
+  `WHEELS_BROWSER_TEST_BASE_URL` (default `http://localhost:8080`).
+  Start with `lucli server run --port=8080`.
+- **`##` in selectors**: CFML requires `##` to emit a literal `#`. In
+  selectors: `"##email"` becomes `"#email"` at runtime.
+- **Cookies persisting across tests**: shouldn't happen — each `it` gets
+  a fresh context. If you see this, check the spec didn't set cookies in
+  `beforeAll` instead of `beforeEach`.
+
+## Deferred to later PRs
+
+- CLI (`wheels browser:install`, `wheels browser:test`) — PR 2
+- Hotwire dogfood specs — PR 3
+- CI workflow integration — PR 4
+- Adobe CF / BoxLang support — v4.1+
+- Parallel browser test execution — v4.1+
+- Multi-engine per spec CFC — v4.1+
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md .ai/wheels/testing/browser-testing.md
+git commit -m "docs(test): add browser testing quick reference and full guide"
+```
+
+---
+
+## Task 19: Verify full suite still passes
+
+- [ ] **Step 1: Run all core tests to verify no regressions**
+
+```bash
+bash tools/test-local.sh
+```
+Expected: all existing specs still pass (no impact on non-browser tests). New browser specs pass when `~/.wheels/browser/` is populated; gracefully skip otherwise.
+
+- [ ] **Step 2: Run browser suite in isolation to verify clean execution**
+
+```bash
+cd /Users/peter/GitHub/wheels-dev/wheels && lucli server run --port=8080 &
+sleep 5
+bash tools/test-local.sh --filter=wheelstest
+```
+Expected: `BrowserLauncherSpec`, `BrowserTestLoginControllerSpec`, `BrowserIntegrationSpec`, `BrowserTestLifecycleSpec`, `BrowserArtifactsSpec`, `BrowserEndToEndSpec` all pass.
+
+- [ ] **Step 3: Final branch cleanup and PR creation**
+
+Ensure all commits are on `peter/browser-testing-foundation`:
+
+```bash
+git checkout -b peter/browser-testing-foundation  # if not already on it
+git log --oneline develop..HEAD                   # verify commits
+git push -u origin peter/browser-testing-foundation
+
+gh pr create --title "feat(test): browser testing foundation (PR 1 of 4)" --body "$(cat <<'EOF'
+## Summary
+
+- Adds `BrowserClient.cfc` — fluent DSL for browser automation (~35 methods)
+- Adds `BrowserLauncher.cfc` — Playwright Java JAR loading + singleton management
+- Adds `BrowserTest.cfc` — TestBox base class with per-it context lifecycle, storageState replay, artifact dumping
+- Adds test-only `POST /_browser/login-as` route (environment-guarded)
+- Adds `BrowserTestLoginController.cfc` + app-defined `$signInAsForBrowserTest` hook contract
+- Adds `tools/install-playwright.sh` (temporary bootstrap; replaced by `wheels browser:install` in PR 2)
+- Adds fixture app + end-to-end integration spec proving the full flow
+
+Closes item 4 of `docs/wheels-vs-frameworks.md` "Where Wheels Trails" (PR 1 of 4).
+
+Spec: `docs/superpowers/specs/2026-04-15-browser-testing-design.md`
+Plan: `docs/superpowers/plans/2026-04-15-browser-testing-foundation.md`
+
+## Test plan
+
+- [ ] `bash tools/install-playwright.sh` succeeds on macOS
+- [ ] `bash tools/install-playwright.sh` succeeds on Linux
+- [ ] `bash tools/test-local.sh --filter=wheelstest` passes end-to-end
+- [ ] Full core test suite still passes (`bash tools/test-local.sh`)
+- [ ] Test-only login route does NOT appear in `production` environment
+- [ ] Failure artifacts dumped to `tests/_artifacts/` and viewable
+
+## Deferred to follow-up PRs
+
+- PR 2: `wheels browser:install` + `wheels browser:test` CLI + MCP tools
+- PR 3: `packages/hotwire/` browser specs (dogfood)
+- PR 4: CI workflow + final docs
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR created, returns URL.
+
+---
+
+## Summary
+
+This plan delivers PR 1 of the 4-PR browser testing rollout. It's self-sufficient: the DSL can be used directly from any spec after `bash tools/install-playwright.sh`, without needing the CLI infrastructure from PR 2.
+
+Key invariants:
+- `BrowserClient` has no TestBox coupling (can be used standalone)
+- `BrowserLauncher` owns one Playwright + Browser per process (not per spec)
+- `BrowserTest` creates a fresh context per `it` (cookie/storage isolation)
+- Test-only login route guarded by `environment == "testing"`
+- All failures dump screenshots + HTML to `tests/_artifacts/<timestamp>/`

--- a/docs/superpowers/plans/2026-04-15-browser-testing-foundation.md
+++ b/docs/superpowers/plans/2026-04-15-browser-testing-foundation.md
@@ -68,26 +68,47 @@ Expected: 64-char hex SHA256. Record it.
 
 - [ ] **Step 3: Write `vendor/wheels/browser-manifest.json`**
 
+Playwright Java needs Maven's full transitive runtime graph on the classpath to boot (the standalone client JAR isn't sufficient). Since this script doesn't use Maven, the manifest pins **every** runtime JAR under a `classpath` array. Walk `com.microsoft.playwright:playwright`'s POM plus its parent to enumerate:
+
+- `com.microsoft.playwright:playwright` — client API + CLI
+- `com.microsoft.playwright:driver` — `impl.driver.Driver` class
+- `com.microsoft.playwright:driver-bundle` — bundled Node + JS driver (~190MB)
+- `com.google.code.gson:gson` — JSON
+- `org.java-websocket:Java-WebSocket` — WS transport
+- `org.slf4j:slf4j-api` + `org.slf4j:slf4j-simple` — logging
+
+For each JAR, `curl -sSL <url> -o /tmp/x && shasum -a 256 /tmp/x` to compute SHA256.
+
 ```json
 {
-    "schemaVersion": 1,
-    "playwrightJavaVersion": "1.45.0",
-    "playwrightJavaJar": {
-        "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/playwright/1.45.0/playwright-1.45.0.jar",
-        "sha256": "REPLACE_WITH_SHA256_FROM_STEP_2",
-        "size": 51380224
-    },
+    "schemaVersion": 2,
+    "playwrightJavaVersion": "1.52.0",
+    "classpath": [
+        {
+            "filename": "playwright-1.52.0.jar",
+            "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/playwright/1.52.0/playwright-1.52.0.jar",
+            "sha256": "REPLACE_ME",
+            "size": 619097
+        },
+        {
+            "filename": "driver-1.52.0.jar",
+            "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/driver/1.52.0/driver-1.52.0.jar",
+            "sha256": "REPLACE_ME",
+            "size": 6863
+        }
+        // ... driver-bundle, gson, Java-WebSocket, slf4j-api, slf4j-simple
+    ],
     "browsers": {
-        "chromium": "1124",
-        "firefox": "1440",
-        "webkit": "2033"
+        "chromium": "136.0.7103.25",
+        "firefox": "137.0",
+        "webkit": "18.4"
     },
     "minJavaVersion": 21,
     "installDir": "~/.wheels/browser"
 }
 ```
 
-Substitute `REPLACE_WITH_SHA256_FROM_STEP_2` and `"1.45.0"` with the real values from steps 1-2.
+Substitute each `REPLACE_ME` with the SHA256 from step 2.
 
 - [ ] **Step 4: Commit**
 
@@ -296,11 +317,7 @@ git commit -m "feat(test): add BrowserLauncher JAR path discovery"
 
 Integration tests in subsequent tasks require Playwright installed locally. This is a temporary bootstrap script; PR 2 will replace it with `wheels browser:install`.
 
-**Important — two-JAR install:** Playwright Java needs **both** artifacts on the classpath to boot:
-- `playwright-<ver>.jar` (client API, ~600KB) — pinned under `playwrightJavaJar` in manifest
-- `driver-bundle-<ver>.jar` (bundled Node + driver, ~191MB) — pinned under `playwrightDriverBundle` in manifest
-
-The bootstrap downloads both, SHA-verifies both, then runs `playwright install chromium` using **both on the classpath** so the CLI can find the driver.
+**Important — full classpath install:** Playwright Java needs all seven runtime JARs on the classpath to boot (client, driver, driver-bundle, plus transitive `gson`, `Java-WebSocket`, `slf4j-api`, `slf4j-simple`). The manifest's `classpath` array pins every one; the script iterates the array, downloads each, SHA-verifies, then invokes `playwright install chromium` with all seven on the classpath.
 
 **Files:**
 - Create: `tools/install-playwright.sh`
@@ -313,73 +330,85 @@ Create `tools/install-playwright.sh`:
 #!/usr/bin/env bash
 # Temporary bootstrap for browser testing. Replaced by `wheels browser:install`
 # once PR 2 lands. Reads vendor/wheels/browser-manifest.json for pinned versions.
+#
+# Playwright Java needs the full classpath — client, driver, driver-bundle, plus
+# transitive runtime deps (gson, Java-WebSocket, slf4j) — to boot. Maven normally
+# resolves these; since we bootstrap without Maven, the manifest pins every JAR
+# with SHA256, and this script downloads + verifies each before invoking the CLI.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 MANIFEST="$REPO_ROOT/vendor/wheels/browser-manifest.json"
 INSTALL_DIR="${WHEELS_BROWSER_HOME:-$HOME/.wheels/browser}"
+LIB_DIR="$INSTALL_DIR/lib"
 
 if [[ ! -f "$MANIFEST" ]]; then
     echo "ERROR: $MANIFEST not found" >&2
     exit 1
 fi
 
-# Helper: download a JAR from a manifest entry, SHA-verify, place at target path.
-# Usage: download_jar <manifest-key> <target-jar-path>
-download_jar() {
-    local key="$1"
-    local target="$2"
+mkdir -p "$LIB_DIR"
 
-    local url sha
-    url=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['$key']['url'])")
-    sha=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['$key']['sha256'])")
+# Read classpath entries as tab-separated rows: filename\turl\tsha256.
+# Avoids bash-4 `mapfile` so the script works with macOS's default bash 3.2.
+ENTRIES_FILE=$(mktemp)
+trap 'rm -f "$ENTRIES_FILE"' EXIT
+python3 -c "
+import json
+m = json.load(open('$MANIFEST'))
+for e in m['classpath']:
+    print(e['filename'] + '\t' + e['url'] + '\t' + e['sha256'])
+" > "$ENTRIES_FILE"
+
+ENTRY_COUNT=$(wc -l < "$ENTRIES_FILE" | tr -d ' ')
+if [[ "$ENTRY_COUNT" -eq 0 ]]; then
+    echo "ERROR: manifest has no classpath entries" >&2
+    exit 1
+fi
+
+CLASSPATH=""
+while IFS=$'\t' read -r filename url sha; do
+    target="$LIB_DIR/$filename"
 
     if [[ -f "$target" ]]; then
-        local actual
         actual=$(shasum -a 256 "$target" | awk '{print $1}')
         if [[ "$actual" == "$sha" ]]; then
-            echo "✓ $(basename "$target") already present (SHA verified)"
-            return
+            echo "✓ $filename already present (SHA verified)"
+            CLASSPATH+="$target:"
+            continue
         fi
-        echo "! $(basename "$target") exists but SHA mismatch; re-downloading"
+        echo "! $filename exists but SHA mismatch; re-downloading"
         rm -f "$target"
     fi
 
-    echo "Downloading $(basename "$target") from Maven Central..."
+    echo "Downloading $filename from Maven Central..."
     curl -sSL -o "$target" "$url"
 
-    local actual
     actual=$(shasum -a 256 "$target" | awk '{print $1}')
     if [[ "$actual" != "$sha" ]]; then
-        echo "ERROR: SHA mismatch for $target" >&2
+        echo "ERROR: SHA mismatch for $filename" >&2
         echo "  expected: $sha" >&2
         echo "  actual:   $actual" >&2
         rm -f "$target"
         exit 1
     fi
-    echo "✓ $(basename "$target") downloaded and SHA-verified"
-}
+    echo "✓ $filename downloaded and SHA-verified"
+    CLASSPATH+="$target:"
+done < "$ENTRIES_FILE"
 
-VERSION=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['playwrightJavaVersion'])")
-CLIENT_JAR="$INSTALL_DIR/lib/playwright-$VERSION.jar"
-DRIVER_JAR="$INSTALL_DIR/lib/driver-bundle-$VERSION.jar"
-
-mkdir -p "$INSTALL_DIR/lib"
-
-download_jar "playwrightJavaJar"      "$CLIENT_JAR"
-download_jar "playwrightDriverBundle" "$DRIVER_JAR"
+# Strip trailing colon
+CLASSPATH="${CLASSPATH%:}"
 
 echo ""
-echo "Installing Chromium via Playwright CLI (requires both JARs on classpath)..."
-java -cp "$CLIENT_JAR:$DRIVER_JAR" com.microsoft.playwright.CLI install chromium
+echo "Installing Chromium via Playwright CLI (full classpath: $ENTRY_COUNT JARs)..."
+java -cp "$CLASSPATH" com.microsoft.playwright.CLI install chromium
 
 echo ""
 echo "Done."
-echo "  Client JAR:     $CLIENT_JAR"
-echo "  Driver bundle:  $DRIVER_JAR"
-echo "  Browsers:       ~/.cache/ms-playwright/ (Playwright default cache dir)"
-echo "  Install dir:    $INSTALL_DIR"
+echo "  JARs:        $LIB_DIR/  ($ENTRY_COUNT files)"
+echo "  Browsers:    ~/.cache/ms-playwright/ (Playwright default cache dir)"
+echo "  Install dir: $INSTALL_DIR"
 ```
 
 - [ ] **Step 2: Make executable and test it runs**
@@ -388,7 +417,7 @@ echo "  Install dir:    $INSTALL_DIR"
 chmod +x tools/install-playwright.sh
 bash tools/install-playwright.sh
 ```
-Expected: downloads JAR, verifies SHA, installs Chromium. `~/.wheels/browser/lib/playwright-1.45.0.jar` and `~/.wheels/browser/browsers/chromium-*/` exist afterward.
+Expected: downloads all 7 JARs (reusing any already present with matching SHA), installs Chromium. `~/.wheels/browser/lib/*.jar` (7 files) and `~/Library/Caches/ms-playwright/chromium-*/` exist afterward. Re-running should be a no-op (all JARs SHA-verified present).
 
 - [ ] **Step 3: Commit**
 
@@ -400,6 +429,14 @@ git commit -m "feat(test): add temporary Playwright install bootstrap"
 ---
 
 ## Task 4: `BrowserLauncher` — Playwright instance + Browser acquisition
+
+**⚠ Manifest amended in Task 3:** The original plan assumed two JARs (client + driver-bundle). Task 3 discovered Playwright's full runtime set is seven JARs and restructured the manifest to a `classpath` array. That invalidates the `$jarPath` + `$driverBundlePath` helpers and the integration-test skip logic shown below. Before implementing, replace the two-helper pattern with:
+
+- **`$classpathJarPaths(installDir) → array`** — reads `variables.$manifest.classpath` and returns `[installDir & "/lib/" & entry.filename, …]` for every entry.
+- **Skip logic** — `ArrayEvery(paths, fileExists)` rather than two individual `fileExists` checks.
+- **`$loadJars(jarPaths)`** — unchanged; already takes an array. Just pass it all seven paths.
+
+The `$jarPath()` helper written in Task 2 still works for the client JAR specifically (used in unit tests), so it does not need to be removed.
 
 **Files:**
 - Modify: `vendor/wheels/wheelstest/BrowserLauncher.cfc`

--- a/docs/superpowers/plans/2026-04-15-browser-testing-foundation.md
+++ b/docs/superpowers/plans/2026-04-15-browser-testing-foundation.md
@@ -296,6 +296,12 @@ git commit -m "feat(test): add BrowserLauncher JAR path discovery"
 
 Integration tests in subsequent tasks require Playwright installed locally. This is a temporary bootstrap script; PR 2 will replace it with `wheels browser:install`.
 
+**Important — two-JAR install:** Playwright Java needs **both** artifacts on the classpath to boot:
+- `playwright-<ver>.jar` (client API, ~600KB) — pinned under `playwrightJavaJar` in manifest
+- `driver-bundle-<ver>.jar` (bundled Node + driver, ~191MB) — pinned under `playwrightDriverBundle` in manifest
+
+The bootstrap downloads both, SHA-verifies both, then runs `playwright install chromium` using **both on the classpath** so the CLI can find the driver.
+
 **Files:**
 - Create: `tools/install-playwright.sh`
 
@@ -319,39 +325,61 @@ if [[ ! -f "$MANIFEST" ]]; then
     exit 1
 fi
 
+# Helper: download a JAR from a manifest entry, SHA-verify, place at target path.
+# Usage: download_jar <manifest-key> <target-jar-path>
+download_jar() {
+    local key="$1"
+    local target="$2"
+
+    local url sha
+    url=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['$key']['url'])")
+    sha=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['$key']['sha256'])")
+
+    if [[ -f "$target" ]]; then
+        local actual
+        actual=$(shasum -a 256 "$target" | awk '{print $1}')
+        if [[ "$actual" == "$sha" ]]; then
+            echo "✓ $(basename "$target") already present (SHA verified)"
+            return
+        fi
+        echo "! $(basename "$target") exists but SHA mismatch; re-downloading"
+        rm -f "$target"
+    fi
+
+    echo "Downloading $(basename "$target") from Maven Central..."
+    curl -sSL -o "$target" "$url"
+
+    local actual
+    actual=$(shasum -a 256 "$target" | awk '{print $1}')
+    if [[ "$actual" != "$sha" ]]; then
+        echo "ERROR: SHA mismatch for $target" >&2
+        echo "  expected: $sha" >&2
+        echo "  actual:   $actual" >&2
+        rm -f "$target"
+        exit 1
+    fi
+    echo "✓ $(basename "$target") downloaded and SHA-verified"
+}
+
 VERSION=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['playwrightJavaVersion'])")
-JAR_URL=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['playwrightJavaJar']['url'])")
-JAR_SHA=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['playwrightJavaJar']['sha256'])")
-JAR_PATH="$INSTALL_DIR/lib/playwright-$VERSION.jar"
+CLIENT_JAR="$INSTALL_DIR/lib/playwright-$VERSION.jar"
+DRIVER_JAR="$INSTALL_DIR/lib/driver-bundle-$VERSION.jar"
 
 mkdir -p "$INSTALL_DIR/lib"
 
-if [[ -f "$JAR_PATH" ]]; then
-    ACTUAL_SHA=$(shasum -a 256 "$JAR_PATH" | awk '{print $1}')
-    if [[ "$ACTUAL_SHA" == "$JAR_SHA" ]]; then
-        echo "✓ Playwright JAR already installed at $JAR_PATH"
-    else
-        echo "! JAR exists but SHA mismatch; re-downloading"
-        rm -f "$JAR_PATH"
-    fi
-fi
+download_jar "playwrightJavaJar"      "$CLIENT_JAR"
+download_jar "playwrightDriverBundle" "$DRIVER_JAR"
 
-if [[ ! -f "$JAR_PATH" ]]; then
-    echo "Downloading Playwright Java $VERSION..."
-    curl -sSL -o "$JAR_PATH" "$JAR_URL"
-    ACTUAL_SHA=$(shasum -a 256 "$JAR_PATH" | awk '{print $1}')
-    if [[ "$ACTUAL_SHA" != "$JAR_SHA" ]]; then
-        echo "ERROR: SHA mismatch. Expected $JAR_SHA, got $ACTUAL_SHA" >&2
-        rm -f "$JAR_PATH"
-        exit 1
-    fi
-    echo "✓ Downloaded and verified"
-fi
+echo ""
+echo "Installing Chromium via Playwright CLI (requires both JARs on classpath)..."
+java -cp "$CLIENT_JAR:$DRIVER_JAR" com.microsoft.playwright.CLI install chromium
 
-echo "Installing Chromium via Playwright CLI..."
-java -cp "$JAR_PATH" com.microsoft.playwright.CLI install chromium
-
-echo "Done. Install dir: $INSTALL_DIR"
+echo ""
+echo "Done."
+echo "  Client JAR:     $CLIENT_JAR"
+echo "  Driver bundle:  $DRIVER_JAR"
+echo "  Browsers:       ~/.cache/ms-playwright/ (Playwright default cache dir)"
+echo "  Install dir:    $INSTALL_DIR"
 ```
 
 - [ ] **Step 2: Make executable and test it runs**
@@ -385,19 +413,18 @@ Append to `vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc`, inside
 describe("BrowserLauncher integration (requires Playwright install)", () => {
 
     it("acquireBrowser('chromium') returns a Java Browser instance", () => {
-        // skip if JAR missing — will be loud in unit-test CI but silent locally
+        // skip if JARs missing — will be loud in unit-test CI but silent locally
         // when developer hasn't run install-playwright.sh yet
         var installDir = variables.launcher.resolveInstallDir();
-        var jarPath = variables.launcher.$jarPath(
-            installDir=installDir,
-            version=variables.launcher.$manifest.playwrightJavaVersion
-        );
-        if (!fileExists(jarPath)) {
-            debug("Skipping: Playwright JAR not installed. Run tools/install-playwright.sh");
+        var version = variables.launcher.$manifest.playwrightJavaVersion;
+        var clientJar = variables.launcher.$jarPath(installDir=installDir, version=version);
+        var driverJar = variables.launcher.$driverBundlePath(installDir=installDir, version=version);
+        if (!fileExists(clientJar) || !fileExists(driverJar)) {
+            debug("Skipping: Playwright JARs not installed. Run tools/install-playwright.sh");
             return;
         }
 
-        variables.launcher.$loadJar(jarPath=jarPath);
+        variables.launcher.$loadJars(jarPaths=[clientJar, driverJar]);
         var browser = variables.launcher.acquireBrowser(engine="chromium");
 
         expect(browser).notToBeNull();
@@ -412,15 +439,14 @@ describe("BrowserLauncher integration (requires Playwright install)", () => {
 
     it("acquireBrowser() returns the same Browser across calls (singleton per engine)", () => {
         var installDir = variables.launcher.resolveInstallDir();
-        var jarPath = variables.launcher.$jarPath(
-            installDir=installDir,
-            version=variables.launcher.$manifest.playwrightJavaVersion
-        );
-        if (!fileExists(jarPath)) {
+        var version = variables.launcher.$manifest.playwrightJavaVersion;
+        var clientJar = variables.launcher.$jarPath(installDir=installDir, version=version);
+        var driverJar = variables.launcher.$driverBundlePath(installDir=installDir, version=version);
+        if (!fileExists(clientJar) || !fileExists(driverJar)) {
             return;
         }
 
-        variables.launcher.$loadJar(jarPath=jarPath);
+        variables.launcher.$loadJars(jarPaths=[clientJar, driverJar]);
         var b1 = variables.launcher.acquireBrowser(engine="chromium");
         var b2 = variables.launcher.acquireBrowser(engine="chromium");
 
@@ -429,6 +455,10 @@ describe("BrowserLauncher integration (requires Playwright install)", () => {
     });
 });
 ```
+
+**Note on new methods:** Task 4 adds two methods beyond what Task 2 shipped:
+- `$driverBundlePath(installDir, version)` — parallel to `$jarPath`, returns path to driver-bundle JAR
+- `$loadJars(jarPaths)` — loads an array of JAR paths onto the classloader (supersedes the single-path `$loadJar` originally planned)
 
 - [ ] **Step 2: Run test — expect fail on missing `acquireBrowser` method**
 
@@ -445,27 +475,36 @@ Append to `vendor/wheels/wheelstest/BrowserLauncher.cfc` (before the closing `}`
 
 ```cfm
 /**
- * Dynamically loads the Playwright JAR into the current ClassLoader so
- * CreateObject("java", ...) can find Playwright classes. Lucee-specific;
+ * Returns the filesystem path to the driver-bundle JAR.
+ * Parallel to $jarPath (which returns the client JAR path).
+ */
+public string function $driverBundlePath(
+    required string installDir,
+    required string version
+) {
+    return arguments.installDir & "/lib/driver-bundle-" & arguments.version & ".jar";
+}
+
+/**
+ * Dynamically loads the Playwright JARs into a URLClassLoader so
+ * CreateObject("java", ...) can find Playwright classes.
+ *
+ * Takes an array so callers can load the client JAR + driver-bundle JAR
+ * (both are required for Playwright to boot). Lucee-specific;
  * Adobe CF support deferred.
  *
  * Must be called before any acquireBrowser() call.
  */
-public void function $loadJar(required string jarPath) {
+public void function $loadJars(required array jarPaths) {
     if (variables.$state != "uninitialized") {
         return;  // idempotent
     }
 
-    // Use Lucee's JavaLoader equivalent — application scope javaSettings
-    var jarDir = getDirectoryFromPath(arguments.jarPath);
-    application.$wheelsBrowserJarDir = jarDir;
-
-    // Lucee 7: reload the classloader by touching Application.cfc settings
-    // Alternative: use the java.net.URLClassLoader directly
-    var urlClass = createObject("java", "java.net.URL");
-    var jarFile = createObject("java", "java.io.File").init(arguments.jarPath);
-    var jarUrl = jarFile.toURI().toURL();
-    var urls = [jarUrl];
+    var urls = [];
+    for (var jarPath in arguments.jarPaths) {
+        var jarFile = createObject("java", "java.io.File").init(jarPath);
+        arrayAppend(urls, jarFile.toURI().toURL());
+    }
 
     var parentLoader = createObject("java", "java.lang.Thread")
         .currentThread()
@@ -486,7 +525,7 @@ public any function acquireBrowser(string engine = "chromium") {
     if (variables.$state != "ready") {
         throw(
             type="Wheels.BrowserLauncherNotReady",
-            message="Call $loadJar() first. State: " & variables.$state
+            message="Call $loadJars() first. State: " & variables.$state
         );
     }
 
@@ -734,16 +773,15 @@ component extends="wheels.WheelsTest" {
     function beforeAll() {
         variables.launcher = CreateObject("component", "wheels.wheelstest.BrowserLauncher");
         var installDir = variables.launcher.resolveInstallDir();
-        var jarPath = variables.launcher.$jarPath(
-            installDir=installDir,
-            version=variables.launcher.$manifest.playwrightJavaVersion
-        );
-        if (!fileExists(jarPath)) {
+        var version = variables.launcher.$manifest.playwrightJavaVersion;
+        var clientJar = variables.launcher.$jarPath(installDir=installDir, version=version);
+        var driverJar = variables.launcher.$driverBundlePath(installDir=installDir, version=version);
+        if (!fileExists(clientJar) || !fileExists(driverJar)) {
             variables.skipBrowserTests = true;
             return;
         }
         variables.skipBrowserTests = false;
-        variables.launcher.$loadJar(jarPath=jarPath);
+        variables.launcher.$loadJars(jarPaths=[clientJar, driverJar]);
         variables.browser = variables.launcher.acquireBrowser(engine="chromium");
         variables.baseUrl = "http://localhost:8080";
     }
@@ -2527,11 +2565,14 @@ component extends="wheels.WheelsTest" {
      */
     private any function $ensureLauncher() {
         if (!structKeyExists(application, "$wheelsBrowserLauncher")) {
-            var l = CreateObject("component", "wheels.wheelstest.BrowserLauncher");
+            var l = CreateObject("component", "wheels.wheelstest.BrowserLauncher").init();
             var installDir = l.resolveInstallDir();
-            var jarPath = l.$jarPath(installDir=installDir, version=l.$manifest.playwrightJavaVersion);
-            l.$verifyInstall(jarPath=jarPath);
-            l.$loadJar(jarPath=jarPath);
+            var version = l.$manifest.playwrightJavaVersion;
+            var clientJar = l.$jarPath(installDir=installDir, version=version);
+            var driverJar = l.$driverBundlePath(installDir=installDir, version=version);
+            l.$verifyInstall(jarPath=clientJar);
+            l.$verifyInstall(jarPath=driverJar);
+            l.$loadJars(jarPaths=[clientJar, driverJar]);
             application.$wheelsBrowserLauncher = l;
         }
         return application.$wheelsBrowserLauncher;

--- a/docs/superpowers/specs/2026-04-15-browser-testing-design.md
+++ b/docs/superpowers/specs/2026-04-15-browser-testing-design.md
@@ -1,0 +1,597 @@
+# Browser Testing — Design
+
+**Status:** Approved
+**Date:** 2026-04-15
+**Target release:** Wheels v4.0
+**Closes:** Item 4 in `docs/wheels-vs-frameworks.md` "Where Wheels Trails"
+
+## 1. Problem
+
+Wheels has first-class HTTP integration testing via `TestClient.cfc`
+(`visit/get/post/assertOk/assertSee/assertJson`), but no native browser
+automation. Rails ships System Tests (Capybara + Selenium), Laravel ships
+Dusk, Spring ships Selenium/Playwright integration. A Wheels app that
+wants to test a login form end-to-end, a Hotwire Turbo Frame update, or
+any JS-driven flow has to assemble external tooling from scratch.
+
+This design adds native browser testing to Wheels, modeled on Laravel
+Dusk's ergonomics but built on Playwright Java for better cross-browser
+coverage and JVM-native integration.
+
+## 2. Goals
+
+1. **Fluent DSL** (`BrowserClient.cfc`) that mirrors `TestClient.cfc`'s
+   shape — same naming conventions (`visit`, `assertSee`, `assertDontSee`),
+   same chainable pattern, same terminal accessors.
+2. **TestBox integration** via a `BrowserTest.cfc` base class that manages
+   Playwright lifecycle invisibly — spec writers never see
+   `Playwright.create()` or `browser.newContext()`.
+3. **`loginAs` ergonomics** via a test-only route + `storageState` hook,
+   so specs don't spend 5-10 lines logging in before every test.
+4. **Multi-browser support** (Chromium default, Firefox/WebKit opt-in via
+   `wheels browser:install --browsers=...`) with one engine per spec CFC.
+5. **CLI integration** — `wheels browser:install` for one-time setup,
+   `wheels browser:test` for running specs, with optional `--managed`
+   flag to auto-spawn LuCLI.
+6. **MCP integration** — new `wheels_browser_install`,
+   `wheels_browser_test`, `wheels_browser_status` tools.
+7. **Dogfooding** — `packages/hotwire/` gets browser specs that exercise
+   Turbo Frame, Turbo Stream, and Stimulus flows using the new DSL.
+
+## 3. Non-goals (v4.0)
+
+- **Adobe CF and BoxLang support.** Classloader risk deferred to a future
+  sprint. v4.0 targets Lucee 7 only.
+- **MySQL / PostgreSQL / SQL Server as browser-test DB.** SQLite only for
+  v4.0 to keep CI and inner-loop fast.
+- **Parallel browser test execution.** `ParallelRunner.cfc` works for HTTP
+  tests; browser adds port-collision complexity. v4.1.
+- **Multi-engine per spec CFC** (same `it` block running against Chromium,
+  Firefox, and WebKit in one go). v4.1.
+- **`wheels-plugin-auth` default `$signInAsForBrowserTest` implementation.**
+  The auth plugin doesn't exist as a package yet. Apps implement the hook
+  themselves in v4.0.
+- **`@testid` selector shortcut.** Wait for a convention to emerge.
+- **Touch / mobile tap methods.** v4.1+ if mobile testing grows.
+- **`wheels generate browser-test` scaffold generator.** Nice-to-have; v4.1.
+
+## 4. Architecture
+
+Three new components, each with one responsibility. Boundaries are
+deliberate — `BrowserClient` knows nothing about TestBox,
+`BrowserTest` knows nothing about Playwright internals, CLI knows
+nothing about either.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  tests/specs/browser/LoginBrowserSpec.cfc                   │
+│  (user-written — extends wheels.BrowserTest)                │
+└──────────────────┬──────────────────────────────────────────┘
+                   │ this.browser (fluent DSL)
+                   ▼
+┌─────────────────────────────────────────────────────────────┐
+│  vendor/wheels/wheelstest/BrowserClient.cfc                 │
+│  Fluent DSL: visit/click/fill/assertSee/assertUrlIs/...     │
+│  Wraps one Playwright BrowserContext + Page pair.           │
+└──────────────────┬──────────────────────────────────────────┘
+                   │ CreateObject("java", "com.microsoft.playwright.*")
+                   ▼
+┌─────────────────────────────────────────────────────────────┐
+│  vendor/wheels/wheelstest/BrowserLauncher.cfc               │
+│  Process singleton. Holds one Playwright + one Browser per  │
+│  test run. Loads JAR via this.javaSettings dynamically.     │
+└──────────────────┬──────────────────────────────────────────┘
+                   │ JAR classpath
+                   ▼
+┌─────────────────────────────────────────────────────────────┐
+│  ~/.wheels/browser/lib/playwright-java-1.45.0.jar (~50MB)   │
+│  Includes bundled Node.js driver (invisible to user)        │
+└──────────────────┬──────────────────────────────────────────┘
+                   │ IPC to bundled Node driver
+                   ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Chromium / Firefox / WebKit browser binaries               │
+│  Installed to ~/.wheels/browser/browsers/ by                │
+│  `wheels browser:install`                                   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 4.1 Component responsibilities
+
+| Component | Path | Responsibility |
+|---|---|---|
+| `BrowserClient.cfc` | `vendor/wheels/wheelstest/BrowserClient.cfc` | Fluent DSL for one browser session. Wraps Playwright `BrowserContext` + `Page`. Mirrors `TestClient.cfc`'s shape. No TestBox coupling. |
+| `BrowserTest.cfc` | `vendor/wheels/wheelstest/BrowserTest.cfc` | TestBox base class extending `wheels.WheelsTest`. Manages per-`it` context lifecycle via `beforeEach`/`afterEach`. Provides `this.browser`, `this.keepSignedInAs`, `this.browserViewport`, `this.screenshotOnFailure`, `this.traceOnFailure`, `this.browserEngine`. |
+| `BrowserLauncher.cfc` | `vendor/wheels/wheelstest/BrowserLauncher.cfc` | Process-level singleton. Holds the one `Playwright` instance and one `Browser` per test run. Discovers JAR path from `WHEELS_BROWSER_HOME` env var, then `~/.wheels/browser/lib/`. Integrates with Lucee's `this.javaSettings`. |
+| `wheels browser:install` | `vendor/wheels/cli/commands/browser/install.cfc` | Downloads Playwright Java JAR + runs `playwright install <browsers>`. Writes `~/.wheels/browser/` layout. |
+| `wheels browser:test` | `vendor/wheels/cli/commands/browser/test.cfc` | Preflight checks, optional LuCLI spawn via `--managed`, invokes existing test runner against `tests/specs/browser/`. |
+| Test-only login route | Registered in `vendor/wheels/routes.cfm` | `POST /_browser/login-as` with `identifier` in request body. Only active when `get("environment") == "testing"`. Delegates to app-defined `$signInAsForBrowserTest(identifier)`. |
+
+### 4.2 Key architectural decisions
+
+- **JAR lives in `~/.wheels/browser/`, not `vendor/`.** Keeps the framework
+  repo ~50MB lighter. Same pattern as Playwright's own browser cache.
+  `wheels browser:install` is a one-time per-dev-machine step.
+- **Classloader loading via `this.javaSettings` in `Application.cfc`.**
+  Lucee-specific, fine for v4.0 (Adobe deferred). `BrowserLauncher`
+  verifies JAR presence at init and fails loud with a clear error if
+  missing.
+- **`BrowserLauncher` as process singleton.** `Playwright.create()` is
+  ~1-2s; doing it once per test run vs. per spec CFC is the difference
+  between tests finishing in 30s and 5min.
+- **No coupling between `BrowserClient` and TestBox.** Someone could use
+  `BrowserClient` standalone from a controller or job.
+
+## 5. BrowserClient DSL
+
+### 5.1 Usage example
+
+```cfm
+// tests/specs/browser/LoginBrowserSpec.cfc
+component extends="wheels.BrowserTest" {
+    function run() {
+        describe("Login flow", () => {
+            it("signs in an existing user", () => {
+                this.browser
+                    .visit("/login")
+                    .fill("##email", "alice@example.com")
+                    .fill("##password", "secret")
+                    .click("button[type=submit]")
+                    .assertUrlIs("/dashboard")
+                    .assertSee("Welcome, Alice");
+            });
+
+            it("rejects bad credentials", () => {
+                this.browser
+                    .visit("/login")
+                    .fill("##email", "alice@example.com")
+                    .fill("##password", "wrong")
+                    .click("button[type=submit]")
+                    .assertUrlIs("/login")
+                    .assertSee("Invalid credentials");
+            });
+        });
+    }
+}
+```
+
+### 5.2 Method catalog (~35 methods)
+
+**Navigation**
+- `visit(path)` — navigate to path (relative to baseUrl)
+- `visitRoute(name, params={})` — navigate via named route
+- `back()` / `forward()` / `refresh()`
+
+**Interaction**
+- `click(selector)` — click first matching element; auto-waits for actionable
+- `press(buttonText)` — find button by visible text and click
+- `fill(selector, value)` — set input value instantly (fast path)
+- `type(selector, value)` — simulate keystrokes (for autocomplete / char-count
+  validation)
+- `clear(selector)` — clear input value
+- `select(selector, value)` — choose option in `<select>`
+- `check(selector)` / `uncheck(selector)` — checkbox/radio
+- `attach(selector, filePath)` — file upload
+- `dragAndDrop(fromSelector, toSelector)` — drag source to target
+
+**Keyboard**
+- `keys(selector, ...keys)` — `.keys("##search", "{enter}")`
+- `pressEnter()` / `pressTab()` / `pressEscape()` — sugar over `keys`
+
+**Dialogs**
+- `acceptDialog()` — accept next native confirm/alert
+- `dismissDialog()` — dismiss next native confirm
+- `typeInDialog(text)` — respond to native prompt
+
+**Waiting**
+- `waitFor(selector, seconds=5)`
+- `waitForText(text, seconds=5)`
+- `waitForUrl(path, seconds=5)`
+
+**Scoping**
+- `within(selector, callback)` — scope subsequent selectors to subtree.
+  Callback receives a scoped BrowserClient.
+
+**Viewport**
+- `resize(width, height)`
+- `resizeToMobile()` — 375×667
+- `resizeToTablet()` — 768×1024
+- `resizeToDesktop()` — 1440×900
+
+**Auth**
+- `loginAs(identifier)` — call test-only route, set session cookie.
+  `identifier` is passed through to the app's `$signInAsForBrowserTest`
+  hook unchanged (can be a numeric user ID, an email, or any value the
+  app's resolver accepts).
+- `logout()` — clear session cookies from context
+
+**Debug / escape**
+- `script(js)` — run arbitrary JS in page context, return result
+- `pause(milliseconds)` — DEBUG ONLY; CI fails if detected unless
+  `BROWSER_TEST_PAUSE_WARNING=off`
+
+**Cookies**
+- `setCookie(name, value)` / `deleteCookie(name)` / `cookie(name)`
+
+**Assertions**
+- `assertSee(text)` / `assertDontSee(text)`
+- `assertSeeIn(selector, text)`
+- `assertUrlIs(path)` / `assertRouteIs(name, params={})`
+- `assertQueryStringHas(key, value="")` / `assertQueryStringMissing(key)`
+- `assertTitleContains(text)`
+- `assertVisible(selector)` / `assertMissing(selector)` — visible ≠ present
+- `assertPresent(selector)` / `assertNotPresent(selector)` — DOM presence
+  regardless of display
+- `assertInputValue(selector, value)`
+- `assertChecked(selector)`
+- `assertHasClass(selector, class)`
+
+**Terminals** (for `expect()` drop-out)
+- `currentUrl()` / `title()` / `pageSource()` / `text(selector)` /
+  `value(selector)` / `screenshot(path)`
+
+### 5.3 Design decisions
+
+- **`fill` vs `type` distinction preserved** (Playwright convention).
+  `fill` sets value instantly (95% case), `type` simulates keystrokes
+  (autocomplete, char-count validation).
+- **`within(selector, callback)` over `scope()/unscope()`.** Lexical
+  boundary prevents forgotten-unscope bugs. Callback receives a scoped
+  client; chain resumes after.
+- **Selectors are raw CSS.** No `@name` shortcut. Tests requiring stable
+  selectors use `data-testid="..."` and `[data-testid=foo]`.
+- **`assertRouteIs(name, params)` uses `urlFor()` internally.** Tests
+  survive URL structure changes.
+- **No mouse-positioning methods** (`mouseover`, `clickAtPoint`). Rare;
+  `script()` is the fallback.
+
+## 6. BrowserTest base class
+
+### 6.1 Hooks and properties
+
+```cfm
+component extends="wheels.WheelsTest" {
+    // All optional; sensible defaults
+    this.keepSignedInAs = "";          // identifier passed to $signInAsForBrowserTest; non-empty triggers storageState reuse
+    this.browserViewport = "desktop";  // "desktop" | "tablet" | "mobile" | struct{w,h}
+    this.browserEngine = "chromium";   // "chromium" | "firefox" | "webkit"
+    this.screenshotOnFailure = true;   // dump PNG to tests/_artifacts/
+    this.traceOnFailure = false;       // dump Playwright trace.zip (slower, richer)
+    this.browser = "";                 // populated in beforeEach — the BrowserClient
+
+    function beforeAll() { ... }
+    function beforeEach() { ... }
+    function afterEach() { ... }
+    function afterAll() { ... }
+}
+```
+
+### 6.2 Lifecycle
+
+| Hook | Action | Cost |
+|---|---|---|
+| `beforeAll` (once per spec CFC) | `BrowserLauncher.acquireBrowser(engine=this.browserEngine)` — returns process-level singleton. If `this.keepSignedInAs` set, logs that user in via test-only route, captures `storageState` into `variables.$savedState`. | ~1-2s first spec CFC; ~10ms thereafter |
+| `beforeEach` (per `it` block) | `context = browser.newContext(storageState=$savedState, viewport=...)`, `page = context.newPage()`, wire both into fresh `BrowserClient`, assign to `this.browser`. | ~15ms |
+| `afterEach` (per `it` block) | On failure: dump screenshot to `tests/_artifacts/{run}/{specName}/{itName}.png`, dump HTML source, optionally trace.zip. Close context. | ~20ms |
+| `afterAll` (once per spec CFC) | Release browser handle (Playwright itself stays alive for next spec). | ~5ms |
+
+### 6.3 `loginAs` flow
+
+Two complementary patterns; choose per-spec based on need:
+
+**Pattern A — `this.keepSignedInAs` property** (once per spec CFC).
+Every `it` in the spec starts as that user. Uses `storageState` replay
+for speed.
+
+```cfm
+component extends="wheels.BrowserTest" {
+    this.keepSignedInAs = 42;  // passed to app's $signInAsForBrowserTest hook
+
+    function run() {
+        describe("Admin dashboard", () => {
+            it("shows user list", () => {
+                this.browser.visit("/admin/users").assertSee("Users");
+            });
+        });
+    }
+}
+```
+
+**Pattern B — `this.browser.loginAs(userId)` mid-test** (ad-hoc).
+Use when different `it` blocks need different users, or the test itself
+exercises login.
+
+```cfm
+it("admin sees edit buttons, member does not", () => {
+    this.browser.loginAs(adminId).visit("/posts/1").assertVisible(".edit");
+    this.browser.logout().loginAs(memberId).visit("/posts/1").assertMissing(".edit");
+});
+```
+
+### 6.4 Test-only login route
+
+Registered in `vendor/wheels/routes.cfm` with an environment guard:
+
+```cfm
+// Inside mapper() chain, before .wildcard()
+if (get("environment") == "testing") {
+    .post(name="wheelsBrowserTestLogin",
+          pattern="/_browser/login-as",
+          to="wheels.wheelstest.BrowserTestLoginController##loginAs")
+}
+```
+
+The controller reads `params.identifier` from the POST body and passes
+it through to `$signInAsForBrowserTest`. Body transport avoids URL
+encoding concerns when the identifier contains special characters
+(e.g., `admin@example.com`).
+
+**Safety layers:**
+
+1. Route only registered when `environment == "testing"`. Same guard
+   pattern used by the dev toolbar.
+2. Startup check in `BrowserLauncher` logs a loud warning if the route
+   is detected in production mode (belt-and-suspenders).
+3. Controller delegates to app-defined `$signInAsForBrowserTest(userId)`
+   — app provides the actual auth logic. If app hasn't defined it,
+   route returns 501 Not Implemented with clear error.
+
+**App implementation contract** (docs in
+`.ai/wheels/testing/browser-testing.md`):
+
+```cfm
+// app/events/onapplicationstart.cfm or a dedicated app/events/browsertest.cfm
+function $signInAsForBrowserTest(required any identifier) {
+    // App fills in: look up user (by id, email, or custom), set session, etc.
+    // arguments.identifier is whatever the test passed to
+    // this.browser.loginAs() or this.keepSignedInAs (no coercion).
+    session.userId = arguments.identifier;
+}
+```
+
+## 7. CLI + installation
+
+### 7.1 `wheels browser:install`
+
+One-time per developer machine; idempotent.
+
+```bash
+wheels browser:install                              # default: chromium only
+wheels browser:install --browsers=chromium,firefox
+wheels browser:install --all                        # all three
+wheels browser:install --add=webkit                 # add to existing
+wheels browser:install --remove=firefox             # reclaim disk
+wheels browser:install --force                      # re-download even if present
+```
+
+Output:
+```
+Installing Playwright Java browser automation...
+
+✓ Java 21 detected
+✓ Downloading playwright-1.45.0.jar (49.2 MB)
+✓ Verified SHA256 (pinned in vendor/wheels/browser-manifest.json)
+✓ Installing Chromium 127.0.6533.17 (130 MB, to ~/.wheels/browser/browsers/)
+✓ Writing ~/.wheels/browser/version
+
+Installed to ~/.wheels/browser/.
+
+Add this to your app's Application.cfc this.javaSettings.loadPaths:
+  getUserHome() & "/.wheels/browser/lib/"
+
+Or set BROWSER_TEST_AUTO_LOAD=true in .env (done automatically for
+LuCLI dev servers).
+```
+
+### 7.2 Install layout
+
+```
+~/.wheels/browser/
+├── lib/
+│   └── playwright-java-1.45.0.jar          # ~50MB (JAR + bundled Node)
+├── browsers/
+│   ├── chromium-1124/                      # ~300MB on disk
+│   ├── firefox-1440/                       # ~180MB (optional)
+│   └── webkit-2033/                        # ~200MB (optional)
+├── version                                  # "1.45.0"
+├── manifest.json                            # SHA256s, pinned versions
+└── install.log
+```
+
+### 7.3 Browser sizes (reference)
+
+| Browser | Download | Disk after extract |
+|---|---|---|
+| Chromium | ~130 MB (macOS), ~170 MB (Linux) | ~300 MB |
+| Firefox | ~80 MB | ~180 MB |
+| WebKit | ~70 MB | ~200 MB |
+| **All three** | **~280 MB** | **~680 MB** |
+
+The Playwright Java JAR itself is ~50MB regardless of which browsers are
+installed.
+
+### 7.4 Pinned versions
+
+`vendor/wheels/browser-manifest.json` (checked into repo):
+
+```json
+{
+    "playwrightJavaVersion": "1.45.0",
+    "playwrightJavaJar": {
+        "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/playwright/1.45.0/playwright-1.45.0.jar",
+        "sha256": "..."
+    },
+    "browsers": {
+        "chromium": "1124",
+        "firefox": "1440",
+        "webkit": "2033"
+    }
+}
+```
+
+Updating Playwright = bumping the manifest + re-testing. No
+"works on my machine" surprises.
+
+### 7.5 `wheels browser:test`
+
+```bash
+wheels browser:test                           # assumes server on :8080
+wheels browser:test --managed                 # spawns LuCLI on ephemeral port
+wheels browser:test --managed --port=8090     # specific port
+wheels browser:test --directory=tests/specs/browser/login/
+wheels browser:test --spec=LoginBrowserSpec
+wheels browser:test --headed                  # visible browser (debug)
+wheels browser:test --pause-on-failure        # halt on first fail, browser stays open
+```
+
+**Under the hood:**
+
+1. Preflight: `~/.wheels/browser/` populated? Java version ok?
+   If not: "run wheels browser:install" and exit non-zero.
+2. If `--managed`: start LuCLI server on ephemeral port, set baseUrl.
+3. Clean `tests/_artifacts/` of stale runs (respecting `--keep-runs=N`).
+4. Invoke existing test runner (same infra as `wheels test run`)
+   pointing at `tests/specs/browser/` (or `--directory`).
+5. If `--managed`: stop LuCLI server, forward exit code.
+6. Print summary + artifact locations for failures.
+
+**Why separate from `wheels test run`:** preconditions matter.
+`wheels test run` should stay lightweight. Browser tests have a hard
+prerequisite (JAR must be installed). A distinct command enforces that
+with a fast, loud failure path.
+
+**No auto-install on first `wheels browser:test`.** A 150MB download
+happening "magically" is a bad surprise. Dev runs install consciously
+(matches `npm install` behavior).
+
+### 7.6 MCP tools
+
+Three additions to `/wheels/mcp`:
+
+- `wheels_browser_install(browsers="chromium", force=false)` — runs install
+- `wheels_browser_test(directory="tests.specs.browser", managed=true, spec="", engine="chromium")` — runs browser specs
+- `wheels_browser_status()` — reports install state, pinned version,
+  detected Java, cached browser binaries
+
+The MCP `wheels_test()` tool stays as-is (non-browser specs). Browser
+tests get their own tool because their semantics differ enough that
+collapsing would hide the cost.
+
+### 7.7 `tools/test-local.sh` integration
+
+New `browser` target:
+
+```bash
+bash tools/test-local.sh browser    # preflight, then --managed mode
+```
+
+Checks `~/.wheels/browser/`, errors with install instructions if
+missing (doesn't auto-install — too slow for inner loop).
+
+## 8. Artifacts on failure
+
+### 8.1 Directory structure
+
+```
+tests/_artifacts/
+└── 2026-04-15-142301/                      # timestamped run dir
+    ├── LoginBrowserSpec/
+    │   ├── rejects-bad-credentials.png
+    │   ├── rejects-bad-credentials.html
+    │   └── rejects-bad-credentials.trace.zip   # only if traceOnFailure=true
+    ├── CheckoutBrowserSpec/
+    │   └── ...
+    └── summary.json                        # failures, timings, trace paths
+```
+
+Timestamped run dirs so yesterday's failure artifacts aren't lost.
+`--keep-runs=5` trims to last N. `.gitignore` gets `tests/_artifacts/`.
+
+### 8.2 Failure output
+
+```
+✗ LoginBrowserSpec > rejects bad credentials (1.2s)
+  AssertionError: expected to see "Invalid credentials" but page contained "Server error"
+  Screenshot: tests/_artifacts/2026-04-15-142301/LoginBrowserSpec/rejects-bad-credentials.png
+  Page source: tests/_artifacts/2026-04-15-142301/LoginBrowserSpec/rejects-bad-credentials.html
+```
+
+Paths are clickable in modern terminals (iTerm2, VS Code).
+
+## 9. Testing the framework feature itself
+
+Three layers:
+
+| Layer | Location | What it proves |
+|---|---|---|
+| Unit | `vendor/wheels/tests/specs/wheelstest/BrowserClientSpec.cfc` | Each DSL method calls the correct Playwright Java method with correct args (mocked `Page`). No browser launch. Fast. |
+| Integration | `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc` | Real Chromium launch. Exercises `BrowserLauncher` singleton, `BrowserTest` lifecycle, `loginAs`, storageState replay. Uses fixture app in `vendor/wheels/tests/fixtures/browserapp/`. |
+| Dogfood | `packages/hotwire/tests/specs/browser/` | ~8 browser specs for wheels-hotwire: Turbo Frame updates, Turbo Stream broadcasts, Stimulus controllers activating, form submissions without full reload. |
+
+The dogfood layer is where the design justifies itself. If
+wheels-hotwire specs are noisy, we iterate on the DSL before v4.0 ships.
+
+## 10. Rollout
+
+### 10.1 PR split
+
+| PR | Scope | Approx LOC |
+|---|---|---|
+| **1. Foundation** | `BrowserLauncher.cfc`, `BrowserClient.cfc`, `BrowserTest.cfc`, `browser-manifest.json`, unit + integration tests, `BrowserTestLoginController.cfc`, route registration | ~2500 |
+| **2. CLI + install** | `wheels browser:install`, `wheels browser:test`, MCP tools, `tools/test-local.sh browser target` | ~800 |
+| **3. Hotwire dogfood** | 8 browser specs for `packages/hotwire/`, minor hotwire fixes surfaced by testing | ~500 |
+| **4. CI + docs** | GitHub Actions `browser-tests` job (soft-fail initially), `.ai/wheels/testing/browser-testing.md`, CLAUDE.md section, changelog | ~300 |
+
+Each PR independently reviewable and mergeable. If a PR blocks,
+subsequent ones can land behind the partial foundation (the DSL works
+without CI; docs stand alone).
+
+### 10.2 CI integration
+
+New `browser-tests` job in `.github/workflows/tests.yml`:
+
+- Runs only on Lucee 7 + SQLite for v4.0 (per Section 3 scope).
+- Caches `~/.wheels/browser/` by `browser-manifest.json` hash — JAR +
+  Chromium download happens once per manifest bump, not per build.
+- **Soft-fail for the first 2 weeks after merge**, same pattern
+  CockroachDB followed. Promoted to hard-fail only after a green streak
+  demonstrates stability.
+
+### 10.3 Multi-engine CI (optional)
+
+Separate `browser-tests-multi-engine` job runs on nightly schedule or
+release candidates only. Exercises Firefox + WebKit. Does not block
+normal builds.
+
+## 11. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Playwright Java JAR has classloader issues under some Lucee 7 configs | Integration specs run on lucee7 matrix; also verified manually against a real Lucee 7 deployment before PR merge |
+| Flaky tests erode trust | Soft-fail in CI initially; promote to hard-fail only after 2-week green streak |
+| Test-only `loginAs` route accidentally enabled in production | Environment guard (`get("environment") == "testing"`); startup warning if detected in production mode; controller returns 501 if app hasn't defined `$signInAsForBrowserTest` |
+| Install flow confuses first-time users | Dedicated `.ai/wheels/testing/browser-testing.md` doc; error messages that link to it; `wheels browser:status` MCP tool for diagnosis |
+| Disk use balloons (all three browsers = ~680MB) | Opt-in via `--browsers=` flag; Chromium-only default; `--remove=firefox` reclaims |
+| Users on Java < 21 | Preflight check in `wheels browser:install` fails with clear version requirement |
+
+## 12. Documentation
+
+- `.ai/wheels/testing/browser-testing.md` — reference doc (DSL method
+  table, setup walkthrough, failure-artifact guide, `$signInAsForBrowserTest`
+  contract, common pitfalls)
+- `CLAUDE.md` — new "Browser Testing" section summarizing the runner
+  URL, DSL, install steps
+- `packages/hotwire/README.md` — example browser spec in the package
+  readme
+- Changelog entry under v4.0 release notes
+
+## 13. Open questions (minor)
+
+- Do we pin Chromium to a specific version in `browser-manifest.json`,
+  or use Playwright's default per JAR version? Leaning pin for
+  reproducibility.
+- Should `wheels browser:status` be under the MCP `wheels_browser_status`
+  tool only, or also a CLI command? Leaning both (trivial cost, useful
+  for CI preflight).
+- Artifact retention default: `--keep-runs=5` or `--keep-runs=10`?
+  Leaning 5 for disk friendliness.

--- a/tools/install-playwright.sh
+++ b/tools/install-playwright.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Temporary bootstrap for browser testing. Replaced by `wheels browser:install`
+# once PR 2 lands. Reads vendor/wheels/browser-manifest.json for pinned versions.
+#
+# Playwright Java needs the full classpath — client, driver, driver-bundle, plus
+# transitive runtime deps (gson, Java-WebSocket, slf4j) — to boot. Maven normally
+# resolves these; since we bootstrap without Maven, the manifest pins every JAR
+# with SHA256, and this script downloads + verifies each before invoking the CLI.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST="$REPO_ROOT/vendor/wheels/browser-manifest.json"
+INSTALL_DIR="${WHEELS_BROWSER_HOME:-$HOME/.wheels/browser}"
+LIB_DIR="$INSTALL_DIR/lib"
+
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: $MANIFEST not found" >&2
+    exit 1
+fi
+
+mkdir -p "$LIB_DIR"
+
+# Read classpath entries as tab-separated rows: filename\turl\tsha256.
+# Avoids bash-4 `mapfile` so the script works with macOS's default bash 3.2.
+ENTRIES_FILE=$(mktemp)
+trap 'rm -f "$ENTRIES_FILE"' EXIT
+python3 -c "
+import json
+m = json.load(open('$MANIFEST'))
+for e in m['classpath']:
+    print(e['filename'] + '\t' + e['url'] + '\t' + e['sha256'])
+" > "$ENTRIES_FILE"
+
+ENTRY_COUNT=$(wc -l < "$ENTRIES_FILE" | tr -d ' ')
+if [[ "$ENTRY_COUNT" -eq 0 ]]; then
+    echo "ERROR: manifest has no classpath entries" >&2
+    exit 1
+fi
+
+CLASSPATH=""
+while IFS=$'\t' read -r filename url sha; do
+    target="$LIB_DIR/$filename"
+
+    if [[ -f "$target" ]]; then
+        actual=$(shasum -a 256 "$target" | awk '{print $1}')
+        if [[ "$actual" == "$sha" ]]; then
+            echo "✓ $filename already present (SHA verified)"
+            CLASSPATH+="$target:"
+            continue
+        fi
+        echo "! $filename exists but SHA mismatch; re-downloading"
+        rm -f "$target"
+    fi
+
+    echo "Downloading $filename from Maven Central..."
+    curl -sSL -o "$target" "$url"
+
+    actual=$(shasum -a 256 "$target" | awk '{print $1}')
+    if [[ "$actual" != "$sha" ]]; then
+        echo "ERROR: SHA mismatch for $filename" >&2
+        echo "  expected: $sha" >&2
+        echo "  actual:   $actual" >&2
+        rm -f "$target"
+        exit 1
+    fi
+    echo "✓ $filename downloaded and SHA-verified"
+    CLASSPATH+="$target:"
+done < "$ENTRIES_FILE"
+
+# Strip trailing colon
+CLASSPATH="${CLASSPATH%:}"
+
+echo ""
+echo "Installing Chromium via Playwright CLI (full classpath: $ENTRY_COUNT JARs)..."
+java -cp "$CLASSPATH" com.microsoft.playwright.CLI install chromium
+
+echo ""
+echo "Done."
+echo "  JARs:        $LIB_DIR/  ($ENTRY_COUNT files)"
+echo "  Browsers:    ~/.cache/ms-playwright/ (Playwright default cache dir)"
+echo "  Install dir: $INSTALL_DIR"

--- a/tools/install-playwright.sh
+++ b/tools/install-playwright.sh
@@ -25,12 +25,14 @@ mkdir -p "$LIB_DIR"
 # Avoids bash-4 `mapfile` so the script works with macOS's default bash 3.2.
 ENTRIES_FILE=$(mktemp)
 trap 'rm -f "$ENTRIES_FILE"' EXIT
+# Pass MANIFEST as argv[1] so paths with apostrophes don't break the
+# Python single-quoted string. Paranoid for vendor/wheels/ but free.
 python3 -c "
-import json
-m = json.load(open('$MANIFEST'))
+import json, sys
+m = json.load(open(sys.argv[1]))
 for e in m['classpath']:
     print(e['filename'] + '\t' + e['url'] + '\t' + e['sha256'])
-" > "$ENTRIES_FILE"
+" "$MANIFEST" > "$ENTRIES_FILE"
 
 ENTRY_COUNT=$(wc -l < "$ENTRIES_FILE" | tr -d ' ')
 if [[ "$ENTRY_COUNT" -eq 0 ]]; then

--- a/vendor/wheels/browser-manifest.json
+++ b/vendor/wheels/browser-manifest.json
@@ -6,6 +6,11 @@
         "sha256": "37eb1cd92d971469834755e139fd3193d03674917b498cc51f4cae715237ba39",
         "size": 619097
     },
+    "playwrightDriverBundle": {
+        "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/driver-bundle/1.52.0/driver-bundle-1.52.0.jar",
+        "sha256": "144c435fbca910da329a903a47d2f93bc9723acc1320a2b45b604ea335ae5242",
+        "size": 200138356
+    },
     "browsers": {
         "chromium": "136.0.7103.25",
         "firefox": "137.0",

--- a/vendor/wheels/browser-manifest.json
+++ b/vendor/wheels/browser-manifest.json
@@ -1,16 +1,50 @@
 {
-    "schemaVersion": 1,
+    "schemaVersion": 2,
     "playwrightJavaVersion": "1.52.0",
-    "playwrightJavaJar": {
-        "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/playwright/1.52.0/playwright-1.52.0.jar",
-        "sha256": "37eb1cd92d971469834755e139fd3193d03674917b498cc51f4cae715237ba39",
-        "size": 619097
-    },
-    "playwrightDriverBundle": {
-        "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/driver-bundle/1.52.0/driver-bundle-1.52.0.jar",
-        "sha256": "144c435fbca910da329a903a47d2f93bc9723acc1320a2b45b604ea335ae5242",
-        "size": 200138356
-    },
+    "classpath": [
+        {
+            "filename": "playwright-1.52.0.jar",
+            "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/playwright/1.52.0/playwright-1.52.0.jar",
+            "sha256": "37eb1cd92d971469834755e139fd3193d03674917b498cc51f4cae715237ba39",
+            "size": 619097
+        },
+        {
+            "filename": "driver-1.52.0.jar",
+            "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/driver/1.52.0/driver-1.52.0.jar",
+            "sha256": "bfed51b42047ff11c7de62d6756e3b4ec459f41ff407fd2082c8cc5e52e875df",
+            "size": 6863
+        },
+        {
+            "filename": "driver-bundle-1.52.0.jar",
+            "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/driver-bundle/1.52.0/driver-bundle-1.52.0.jar",
+            "sha256": "144c435fbca910da329a903a47d2f93bc9723acc1320a2b45b604ea335ae5242",
+            "size": 200138356
+        },
+        {
+            "filename": "gson-2.12.1.jar",
+            "url": "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.12.1/gson-2.12.1.jar",
+            "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+            "size": 285943
+        },
+        {
+            "filename": "Java-WebSocket-1.6.0.jar",
+            "url": "https://repo1.maven.org/maven2/org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.jar",
+            "sha256": "eae29213e4f16515639c28957200f011b3967fffcada1962cf0255d24919c22f",
+            "size": 140686
+        },
+        {
+            "filename": "slf4j-api-2.0.17.jar",
+            "url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar",
+            "sha256": "7b751d952061954d5abfed7181c1f645d336091b679891591d63329c622eb832",
+            "size": 69908
+        },
+        {
+            "filename": "slf4j-simple-2.0.17.jar",
+            "url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/2.0.17/slf4j-simple-2.0.17.jar",
+            "sha256": "ddfea59ac074c6d3e24ac2c38622d2d963895e17f70b38ed4bdae4d780be6964",
+            "size": 15716
+        }
+    ],
     "browsers": {
         "chromium": "136.0.7103.25",
         "firefox": "137.0",

--- a/vendor/wheels/browser-manifest.json
+++ b/vendor/wheels/browser-manifest.json
@@ -1,0 +1,16 @@
+{
+    "schemaVersion": 1,
+    "playwrightJavaVersion": "1.52.0",
+    "playwrightJavaJar": {
+        "url": "https://repo1.maven.org/maven2/com/microsoft/playwright/playwright/1.52.0/playwright-1.52.0.jar",
+        "sha256": "37eb1cd92d971469834755e139fd3193d03674917b498cc51f4cae715237ba39",
+        "size": 619097
+    },
+    "browsers": {
+        "chromium": "136.0.7103.25",
+        "firefox": "137.0",
+        "webkit": "18.4"
+    },
+    "minJavaVersion": 21,
+    "installDir": "~/.wheels/browser"
+}

--- a/vendor/wheels/tests/fixtures/browserapp/app/controllers/Home.cfc
+++ b/vendor/wheels/tests/fixtures/browserapp/app/controllers/Home.cfc
@@ -1,6 +1,6 @@
 component extends="Controller" {
 
-    function init() {
+    function config() {
         filters(through="$requireLogin", except="index");
     }
 

--- a/vendor/wheels/tests/fixtures/browserapp/app/controllers/Home.cfc
+++ b/vendor/wheels/tests/fixtures/browserapp/app/controllers/Home.cfc
@@ -1,0 +1,19 @@
+component extends="Controller" {
+
+    function init() {
+        filters(through="$requireLogin", except="index");
+    }
+
+    function index() {
+    }
+
+    function dashboard() {
+        user = { email: session.userEmail ?: "" };
+    }
+
+    private function $requireLogin() {
+        if (!structKeyExists(session, "userId")) {
+            redirectTo(route="login");
+        }
+    }
+}

--- a/vendor/wheels/tests/fixtures/browserapp/app/controllers/Sessions.cfc
+++ b/vendor/wheels/tests/fixtures/browserapp/app/controllers/Sessions.cfc
@@ -1,0 +1,22 @@
+component extends="Controller" {
+
+    function new() {
+        flashError = flash("error") ?: "";
+    }
+
+    function create() {
+        if (params.email == "alice@example.com" && params.password == "secret") {
+            session.userId = 1;
+            session.userEmail = params.email;
+            redirectTo(route="dashboard");
+        } else {
+            flashInsert(error="Invalid credentials");
+            redirectTo(route="login");
+        }
+    }
+
+    function destroy() {
+        structClear(session);
+        redirectTo(route="login");
+    }
+}

--- a/vendor/wheels/tests/fixtures/browserapp/app/views/home/dashboard.cfm
+++ b/vendor/wheels/tests/fixtures/browserapp/app/views/home/dashboard.cfm
@@ -1,0 +1,8 @@
+<cfparam name="user" default="#{}#">
+<cfoutput>
+<h1>Dashboard</h1>
+<p>Welcome, #encodeForHTML(user.email)#</p>
+<form method="post" action="#urlFor(route='logout')#">
+    <button type="submit">Log out</button>
+</form>
+</cfoutput>

--- a/vendor/wheels/tests/fixtures/browserapp/app/views/home/index.cfm
+++ b/vendor/wheels/tests/fixtures/browserapp/app/views/home/index.cfm
@@ -1,0 +1,5 @@
+<cfoutput>
+<h1>Home</h1>
+<p>Welcome to the browser test fixture app.</p>
+<a href="#urlFor(route='login')#">Log in</a>
+</cfoutput>

--- a/vendor/wheels/tests/fixtures/browserapp/app/views/sessions/new.cfm
+++ b/vendor/wheels/tests/fixtures/browserapp/app/views/sessions/new.cfm
@@ -1,0 +1,12 @@
+<cfparam name="flashError" default="">
+<cfoutput>
+<h1>Log in</h1>
+<cfif len(flashError)>
+    <div class="error">#flashError#</div>
+</cfif>
+<form method="post" action="#urlFor(route='authenticate')#">
+    <input type="email" name="email" id="email">
+    <input type="password" name="password" id="password">
+    <button type="submit">Sign in</button>
+</form>
+</cfoutput>

--- a/vendor/wheels/tests/fixtures/browserapp/config/routes.cfm
+++ b/vendor/wheels/tests/fixtures/browserapp/config/routes.cfm
@@ -1,0 +1,10 @@
+<cfscript>
+mapper()
+    .root(to="home##index", method="get")
+    .get(name="login", pattern="/login", to="sessions##new")
+    .post(name="authenticate", pattern="/login", to="sessions##create")
+    .get(name="dashboard", pattern="/dashboard", to="home##dashboard")
+    .post(name="logout", pattern="/logout", to="sessions##destroy")
+    .wildcard()
+.end();
+</cfscript>

--- a/vendor/wheels/tests/fixtures/browserapp/config/settings.cfm
+++ b/vendor/wheels/tests/fixtures/browserapp/config/settings.cfm
@@ -1,0 +1,4 @@
+<cfscript>
+set(environment="testing");
+set(dataSourceName="wheelstestdb");
+</cfscript>

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -4,15 +4,23 @@ component extends="wheels.WheelsTest" {
     // beforeEach creates a fresh BrowserContext for isolation between `it`s.
 
     function beforeAll() {
-        variables.skipBrowserTests = true;
         variables.launcher = new wheels.wheelstest.BrowserLauncher();
         var paths = variables.launcher.$classpathJarPaths(installDir=variables.launcher.resolveInstallDir());
+        // Check JAR presence explicitly. Distinguishes "not installed"
+        // (legitimate skip) from "installed but launcher crashed" (loud
+        // failure that should propagate). Mirrors BrowserTest.cfc's
+        // catch-specific pattern.
         for (var p in paths) {
-            if (!fileExists(p)) return;
+            if (!fileExists(p)) {
+                variables.skipBrowserTests = true;
+                return;
+            }
         }
-        variables.launcher.$loadJars(jarPaths=paths);
-        variables.browser = variables.launcher.acquireBrowser(engine="chromium");
         variables.skipBrowserTests = false;
+        variables.launcher.$loadJars(jarPaths=paths);
+        // If acquireBrowser throws (Wheels.BrowserLaunchFailed, etc), let it
+        // propagate — those are real failures that should surface, not skip.
+        variables.browser = variables.launcher.acquireBrowser(engine="chromium");
     }
 
     function afterAll() {
@@ -468,7 +476,7 @@ component extends="wheels.WheelsTest" {
                 expect(variables.bc.value("##e")).toBe("preset");
             });
 
-            it("screenshot(path) writes a non-empty PNG file", () => {
+            it("screenshot(path) writes a valid PNG (magic bytes verified)", () => {
                 if (variables.skipBrowserTests) return;
                 variables.bc.visitUrl("data:text/html,<h1>Snap</h1>");
                 var tmpPath = getTempDirectory() & "wheels-bc-" & createUUID() & ".png";
@@ -476,9 +484,113 @@ component extends="wheels.WheelsTest" {
                     variables.bc.screenshot(tmpPath);
                     expect(fileExists(tmpPath)).toBeTrue();
                     expect(getFileInfo(tmpPath).size).toBeGT(0);
+                    // PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A. Verifying these
+                    // catches binary-encoding regressions where fileWrite turns
+                    // the byte[] into a text-encoded blob.
+                    var bytes = fileReadBinary(tmpPath);
+                    expect(bytes[1]).toBe(-119);  // 0x89 as signed byte
+                    expect(bytes[2]).toBe(80);    // P
+                    expect(bytes[3]).toBe(78);    // N
+                    expect(bytes[4]).toBe(71);    // G
                 } finally {
                     if (fileExists(tmpPath)) fileDelete(tmpPath);
                 }
+            });
+        });
+
+        describe("BrowserClient — additional negative-path + coverage gaps", () => {
+
+            beforeEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx = variables.browser.newContext();
+                variables.pg = variables.ctx.newPage();
+                variables.bc = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+            });
+
+            afterEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx.close();
+            });
+
+            // assertUrlIs — the most complex assertion; previously untested
+            it("assertUrlIs with full URL passes when current URL matches exactly", () => {
+                if (variables.skipBrowserTests) return;
+                var dataUrl = "data:text/html,<h1>x</h1>";
+                variables.bc.visitUrl(dataUrl);
+                variables.bc.assertUrlIs(variables.bc.currentUrl());
+            });
+
+            it("assertUrlIs with full URL throws on mismatch", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>a</h1>");
+                expect(() => variables.bc.assertUrlIs("data:text/html,<h1>b</h1>"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            it("assertUrlIs with leading-slash arg compares path only", () => {
+                if (variables.skipBrowserTests) return;
+                // Use page.evaluate to push a synthetic history entry so we
+                // can test path extraction without a real HTTP server.
+                variables.bc.visitUrl("data:text/html,<h1>x</h1>");
+                // currentUrl() will be the data: URL — assertUrlIs("/path")
+                // would extract the "path" from a data: URL and compare.
+                // For data: URLs $pathFromUrl returns the full URL, so the
+                // compare fails. That's correct behavior; verify it throws:
+                expect(() => variables.bc.assertUrlIs("/some-path"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            // Negative paths on assertions that previously had positive-only tests
+            it("assertDontSee throws when text IS on page", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>Welcome</h1>");
+                expect(() => variables.bc.assertDontSee("Welcome"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            it("assertVisible throws when selector matches no visible elements", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='hidden' style='display:none'>");
+                expect(() => variables.bc.assertVisible("##hidden"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            it("assertMissing throws when selector matches at least one element", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='here'>");
+                expect(() => variables.bc.assertMissing("##here"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            it("assertInputValue throws on mismatch", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='e' value='actual'>");
+                expect(() => variables.bc.assertInputValue("##e", "wrong"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            it("assertChecked throws when checkbox is unchecked", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='cb' type='checkbox'>");
+                expect(() => variables.bc.assertChecked("##cb"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            it("assertQueryStringHas throws when key missing", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>x</h1>");
+                expect(() => variables.bc.assertQueryStringHas("nope"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            // Previously untested method: pressEscape
+            it("pressEscape(selector) dispatches Escape keypress", () => {
+                if (variables.skipBrowserTests) return;
+                var html = "<input id='i' onkeydown=""if(event.key==='Escape') document.getElementById('o').textContent='ESC'""><div id='o'></div>";
+                variables.bc.visitUrl("data:text/html," & html);
+                variables.bc.pressEscape("##i");
+                expect(variables.pg.locator("##o").textContent()).toBe("ESC");
             });
         });
     }

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -1,0 +1,99 @@
+component extends="wheels.WheelsTest" {
+
+    // Shared BrowserLauncher + Browser across specs (expensive, ~1.7s per launch).
+    // beforeEach creates a fresh BrowserContext for isolation between `it`s.
+
+    function beforeAll() {
+        variables.skipBrowserTests = true;
+        variables.launcher = new wheels.wheelstest.BrowserLauncher();
+        var paths = variables.launcher.$classpathJarPaths(installDir=variables.launcher.resolveInstallDir());
+        for (var p in paths) {
+            if (!fileExists(p)) return;
+        }
+        variables.launcher.$loadJars(jarPaths=paths);
+        variables.browser = variables.launcher.acquireBrowser(engine="chromium");
+        variables.skipBrowserTests = false;
+    }
+
+    function afterAll() {
+        if (!(variables.skipBrowserTests ?: true)) {
+            variables.launcher.release();
+        }
+    }
+
+    function run() {
+
+        describe("BrowserClient — pure unit-level behavior (no browser)", () => {
+
+            it("visit() rejects paths without a leading slash", () => {
+                var c = new wheels.wheelstest.BrowserClient()
+                    .init(page="", context="", baseUrl="http://localhost");
+                expect(() => {
+                    c.visit("no-leading-slash");
+                }).toThrow(type="Wheels.BrowserInvalidPath");
+            });
+
+            it("getBaseUrl() returns what init() received", () => {
+                var c = new wheels.wheelstest.BrowserClient()
+                    .init(baseUrl="http://example.test:1234");
+                expect(c.getBaseUrl()).toBe("http://example.test:1234");
+            });
+
+            it("init() is chainable", () => {
+                var c = new wheels.wheelstest.BrowserClient();
+                var result = c.init(baseUrl="http://x");
+                expect(result).toBe(c);
+            });
+        });
+
+        describe("BrowserClient — navigation against real Chromium (data: URLs)", () => {
+
+            // data: URLs avoid needing a fixture server; still exercises real
+            // Playwright navigation + currentUrl plumbing through our DSL.
+
+            beforeEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx = variables.browser.newContext();
+                variables.pg = variables.ctx.newPage();
+            });
+
+            afterEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx.close();
+            });
+
+            it("visitUrl() navigates and currentUrl() reflects the page", () => {
+                if (variables.skipBrowserTests) return;
+                var c = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+                var result = c.visitUrl("data:text/html,<h1>Hello</h1>");
+                expect(result).toBe(c);
+                expect(c.currentUrl()).toInclude("data:text/html");
+                expect(c.currentUrl()).toInclude("Hello");
+            });
+
+            it("back() / forward() navigate history", () => {
+                if (variables.skipBrowserTests) return;
+                var c = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+                c.visitUrl("data:text/html,<h1>One</h1>");
+                c.visitUrl("data:text/html,<h1>Two</h1>");
+                expect(c.currentUrl()).toInclude("Two");
+                c.back();
+                expect(c.currentUrl()).toInclude("One");
+                c.forward();
+                expect(c.currentUrl()).toInclude("Two");
+            });
+
+            it("refresh() keeps the url stable", () => {
+                if (variables.skipBrowserTests) return;
+                var c = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+                c.visitUrl("data:text/html,<title>X</title>");
+                var before = c.currentUrl();
+                c.refresh();
+                expect(c.currentUrl()).toBe(before);
+            });
+        });
+    }
+}

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -302,5 +302,184 @@ component extends="wheels.WheelsTest" {
                 expect(variables.bc.script("() => document.querySelector('h1').textContent")).toBe("Hello");
             });
         });
+
+        describe("BrowserClient — text + visibility + presence assertions", () => {
+
+            beforeEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx = variables.browser.newContext();
+                variables.pg = variables.ctx.newPage();
+                variables.bc = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+            });
+
+            afterEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx.close();
+            });
+
+            it("assertSee passes when text is on page", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>Welcome</h1>").assertSee("Welcome");
+            });
+
+            it("assertSee throws Wheels.BrowserAssertionFailed when absent", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>A</h1>");
+                expect(() => variables.bc.assertSee("Missing")).toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            it("assertDontSee passes when text is absent", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>A</h1>").assertDontSee("Missing");
+            });
+
+            it("assertSeeIn scopes text search to a selector", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>Title</h1><p>Body text</p>")
+                    .assertSeeIn("h1", "Title");
+                expect(() => variables.bc.assertSeeIn("h1", "Body"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            it("assertVisible passes when element is rendered", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='e'>").assertVisible("##e");
+            });
+
+            it("assertMissing passes when selector matches no elements", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='e'>").assertMissing("##nope");
+            });
+
+            it("assertPresent / assertNotPresent check DOM presence", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='e'>")
+                    .assertPresent("##e")
+                    .assertNotPresent("##nope");
+            });
+        });
+
+        describe("BrowserClient — URL + title + query assertions", () => {
+
+            beforeEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx = variables.browser.newContext();
+                variables.pg = variables.ctx.newPage();
+                variables.bc = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+            });
+
+            afterEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx.close();
+            });
+
+            it("assertUrlContains matches a substring of the current URL", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>X</h1>")
+                    .assertUrlContains("text/html");
+            });
+
+            it("assertUrlContains throws when substring not present", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>X</h1>");
+                expect(() => variables.bc.assertUrlContains("not-here"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            it("assertTitleContains matches via <title> element", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<title>My Page</title><h1>X</h1>")
+                    .assertTitleContains("My Page");
+                expect(() => variables.bc.assertTitleContains("Other"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            it("assertQueryStringHas / Missing parse the URL's query", () => {
+                if (variables.skipBrowserTests) return;
+                // data: URL with a query string. Playwright preserves the ?
+                variables.bc.visitUrl("data:text/html,<h1>X</h1>?foo=bar&baz=qux")
+                    .assertQueryStringHas("foo", "bar")
+                    .assertQueryStringHas("baz")
+                    .assertQueryStringMissing("nope");
+            });
+        });
+
+        describe("BrowserClient — form assertions + terminals", () => {
+
+            beforeEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx = variables.browser.newContext();
+                variables.pg = variables.ctx.newPage();
+                variables.bc = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+            });
+
+            afterEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx.close();
+            });
+
+            it("assertInputValue matches on filled value", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='e'>")
+                    .fill("##e", "hello")
+                    .assertInputValue("##e", "hello");
+            });
+
+            it("assertChecked passes on checked box", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='cb' type='checkbox'>")
+                    .check("##cb")
+                    .assertChecked("##cb");
+            });
+
+            it("assertHasClass passes when element has the named class", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<div id='d' class='foo bar baz'>x</div>")
+                    .assertHasClass("##d", "bar")
+                    .assertHasClass("##d", "foo");
+                expect(() => variables.bc.assertHasClass("##d", "nope"))
+                    .toThrow(type="Wheels.BrowserAssertionFailed");
+            });
+
+            it("title() returns the <title> element content", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<title>T</title><h1>X</h1>");
+                expect(variables.bc.title()).toBe("T");
+            });
+
+            it("pageSource() returns full rendered HTML", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>Hello</h1>");
+                expect(variables.bc.pageSource()).toInclude("Hello");
+            });
+
+            it("text(selector) returns the element's textContent", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>Heading</h1>");
+                expect(variables.bc.text("h1")).toBe("Heading");
+            });
+
+            it("value(selector) returns current input value", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='e' value='preset'>");
+                expect(variables.bc.value("##e")).toBe("preset");
+            });
+
+            it("screenshot(path) writes a non-empty PNG file", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>Snap</h1>");
+                var tmpPath = getTempDirectory() & "wheels-bc-" & createUUID() & ".png";
+                try {
+                    variables.bc.screenshot(tmpPath);
+                    expect(fileExists(tmpPath)).toBeTrue();
+                    expect(getFileInfo(tmpPath).size).toBeGT(0);
+                } finally {
+                    if (fileExists(tmpPath)) fileDelete(tmpPath);
+                }
+            });
+        });
     }
 }

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -250,5 +250,57 @@ component extends="wheels.WheelsTest" {
                 expect(variables.pg.locator("##f2 ##email").inputValue()).toBe("in-f2");
             });
         });
+
+        describe("BrowserClient — viewport + script", () => {
+
+            beforeEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx = variables.browser.newContext();
+                variables.pg = variables.ctx.newPage();
+                variables.bc = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+            });
+
+            afterEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx.close();
+            });
+
+            it("resize(w, h) sets viewport size; script can read window dims", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>X</h1>");
+                variables.bc.resize(800, 600);
+                var w = variables.bc.script("() => window.innerWidth");
+                var h = variables.bc.script("() => window.innerHeight");
+                expect(w).toBe(800);
+                expect(h).toBe(600);
+            });
+
+            it("resizeToMobile() sets 375x667", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>X</h1>").resizeToMobile();
+                expect(variables.bc.script("() => window.innerWidth")).toBe(375);
+                expect(variables.bc.script("() => window.innerHeight")).toBe(667);
+            });
+
+            it("resizeToTablet() sets 768x1024", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>X</h1>").resizeToTablet();
+                expect(variables.bc.script("() => window.innerWidth")).toBe(768);
+            });
+
+            it("resizeToDesktop() sets 1440x900", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>X</h1>").resizeToDesktop();
+                expect(variables.bc.script("() => window.innerWidth")).toBe(1440);
+            });
+
+            it("script(js) evaluates and returns result", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>Hello</h1>");
+                expect(variables.bc.script("() => 2 + 2")).toBe(4);
+                expect(variables.bc.script("() => document.querySelector('h1').textContent")).toBe("Hello");
+            });
+        });
     }
 }

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -173,5 +173,82 @@ component extends="wheels.WheelsTest" {
                 expect(variables.pg.locator("##s").inputValue()).toBe("b");
             });
         });
+
+        describe("BrowserClient — keyboard, waiting, scoping", () => {
+
+            beforeEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx = variables.browser.newContext();
+                variables.pg = variables.ctx.newPage();
+                variables.bc = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+            });
+
+            afterEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx.close();
+            });
+
+            it("keys(selector, 'Enter') dispatches an Enter keypress", () => {
+                if (variables.skipBrowserTests) return;
+                var html = "<input id='i' onkeydown=""if(event.key==='Enter') document.getElementById('o').textContent='e'""><div id='o'></div>";
+                variables.bc.visitUrl("data:text/html," & html);
+                variables.bc.keys("##i", "Enter");
+                expect(variables.pg.locator("##o").textContent()).toBe("e");
+            });
+
+            it("pressEnter(selector) is shorthand for keys(selector, 'Enter')", () => {
+                if (variables.skipBrowserTests) return;
+                var html = "<input id='i' onkeydown=""if(event.key==='Enter') document.getElementById('o').textContent='E'""><div id='o'></div>";
+                variables.bc.visitUrl("data:text/html," & html);
+                variables.bc.pressEnter("##i");
+                expect(variables.pg.locator("##o").textContent()).toBe("E");
+            });
+
+            it("pressTab() with no selector sends Tab to keyboard", () => {
+                if (variables.skipBrowserTests) return;
+                // Focus input A, press Tab, expect input B to have focus.
+                var html = "<input id='a' autofocus><input id='b'>";
+                variables.bc.visitUrl("data:text/html," & html);
+                // Give the page a tick to apply autofocus.
+                variables.bc.click("##a");
+                variables.bc.pressTab();
+                // activeElement's id reflects focus
+                var focusedId = variables.pg.evaluate("() => document.activeElement.id");
+                expect(focusedId).toBe("b");
+            });
+
+            it("waitFor(selector) resolves once the element is visible", () => {
+                if (variables.skipBrowserTests) return;
+                // Script injects a new node after 50ms; waitFor blocks until it appears.
+                var html = "<div id='root'></div><script>setTimeout(() => { var n = document.createElement('span'); n.id = 'late'; n.textContent = 'hi'; document.getElementById('root').appendChild(n); }, 50);</script>";
+                variables.bc.visitUrl("data:text/html," & html);
+                var result = variables.bc.waitFor("##late");
+                expect(result).toBe(variables.bc);
+                expect(variables.pg.locator("##late").textContent()).toBe("hi");
+            });
+
+            it("waitForText(text) resolves once the text appears", () => {
+                if (variables.skipBrowserTests) return;
+                var html = "<div id='root'></div><script>setTimeout(() => { document.getElementById('root').textContent = 'Delayed Text'; }, 50);</script>";
+                variables.bc.visitUrl("data:text/html," & html);
+                variables.bc.waitForText("Delayed Text");
+                expect(variables.pg.locator("##root").textContent()).toBe("Delayed Text");
+            });
+
+            it("within(selector, callback) scopes interactions to a subtree", () => {
+                if (variables.skipBrowserTests) return;
+                // Two forms with same-id inputs. within() should restrict
+                // our fill() to the second form.
+                var html = "<form id='f1'><input id='email'></form><form id='f2'><input id='email'></form>";
+                variables.bc.visitUrl("data:text/html," & html);
+                variables.bc.within("form##f2", (scoped) => {
+                    scoped.fill("##email", "in-f2");
+                });
+                // f1's email is still empty; f2's email got set.
+                expect(variables.pg.locator("##f1 ##email").inputValue()).toBe("");
+                expect(variables.pg.locator("##f2 ##email").inputValue()).toBe("in-f2");
+            });
+        });
     }
 }

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -95,5 +95,83 @@ component extends="wheels.WheelsTest" {
                 expect(c.currentUrl()).toBe(before);
             });
         });
+
+        describe("BrowserClient — interaction against real Chromium (inline HTML)", () => {
+
+            // Each `it` gets a fresh context + page. Inline HTML forms via
+            // data: URLs let us test fill/click/check/etc without a real
+            // server. Return values of interaction methods are asserted via
+            // reading the locator's current state after the call.
+
+            beforeEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx = variables.browser.newContext();
+                variables.pg = variables.ctx.newPage();
+                variables.bc = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+            });
+
+            afterEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx.close();
+            });
+
+            it("fill() sets an input value and returns this for chaining", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='e' type='email'>");
+                var result = variables.bc.fill("##e", "alice@example.com");
+                expect(result).toBe(variables.bc);
+                expect(variables.pg.locator("##e").inputValue()).toBe("alice@example.com");
+            });
+
+            it("type() sends keystrokes one-by-one", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='n'>");
+                variables.bc.type("##n", "hello");
+                expect(variables.pg.locator("##n").inputValue()).toBe("hello");
+            });
+
+            it("clear() empties a previously-filled input", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='e'>");
+                variables.bc.fill("##e", "abc").clear("##e");
+                expect(variables.pg.locator("##e").inputValue()).toBe("");
+            });
+
+            it("click() triggers button handler (verified via DOM mutation)", () => {
+                if (variables.skipBrowserTests) return;
+                // Use a button that mutates the DOM on click — avoids needing
+                // a form submit path (which would require a real server).
+                var html = "<button id='b' onclick=""document.getElementById('out').textContent='clicked'"">Go</button><div id='out'></div>";
+                variables.bc.visitUrl("data:text/html," & html);
+                variables.bc.click("##b");
+                expect(variables.pg.locator("##out").textContent()).toBe("clicked");
+            });
+
+            it("press('Go') clicks by visible text", () => {
+                if (variables.skipBrowserTests) return;
+                var html = "<button onclick=""document.getElementById('out').textContent='pressed'"">Go</button><div id='out'></div>";
+                variables.bc.visitUrl("data:text/html," & html);
+                variables.bc.press("Go");
+                expect(variables.pg.locator("##out").textContent()).toBe("pressed");
+            });
+
+            it("check() / uncheck() toggle a checkbox", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<input id='cb' type='checkbox'>");
+                variables.bc.check("##cb");
+                expect(variables.pg.locator("##cb").isChecked()).toBeTrue();
+                variables.bc.uncheck("##cb");
+                expect(variables.pg.locator("##cb").isChecked()).toBeFalse();
+            });
+
+            it("select() chooses a dropdown option by value", () => {
+                if (variables.skipBrowserTests) return;
+                var html = "<select id='s'><option value='a'>A</option><option value='b'>B</option></select>";
+                variables.bc.visitUrl("data:text/html," & html);
+                variables.bc.select("##s", "b");
+                expect(variables.pg.locator("##s").inputValue()).toBe("b");
+            });
+        });
     }
 }

--- a/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
@@ -107,6 +107,42 @@ component extends="wheels.WheelsTest" {
                 expect(klass.getName()).toBe("com.microsoft.playwright.Playwright");
                 l.release();
             });
+
+            it("acquireBrowser('chromium') launches a real headless browser", () => {
+                // Full end-to-end integration. Slow (~2-3s): starts a node driver
+                // process and a Chromium instance.
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+                for (var p in paths) {
+                    if (!fileExists(p)) return;
+                }
+                l.$loadJars(jarPaths=paths);
+                try {
+                    var browser = l.acquireBrowser(engine="chromium");
+                    expect(browser).notToBeNull();
+                    expect(isObject(browser)).toBeTrue();
+                    // Smoke: the Browser should report it's connected
+                    expect(browser.isConnected()).toBeTrue();
+                } finally {
+                    l.release();
+                }
+            });
+
+            it("acquireBrowser() returns the same Browser across calls (singleton per engine)", () => {
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+                for (var p in paths) {
+                    if (!fileExists(p)) return;
+                }
+                l.$loadJars(jarPaths=paths);
+                try {
+                    var b1 = l.acquireBrowser(engine="chromium");
+                    var b2 = l.acquireBrowser(engine="chromium");
+                    expect(b1).toBe(b2);
+                } finally {
+                    l.release();
+                }
+            });
         });
     }
 }

--- a/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
@@ -143,6 +143,57 @@ component extends="wheels.WheelsTest" {
                     l.release();
                 }
             });
+
+            it("$loadJars() is idempotent — second call after ready stays ready", () => {
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+                for (var p in paths) {
+                    if (!fileExists(p)) return;
+                }
+                l.$loadJars(jarPaths=paths);
+                expect(l.getState()).toBe("ready");
+                l.$loadJars(jarPaths=paths);  // should be no-op
+                expect(l.getState()).toBe("ready");
+                l.release();
+            });
+
+            it("acquireBrowser() throws BrowserLauncherNotReady after release()", () => {
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+                for (var p in paths) {
+                    if (!fileExists(p)) return;
+                }
+                l.$loadJars(jarPaths=paths);
+                l.release();
+                expect(l.getState()).toBe("shut-down");
+                expect(() => l.acquireBrowser(engine="chromium"))
+                    .toThrow(type="Wheels.BrowserLauncherNotReady");
+            });
+
+            it("acquireBrowser() throws BrowserEngineInvalid for unknown engine", () => {
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+                for (var p in paths) {
+                    if (!fileExists(p)) return;
+                }
+                l.$loadJars(jarPaths=paths);
+                try {
+                    expect(() => l.acquireBrowser(engine="opera"))
+                        .toThrow(type="Wheels.BrowserEngineInvalid");
+                } finally {
+                    l.release();
+                }
+            });
+
+            it("$findZeroArgMethod throws BrowserLauncherReflectionError when method missing", () => {
+                // Pure reflection helper — testable on any Java class without
+                // needing Playwright JARs loaded. Use String which has no
+                // 'thisDoesNotExist' method.
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var stringClass = createObject("java", "java.lang.String").getClass();
+                expect(() => l.$findZeroArgMethod(klass=stringClass, name="thisDoesNotExistOnString"))
+                    .toThrow(type="Wheels.BrowserLauncherReflectionError");
+            });
         });
     }
 }

--- a/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
@@ -1,7 +1,7 @@
 component extends="wheels.WheelsTest" {
 
     function beforeAll() {
-        variables.launcher = CreateObject("component", "wheels.wheelstest.BrowserLauncher");
+        variables.launcher = new wheels.wheelstest.BrowserLauncher();
     }
 
     function run() {
@@ -53,6 +53,59 @@ component extends="wheels.WheelsTest" {
                 } finally {
                     fileDelete(tmpJar);
                 }
+            });
+
+            it("classpathJarPaths() returns one path per manifest classpath entry", () => {
+                var paths = variables.launcher.$classpathJarPaths(installDir="/tmp/browser");
+                var expectedCount = arrayLen(variables.launcher.getManifest().classpath);
+                expect(arrayLen(paths)).toBe(expectedCount);
+                for (var p in paths) {
+                    expect(p).toInclude("/tmp/browser/lib/");
+                    expect(p).toEndWith(".jar");
+                }
+            });
+
+            it("acquireBrowser() throws BrowserLauncherNotReady before $loadJars()", () => {
+                var l = new wheels.wheelstest.BrowserLauncher();
+                expect(() => {
+                    l.acquireBrowser(engine="chromium");
+                }).toThrow(type="Wheels.BrowserLauncherNotReady");
+            });
+
+            it("$loadJars() transitions state uninitialized -> ready -> shut-down", () => {
+                // Integration: requires Playwright install (~/.wheels/browser/lib/)
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+                var allPresent = true;
+                for (var p in paths) {
+                    if (!fileExists(p)) {
+                        allPresent = false;
+                        break;
+                    }
+                }
+                if (!allPresent) {
+                    debug("Skipping: Playwright JARs not installed. Run tools/install-playwright.sh");
+                    return;
+                }
+                expect(l.getState()).toBe("uninitialized");
+                l.$loadJars(jarPaths=paths);
+                expect(l.getState()).toBe("ready");
+                l.release();
+                expect(l.getState()).toBe("shut-down");
+            });
+
+            it("resolves com.microsoft.playwright.Playwright class through the URLClassLoader", () => {
+                // Integration: requires Playwright install
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+                for (var p in paths) {
+                    if (!fileExists(p)) return;
+                }
+                l.$loadJars(jarPaths=paths);
+                var klass = l.getClassLoader().loadClass("com.microsoft.playwright.Playwright");
+                expect(klass).notToBeNull();
+                expect(klass.getName()).toBe("com.microsoft.playwright.Playwright");
+                l.release();
             });
         });
     }

--- a/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
@@ -1,0 +1,59 @@
+component extends="wheels.WheelsTest" {
+
+    function beforeAll() {
+        variables.launcher = CreateObject("component", "wheels.wheelstest.BrowserLauncher");
+    }
+
+    function run() {
+        describe("BrowserLauncher path discovery", () => {
+
+            it("resolveInstallDir() returns WHEELS_BROWSER_HOME env var when set", () => {
+                var stubbed = variables.launcher.$resolveInstallDir(
+                    envVar="/tmp/custom-browser-home",
+                    homeDir="/Users/someone"
+                );
+                expect(stubbed).toBe("/tmp/custom-browser-home");
+            });
+
+            it("resolveInstallDir() falls back to ~/.wheels/browser when env var empty", () => {
+                var resolved = variables.launcher.$resolveInstallDir(
+                    envVar="",
+                    homeDir="/Users/someone"
+                );
+                expect(resolved).toBe("/Users/someone/.wheels/browser");
+            });
+
+            it("resolveInstallDir() handles home dir with trailing slash", () => {
+                var resolved = variables.launcher.$resolveInstallDir(
+                    envVar="",
+                    homeDir="/Users/someone/"
+                );
+                expect(resolved).toBe("/Users/someone/.wheels/browser");
+            });
+
+            it("jarPath() returns installDir + /lib/playwright-VERSION.jar", () => {
+                var p = variables.launcher.$jarPath(
+                    installDir="/tmp/browser",
+                    version="1.45.0"
+                );
+                expect(p).toBe("/tmp/browser/lib/playwright-1.45.0.jar");
+            });
+
+            it("verifyInstall() throws when JAR missing", () => {
+                expect(() => {
+                    variables.launcher.$verifyInstall(jarPath="/does/not/exist.jar");
+                }).toThrow(type="Wheels.BrowserNotInstalled");
+            });
+
+            it("verifyInstall() returns true when JAR exists", () => {
+                var tmpJar = getTempDirectory() & "dummy-" & createUUID() & ".jar";
+                fileWrite(tmpJar, "");
+                try {
+                    expect(variables.launcher.$verifyInstall(jarPath=tmpJar)).toBeTrue();
+                } finally {
+                    fileDelete(tmpJar);
+                }
+            });
+        });
+    }
+}

--- a/vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc
@@ -1,0 +1,47 @@
+/**
+ * Self-test: exercises BrowserTest base class by extending it and
+ * verifying the lifecycle hooks fire in the expected shape.
+ *
+ * Skips gracefully when Playwright JARs aren't installed (same pattern
+ * as BrowserIntegrationSpec) so CI stays green without the install step.
+ */
+component extends="wheels.wheelstest.BrowserTest" {
+
+    function run() {
+        browserDescribe("BrowserTest lifecycle", () => {
+
+            it("this.browser is populated before each it block", () => {
+                if (this.browserTestSkipped) return;
+                expect(isObject(this.browser)).toBeTrue();
+            });
+
+            it("this.browser exposes the full DSL (has getBaseUrl etc.)", () => {
+                if (this.browserTestSkipped) return;
+                // getBaseUrl / visit / assertSee etc. are the DSL API surface
+                expect(this.browser.getBaseUrl()).toBeTypeOf("string");
+            });
+
+            it("each it gets a fresh Page (window globals don't leak)", () => {
+                if (this.browserTestSkipped) return;
+                // Data URLs disable localStorage/cookies, but window globals
+                // work within a page. A fresh Page per it means fresh window.
+                this.browser.visitUrl("data:text/html,<h1>set</h1>");
+                this.browser.script("() => { window.myLeakProbe = 'leaked'; }");
+                expect(this.browser.script("() => window.myLeakProbe || 'clean'")).toBe("leaked");
+            });
+
+            it("window global from previous it is not visible here", () => {
+                if (this.browserTestSkipped) return;
+                this.browser.visitUrl("data:text/html,<h1>check</h1>");
+                expect(this.browser.script("() => window.myLeakProbe || 'clean'")).toBe("clean");
+            });
+
+            it("getBrowserLauncher() exposes the shared process-scoped launcher", () => {
+                if (this.browserTestSkipped) return;
+                var launcher = getBrowserLauncher();
+                expect(isObject(launcher)).toBeTrue();
+                expect(launcher.getState()).toBe("ready");
+            });
+        });
+    }
+}

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -53,6 +53,86 @@ component {
         return this;
     }
 
+    // ─── Interaction ─────────────────────────────────────────────────
+
+    public BrowserClient function click(required string selector) {
+        variables.page.locator(arguments.selector).click();
+        return this;
+    }
+
+    /**
+     * Clicks the first element matching the given visible text. Simpler than
+     * getByRole because it avoids building Playwright option objects through
+     * the URLClassLoader. If you need role-specific matching (e.g. button
+     * only, ignoring headings), use click("button:has-text('...')") instead.
+     */
+    public BrowserClient function press(required string buttonText) {
+        variables.page.getByText(arguments.buttonText).first().click();
+        return this;
+    }
+
+    public BrowserClient function fill(
+        required string selector,
+        required string value
+    ) {
+        variables.page.locator(arguments.selector).fill(arguments.value);
+        return this;
+    }
+
+    /**
+     * Types character-by-character (like a human). Slower than fill() but
+     * triggers per-keystroke event handlers (autosuggest, live validation).
+     */
+    public BrowserClient function type(
+        required string selector,
+        required string value
+    ) {
+        variables.page.locator(arguments.selector).pressSequentially(arguments.value);
+        return this;
+    }
+
+    public BrowserClient function clear(required string selector) {
+        variables.page.locator(arguments.selector).clear();
+        return this;
+    }
+
+    public BrowserClient function select(
+        required string selector,
+        required string value
+    ) {
+        variables.page.locator(arguments.selector).selectOption(arguments.value);
+        return this;
+    }
+
+    public BrowserClient function check(required string selector) {
+        variables.page.locator(arguments.selector).check();
+        return this;
+    }
+
+    public BrowserClient function uncheck(required string selector) {
+        variables.page.locator(arguments.selector).uncheck();
+        return this;
+    }
+
+    public BrowserClient function attach(
+        required string selector,
+        required string filePath
+    ) {
+        var emptyStringArr = javaCast("String[]", []);
+        var path = createObject("java", "java.nio.file.Paths").get(arguments.filePath, emptyStringArr);
+        variables.page.locator(arguments.selector).setInputFiles(path);
+        return this;
+    }
+
+    public BrowserClient function dragAndDrop(
+        required string fromSelector,
+        required string toSelector
+    ) {
+        variables.page.locator(arguments.fromSelector)
+            .dragTo(variables.page.locator(arguments.toSelector));
+        return this;
+    }
+
     // ─── Terminals ───────────────────────────────────────────────────
 
     public string function currentUrl() {
@@ -83,4 +163,5 @@ component {
             );
         }
     }
+
 }

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -311,10 +311,197 @@ component {
         variables.$scope = arguments.rootLocator;
     }
 
+    // ─── Assertions: text + visibility + presence ────────────────────
+
+    public BrowserClient function assertSee(required string text) {
+        if (!findNoCase(arguments.text, variables.page.content())) {
+            $assertFail("Expected page to contain '" & arguments.text & "'");
+        }
+        return this;
+    }
+
+    public BrowserClient function assertDontSee(required string text) {
+        if (findNoCase(arguments.text, variables.page.content())) {
+            $assertFail("Expected page NOT to contain '" & arguments.text & "'");
+        }
+        return this;
+    }
+
+    public BrowserClient function assertSeeIn(
+        required string selector,
+        required string text
+    ) {
+        var elementText = $locator(arguments.selector).textContent();
+        if (!findNoCase(arguments.text, elementText)) {
+            $assertFail("Expected '" & arguments.selector & "' to contain '"
+                & arguments.text & "', got '" & elementText & "'");
+        }
+        return this;
+    }
+
+    public BrowserClient function assertVisible(required string selector) {
+        if (!$locator(arguments.selector).first().isVisible()) {
+            $assertFail("Expected '" & arguments.selector & "' to be visible");
+        }
+        return this;
+    }
+
+    public BrowserClient function assertMissing(required string selector) {
+        var count = $locator(arguments.selector).count();
+        if (count > 0) {
+            $assertFail("Expected '" & arguments.selector & "' to be missing, found "
+                & count & " element(s)");
+        }
+        return this;
+    }
+
+    public BrowserClient function assertPresent(required string selector) {
+        if ($locator(arguments.selector).count() == 0) {
+            $assertFail("Expected '" & arguments.selector & "' to be present in DOM");
+        }
+        return this;
+    }
+
+    public BrowserClient function assertNotPresent(required string selector) {
+        if ($locator(arguments.selector).count() > 0) {
+            $assertFail("Expected '" & arguments.selector & "' to be absent from DOM");
+        }
+        return this;
+    }
+
+    // ─── Assertions: URL + title ─────────────────────────────────────
+
+    /**
+     * Exact URL match. For data: / about: / file: URLs, compares full URL.
+     * For http(s) URLs, compares the path portion only (protocol + host stripped).
+     */
+    public BrowserClient function assertUrlIs(required string expected) {
+        var current = variables.page.url();
+        // If caller passed a path (starts with /), compare path-only; else full URL
+        if (left(arguments.expected, 1) == "/") {
+            var currentPath = $pathFromUrl(current);
+            if (currentPath != arguments.expected) {
+                $assertFail("Expected path '" & arguments.expected
+                    & "', got '" & currentPath & "' (full URL: '" & current & "')");
+            }
+        } else if (current != arguments.expected) {
+            $assertFail("Expected URL '" & arguments.expected & "', got '" & current & "'");
+        }
+        return this;
+    }
+
+    /** Substring match — more forgiving than assertUrlIs for dynamic URLs. */
+    public BrowserClient function assertUrlContains(required string substring) {
+        var current = variables.page.url();
+        if (!find(arguments.substring, current)) {
+            $assertFail("Expected URL to contain '" & arguments.substring
+                & "', got '" & current & "'");
+        }
+        return this;
+    }
+
+    public BrowserClient function assertTitleContains(required string text) {
+        var pageTitle = variables.page.title();
+        if (!findNoCase(arguments.text, pageTitle)) {
+            $assertFail("Expected title to contain '" & arguments.text
+                & "', got '" & pageTitle & "'");
+        }
+        return this;
+    }
+
+    public BrowserClient function assertQueryStringHas(
+        required string key,
+        string value = ""
+    ) {
+        var query = $queryParamsFromUrl(variables.page.url());
+        if (!structKeyExists(query, arguments.key)) {
+            $assertFail("Expected query string to contain '" & arguments.key
+                & "', current params: " & serializeJSON(query));
+        }
+        if (len(arguments.value) > 0 && query[arguments.key] != arguments.value) {
+            $assertFail("Expected '" & arguments.key & "' = '" & arguments.value
+                & "', got '" & query[arguments.key] & "'");
+        }
+        return this;
+    }
+
+    public BrowserClient function assertQueryStringMissing(required string key) {
+        var query = $queryParamsFromUrl(variables.page.url());
+        if (structKeyExists(query, arguments.key)) {
+            $assertFail("Expected query string NOT to contain '" & arguments.key & "'");
+        }
+        return this;
+    }
+
+    // ─── Assertions: form + attributes ───────────────────────────────
+
+    public BrowserClient function assertInputValue(
+        required string selector,
+        required string value
+    ) {
+        var actual = $locator(arguments.selector).inputValue();
+        if (actual != arguments.value) {
+            $assertFail("Expected input '" & arguments.selector & "' value '"
+                & arguments.value & "', got '" & actual & "'");
+        }
+        return this;
+    }
+
+    public BrowserClient function assertChecked(required string selector) {
+        if (!$locator(arguments.selector).isChecked()) {
+            $assertFail("Expected '" & arguments.selector & "' to be checked");
+        }
+        return this;
+    }
+
+    public BrowserClient function assertHasClass(
+        required string selector,
+        required string class
+    ) {
+        var classAttr = $locator(arguments.selector).getAttribute("class") ?: "";
+        var classes = listToArray(classAttr, " ");
+        if (!arrayContainsNoCase(classes, arguments.class)) {
+            $assertFail("Expected '" & arguments.selector & "' to have class '"
+                & arguments.class & "', got '" & classAttr & "'");
+        }
+        return this;
+    }
+
     // ─── Terminals ───────────────────────────────────────────────────
 
     public string function currentUrl() {
         return variables.page.url();
+    }
+
+    public string function title() {
+        return variables.page.title();
+    }
+
+    /** Full HTML of the rendered page. */
+    public string function pageSource() {
+        return variables.page.content();
+    }
+
+    /** textContent of the first element matching `selector`. */
+    public string function text(required string selector) {
+        return $locator(arguments.selector).textContent();
+    }
+
+    /** Current value of an input/textarea/select element. */
+    public string function value(required string selector) {
+        return $locator(arguments.selector).inputValue();
+    }
+
+    /**
+     * Screenshot to `path`. Uses the no-arg screenshot() → byte[] overload
+     * rather than Page$ScreenshotOptions, since building the options class
+     * through the URLClassLoader hits Lucee's OSGi-bundle resolver (same
+     * trap documented on press() / waitFor() earlier in this file).
+     */
+    public BrowserClient function screenshot(required string path) {
+        var bytes = variables.page.screenshot();
+        fileWrite(arguments.path, bytes);
+        return this;
     }
 
     // ─── Accessors (primarily for tests & lifecycle managers) ────────
@@ -352,6 +539,64 @@ component {
             return variables.$scope.locator(arguments.selector);
         }
         return variables.page.locator(arguments.selector);
+    }
+
+    /**
+     * Throws Wheels.BrowserAssertionFailed with the given message. Callers
+     * in the DSL use this to surface failures in a way tests can catch
+     * distinctly from other errors.
+     */
+    private void function $assertFail(required string message) {
+        throw(
+            type="Wheels.BrowserAssertionFailed",
+            message=arguments.message
+        );
+    }
+
+    /**
+     * Extract the path portion of a URL, stripping scheme+host and query.
+     * Returns "/" when the URL has no explicit path. For data:/file: URLs,
+     * returns the full URL (they have no conventional "path").
+     */
+    private string function $pathFromUrl(required string url) {
+        if (!reFindNoCase("^https?://", arguments.url)) {
+            return arguments.url;  // not an http(s) URL — can't strip host
+        }
+        var noScheme = reReplace(arguments.url, "^https?://", "");
+        var firstSlash = find("/", noScheme);
+        if (firstSlash == 0) {
+            return "/";
+        }
+        var pathPlusQuery = mid(noScheme, firstSlash, len(noScheme));
+        var qIdx = find("?", pathPlusQuery);
+        if (qIdx > 0) {
+            return left(pathPlusQuery, qIdx - 1);
+        }
+        return pathPlusQuery;
+    }
+
+    /**
+     * Parse the query string of a URL into a struct. Keys with no `=`
+     * map to empty string. Values are URL-decoded.
+     */
+    private struct function $queryParamsFromUrl(required string url) {
+        var result = {};
+        var qIdx = find("?", arguments.url);
+        if (qIdx == 0) return result;
+        var queryString = mid(arguments.url, qIdx + 1, len(arguments.url));
+        // Strip fragment if present
+        var hashIdx = find("##", queryString);
+        if (hashIdx > 0) queryString = left(queryString, hashIdx - 1);
+        var pairs = listToArray(queryString, "&");
+        for (var p in pairs) {
+            var eqIdx = find("=", p);
+            if (eqIdx == 0) {
+                result[p] = "";
+            } else {
+                result[left(p, eqIdx - 1)] = urlDecode(mid(p, eqIdx + 1, len(p)));
+            }
+        }
+        return result;
     }
 
 }

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -1,0 +1,86 @@
+/**
+ * Fluent DSL wrapping a Playwright BrowserContext + Page for browser tests.
+ * Mirrors TestClient.cfc's shape: chainable methods return `this`,
+ * terminals return values.
+ *
+ * Instantiation: typically done by BrowserTest.cfc's beforeEach hook.
+ * For manual use, pass Playwright Java objects directly (BrowserContext,
+ * Page) and the base URL of the Wheels app under test.
+ */
+component {
+
+    variables.page = "";
+    variables.context = "";
+    variables.baseUrl = "";
+
+    public BrowserClient function init(
+        any page = "",
+        any context = "",
+        string baseUrl = ""
+    ) {
+        variables.page = arguments.page;
+        variables.context = arguments.context;
+        variables.baseUrl = arguments.baseUrl;
+        return this;
+    }
+
+    // ─── Navigation ──────────────────────────────────────────────────
+
+    public BrowserClient function visit(required string path) {
+        $requireLeadingSlash(arguments.path);
+        variables.page.navigate(variables.baseUrl & arguments.path);
+        return this;
+    }
+
+    public BrowserClient function visitUrl(required string url) {
+        // Escape hatch for absolute URLs (e.g. data:, file://, or another host).
+        variables.page.navigate(arguments.url);
+        return this;
+    }
+
+    public BrowserClient function back() {
+        variables.page.goBack();
+        return this;
+    }
+
+    public BrowserClient function forward() {
+        variables.page.goForward();
+        return this;
+    }
+
+    public BrowserClient function refresh() {
+        variables.page.reload();
+        return this;
+    }
+
+    // ─── Terminals ───────────────────────────────────────────────────
+
+    public string function currentUrl() {
+        return variables.page.url();
+    }
+
+    // ─── Accessors (primarily for tests & lifecycle managers) ────────
+
+    public any function getPage() {
+        return variables.page;
+    }
+
+    public any function getContext() {
+        return variables.context;
+    }
+
+    public string function getBaseUrl() {
+        return variables.baseUrl;
+    }
+
+    // ─── Internal helpers ────────────────────────────────────────────
+
+    private void function $requireLeadingSlash(required string path) {
+        if (left(arguments.path, 1) != "/") {
+            throw(
+                type="Wheels.BrowserInvalidPath",
+                message="BrowserClient paths must start with '/': " & arguments.path
+            );
+        }
+    }
+}

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -56,7 +56,7 @@ component {
     // ─── Interaction ─────────────────────────────────────────────────
 
     public BrowserClient function click(required string selector) {
-        variables.page.locator(arguments.selector).click();
+        $locator(arguments.selector).click();
         return this;
     }
 
@@ -75,7 +75,7 @@ component {
         required string selector,
         required string value
     ) {
-        variables.page.locator(arguments.selector).fill(arguments.value);
+        $locator(arguments.selector).fill(arguments.value);
         return this;
     }
 
@@ -87,12 +87,12 @@ component {
         required string selector,
         required string value
     ) {
-        variables.page.locator(arguments.selector).pressSequentially(arguments.value);
+        $locator(arguments.selector).pressSequentially(arguments.value);
         return this;
     }
 
     public BrowserClient function clear(required string selector) {
-        variables.page.locator(arguments.selector).clear();
+        $locator(arguments.selector).clear();
         return this;
     }
 
@@ -100,17 +100,17 @@ component {
         required string selector,
         required string value
     ) {
-        variables.page.locator(arguments.selector).selectOption(arguments.value);
+        $locator(arguments.selector).selectOption(arguments.value);
         return this;
     }
 
     public BrowserClient function check(required string selector) {
-        variables.page.locator(arguments.selector).check();
+        $locator(arguments.selector).check();
         return this;
     }
 
     public BrowserClient function uncheck(required string selector) {
-        variables.page.locator(arguments.selector).uncheck();
+        $locator(arguments.selector).uncheck();
         return this;
     }
 
@@ -120,7 +120,7 @@ component {
     ) {
         var emptyStringArr = javaCast("String[]", []);
         var path = createObject("java", "java.nio.file.Paths").get(arguments.filePath, emptyStringArr);
-        variables.page.locator(arguments.selector).setInputFiles(path);
+        $locator(arguments.selector).setInputFiles(path);
         return this;
     }
 
@@ -128,9 +128,118 @@ component {
         required string fromSelector,
         required string toSelector
     ) {
-        variables.page.locator(arguments.fromSelector)
-            .dragTo(variables.page.locator(arguments.toSelector));
+        $locator(arguments.fromSelector)
+            .dragTo($locator(arguments.toSelector));
         return this;
+    }
+
+    // ─── Keyboard ────────────────────────────────────────────────────
+
+    /**
+     * Press a keyboard key against the element matching `selector`.
+     * Key syntax follows Playwright: "Enter", "Tab", "Escape",
+     * "Control+A", "Shift+Home", etc.
+     */
+    public BrowserClient function keys(
+        required string selector,
+        required string key
+    ) {
+        $locator(arguments.selector).press(arguments.key);
+        return this;
+    }
+
+    /**
+     * Press Enter. If selector is given, presses inside that element
+     * (useful for "submit the form by pressing Enter in the last input").
+     * Otherwise sends Enter to whatever has focus.
+     */
+    public BrowserClient function pressEnter(string selector = "") {
+        return $pressSpecial(selector=arguments.selector, key="Enter");
+    }
+
+    public BrowserClient function pressTab(string selector = "") {
+        return $pressSpecial(selector=arguments.selector, key="Tab");
+    }
+
+    public BrowserClient function pressEscape(string selector = "") {
+        return $pressSpecial(selector=arguments.selector, key="Escape");
+    }
+
+    private BrowserClient function $pressSpecial(
+        required string selector,
+        required string key
+    ) {
+        if (len(arguments.selector) > 0) {
+            $locator(arguments.selector).press(arguments.key);
+        } else {
+            variables.page.keyboard().press(arguments.key);
+        }
+        return this;
+    }
+
+    // ─── Waiting ─────────────────────────────────────────────────────
+
+    /**
+     * Waits for a selector to become visible. Uses Playwright's default
+     * timeout (30s). seconds param is accepted for API compatibility with
+     * the plan, but not currently honored — configurable timeout requires
+     * building Locator$WaitForOptions through the URLClassLoader, which is
+     * fragile (see Task 7 press() commentary). Uses .first() so selectors
+     * that match multiple elements resolve to the first one.
+     */
+    public BrowserClient function waitFor(
+        required string selector,
+        numeric seconds = 30
+    ) {
+        $locator(arguments.selector).first().waitFor();
+        return this;
+    }
+
+    /**
+     * Waits for visible text to appear anywhere on the page. Same timeout
+     * caveat as waitFor().
+     */
+    public BrowserClient function waitForText(
+        required string text,
+        numeric seconds = 30
+    ) {
+        variables.page.getByText(arguments.text).first().waitFor();
+        return this;
+    }
+
+    // ─── Scoping ─────────────────────────────────────────────────────
+
+    /**
+     * Runs `callback(scopedClient)` with selectors resolved relative to the
+     * first element matching `selector`. Useful for "fill the email field
+     * inside the signin form, even if there's another email field elsewhere
+     * on the page".
+     *
+     *     client.within("form##signin", (scoped) => {
+     *         scoped.fill("##email", "alice@example.com");
+     *     });
+     */
+    public BrowserClient function within(
+        required string selector,
+        required any callback
+    ) {
+        var scoped = new wheels.wheelstest.BrowserClient()
+            .init(
+                page=variables.page,
+                context=variables.context,
+                baseUrl=variables.baseUrl
+            );
+        scoped.$setScope(variables.page.locator(arguments.selector).first());
+        arguments.callback(scoped);
+        return this;
+    }
+
+    /**
+     * Used by within() to restrict $locator() to a subtree. Public so the
+     * parent BrowserClient can set scope on the clone it creates.
+     */
+    public void function $setScope(required any rootLocator) {
+        variables.$scope = arguments.rootLocator;
     }
 
     // ─── Terminals ───────────────────────────────────────────────────
@@ -162,6 +271,18 @@ component {
                 message="BrowserClient paths must start with '/': " & arguments.path
             );
         }
+    }
+
+    /**
+     * Returns a locator for `selector`, scoped to our within() subtree when
+     * one is set. All interaction methods route through here so within()
+     * works uniformly for click/fill/type/check/select/etc.
+     */
+    private any function $locator(required string selector) {
+        if (structKeyExists(variables, "$scope")) {
+            return variables.$scope.locator(arguments.selector);
+        }
+        return variables.page.locator(arguments.selector);
     }
 
 }

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -207,6 +207,75 @@ component {
         return this;
     }
 
+    // ─── Viewport ────────────────────────────────────────────────────
+
+    /**
+     * Resize the page's viewport. Takes effect immediately; CSS media
+     * queries re-evaluate.
+     */
+    public BrowserClient function resize(
+        required numeric width,
+        required numeric height
+    ) {
+        variables.page.setViewportSize(
+            javaCast("int", arguments.width),
+            javaCast("int", arguments.height)
+        );
+        return this;
+    }
+
+    /** iPhone SE-like viewport (common mobile test size). */
+    public BrowserClient function resizeToMobile() {
+        return resize(375, 667);
+    }
+
+    /** iPad portrait-like viewport. */
+    public BrowserClient function resizeToTablet() {
+        return resize(768, 1024);
+    }
+
+    /** Typical laptop viewport. */
+    public BrowserClient function resizeToDesktop() {
+        return resize(1440, 900);
+    }
+
+    // ─── Script + Pause ──────────────────────────────────────────────
+
+    /**
+     * Evaluate a JavaScript expression in the page context and return the
+     * result. Useful for assertions on computed state or reaching into
+     * page.document.activeElement etc.
+     *
+     *     client.script("() => document.title")
+     *     client.script("() => 2 + 2")  // returns 4
+     */
+    public any function script(required string js) {
+        return variables.page.evaluate(arguments.js);
+    }
+
+    /**
+     * Pauses execution for `milliseconds` ms. For debugging real failures
+     * (when you want to hand-inspect browser state) — NOT for synchronizing
+     * with the page. Use waitFor/waitForText instead for synchronization;
+     * sleeps are flaky and slow.
+     *
+     * Prints a warning on use so a stray pause doesn't sneak past review.
+     * Silenceable via BROWSER_TEST_PAUSE_WARNING=off.
+     */
+    public BrowserClient function pause(required numeric milliseconds) {
+        var envOff = false;
+        try {
+            envOff = (createObject("java", "java.lang.System")
+                .getenv("BROWSER_TEST_PAUSE_WARNING") ?: "on") == "off";
+        } catch (any e) {}
+        if (!envOff) {
+            writeOutput("⚠ BrowserClient.pause() called for " & arguments.milliseconds
+                & "ms. Remove before committing or set BROWSER_TEST_PAUSE_WARNING=off." & chr(10));
+        }
+        sleep(arguments.milliseconds);
+        return this;
+    }
+
     // ─── Scoping ─────────────────────────────────────────────────────
 
     /**

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -267,10 +267,25 @@ component {
         try {
             envOff = (createObject("java", "java.lang.System")
                 .getenv("BROWSER_TEST_PAUSE_WARNING") ?: "on") == "off";
-        } catch (any e) {}
+        } catch (any e) {
+            // Best-effort: SecurityManager could deny env access. If the read
+            // fails we err on the side of warning the user (envOff stays false).
+        }
         if (!envOff) {
-            writeOutput("⚠ BrowserClient.pause() called for " & arguments.milliseconds
-                & "ms. Remove before committing or set BROWSER_TEST_PAUSE_WARNING=off." & chr(10));
+            // Use System.err rather than writeOutput because TestBox's JSON
+            // reporter (the primary CI/LuCLI runner format) discards
+            // writeOutput. System.err shows up in the server console
+            // regardless of reporter — visibility is the whole point of the
+            // warning, so prefer the channel that won't be silenced.
+            try {
+                createObject("java", "java.lang.System").err.println(
+                    "[WARN] BrowserClient.pause() called for " & arguments.milliseconds
+                    & "ms. Remove before committing or set BROWSER_TEST_PAUSE_WARNING=off."
+                );
+            } catch (any e) {
+                // Best-effort: if even System.err is unreachable, silently
+                // proceed to the sleep. Nothing else useful to do.
+            }
         }
         sleep(arguments.milliseconds);
         return this;

--- a/vendor/wheels/wheelstest/BrowserLauncher.cfc
+++ b/vendor/wheels/wheelstest/BrowserLauncher.cfc
@@ -58,7 +58,14 @@ component {
      * Default entry point — reads env var + home dir from the runtime.
      */
     public string function resolveInstallDir() {
-        var envVar = server.system.environment["WHEELS_BROWSER_HOME"] ?: "";
+        var envVar = "";
+        if (
+            StructKeyExists(server, "system")
+            && StructKeyExists(server.system, "environment")
+            && StructKeyExists(server.system.environment, "WHEELS_BROWSER_HOME")
+        ) {
+            envVar = server.system.environment["WHEELS_BROWSER_HOME"];
+        }
         return $resolveInstallDir(envVar=envVar, homeDir=getUserHome());
     }
 

--- a/vendor/wheels/wheelstest/BrowserLauncher.cfc
+++ b/vendor/wheels/wheelstest/BrowserLauncher.cfc
@@ -216,6 +216,7 @@ component {
         // Playwright's DriverJar uses TCCL to find bundled driver resources, and
         // default TCCL (AppClassLoader) doesn't have driver-bundle.jar.
         var previousTCCL = $pushTCCL();
+        var browser = "";
         try {
             if (!isObject(variables.$playwright)) {
                 // Playwright.create() via reflection: Lucee's varargs bridge can't
@@ -230,10 +231,36 @@ component {
             // LaunchOptions via reflection through URLClassLoader is fragile;
             // zero-arg launch() defaults to headless=true, which is what we want.
             var launchMethod = $findZeroArgMethod(klass=browserType.getClass(), name="launch");
-            var browser = launchMethod.invoke(browserType, javaCast("Object[]", []));
-        } finally {
+            browser = launchMethod.invoke(browserType, javaCast("Object[]", []));
+        } catch (any e) {
             $popTCCL(previousLoader=previousTCCL);
+            // Re-throw errors that are already Wheels-typed (e.g.,
+            // BrowserEngineInvalid from $getBrowserType, ReflectionError
+            // from $findZeroArgMethod). Only wrap unknown/Java errors.
+            if (findNoCase("Wheels.", e.type ?: "")) {
+                rethrow;
+            }
+            // Most likely cause: Chromium binary missing/corrupt under
+            // ~/Library/Caches/ms-playwright/. The reflection layer surfaces
+            // this as InvocationTargetException wrapping a PlaywrightException;
+            // strip the wrapper so callers see something actionable.
+            var rootCause = e.message;
+            try {
+                if (structKeyExists(e, "cause") && isObject(e.cause)) {
+                    rootCause = e.cause.getMessage();
+                }
+            } catch (any inner) {
+                // best-effort: if cause unwrapping itself fails, fall back to
+                // e.message above. Don't mask the original error.
+            }
+            throw(
+                type="Wheels.BrowserLaunchFailed",
+                message="Failed to launch " & arguments.engine & ": " & rootCause
+                    & ". If Playwright is not installed, run: bash tools/install-playwright.sh",
+                detail=e.detail ?: ""
+            );
         }
+        $popTCCL(previousLoader=previousTCCL);
 
         variables.$browsers[arguments.engine] = browser;
         return browser;
@@ -243,8 +270,12 @@ component {
      * Finds the zero-argument method with the given name on the given class.
      * Workaround for Lucee's Java-varargs bridge which can't reliably express
      * an empty `Class<?>[]` to `Class.getMethod(String, Class<?>...)`.
+     *
+     * Public (with $ prefix indicating "internal but accessible") so callers
+     * needing reflection access through our URLClassLoader — and tests of
+     * the reflection error path — can use it directly.
      */
-    private any function $findZeroArgMethod(required any klass, required string name) {
+    public any function $findZeroArgMethod(required any klass, required string name) {
         var methods = arguments.klass.getMethods();
         for (var i = 1; i <= arrayLen(methods); i++) {
             if (methods[i].getName() == arguments.name && arrayLen(methods[i].getParameterTypes()) == 0) {
@@ -275,15 +306,19 @@ component {
     }
 
     /**
-     * Closes all acquired browsers and the Playwright instance. Call once per
-     * test run (not per spec CFC).
+     * Closes all acquired browsers, the Playwright instance, and the
+     * URLClassLoader (which holds native file handles on the seven JARs).
+     * Call once per test run, not per spec CFC.
      */
     public void function release() {
         for (var engine in variables.$browsers) {
             try {
                 variables.$browsers[engine].close();
             } catch (any e) {
-                // best-effort cleanup
+                // Best-effort: browser close can fail if the node-driver
+                // process already exited (timeout, crash). Safe to swallow —
+                // the JVM exit will reap any orphaned handles. Other browsers
+                // in this loop should still get a chance to close.
             }
         }
         variables.$browsers = {};
@@ -292,8 +327,25 @@ component {
             try {
                 variables.$playwright.close();
             } catch (any e) {
+                // Best-effort: same rationale as the per-browser close above.
+                // Continuing on to URLClassLoader release.
             }
             variables.$playwright = "";
+        }
+
+        // Close the URLClassLoader so its native file handles on the seven
+        // pinned JARs are released. Important on Windows (would prevent JAR
+        // replacement) and prevents FD exhaustion if release() + new launcher
+        // cycles happen in a long-running process.
+        if (structKeyExists(variables, "$classLoader")) {
+            try {
+                variables.$classLoader.close();
+            } catch (any e) {
+                // Best-effort: close can fail if the loader is already closed
+                // (idempotent release()) or if a child class is mid-use. JVM
+                // exit cleans up regardless.
+            }
+            structDelete(variables, "$classLoader");
         }
 
         variables.$state = "shut-down";

--- a/vendor/wheels/wheelstest/BrowserLauncher.cfc
+++ b/vendor/wheels/wheelstest/BrowserLauncher.cfc
@@ -23,6 +23,32 @@ component {
     }
 
     /**
+     * Accessor for the loaded manifest. Preferred over poking `variables.$manifest`
+     * from tests/callers since the variables scope isn't externally accessible.
+     */
+    public struct function getManifest() {
+        return variables.$manifest;
+    }
+
+    /**
+     * Accessor for the URLClassLoader that hosts the Playwright JARs after
+     * $loadJars(). Null until $loadJars() runs. Exposed primarily for tests.
+     */
+    public any function getClassLoader() {
+        if (!structKeyExists(variables, "$classLoader")) {
+            return javaCast("null", "");
+        }
+        return variables.$classLoader;
+    }
+
+    /**
+     * Accessor for the current lifecycle state: "uninitialized" | "ready" | "shut-down".
+     */
+    public string function getState() {
+        return variables.$state;
+    }
+
+    /**
      * Reads vendor/wheels/browser-manifest.json.
      */
     public struct function $loadManifest() {
@@ -92,5 +118,152 @@ component {
      */
     public string function getUserHome() {
         return createObject("java", "java.lang.System").getProperty("user.home");
+    }
+
+    /**
+     * Returns an array of filesystem paths — one per entry in the manifest's
+     * `classpath` array. Used to build the Playwright runtime classpath
+     * (client + driver + driver-bundle + transitive deps = 7 JARs).
+     */
+    public array function $classpathJarPaths(required string installDir) {
+        var paths = [];
+        for (var entry in variables.$manifest.classpath) {
+            arrayAppend(paths, arguments.installDir & "/lib/" & entry.filename);
+        }
+        return paths;
+    }
+
+    /**
+     * Dynamically loads the Playwright runtime JARs into a URLClassLoader so
+     * classloader lookups (`loadClass(...)`) can resolve Playwright classes.
+     * The servlet's default classpath doesn't include them.
+     *
+     * Takes an array because Playwright needs seven JARs on the classpath to
+     * boot (client + driver + driver-bundle + gson + Java-WebSocket + slf4j).
+     * Lucee-specific; Adobe CF support deferred.
+     *
+     * Must be called before any acquireBrowser() call. Idempotent: subsequent
+     * calls after the first are no-ops.
+     */
+    public void function $loadJars(required array jarPaths) {
+        if (variables.$state != "uninitialized") {
+            return;
+        }
+
+        var urls = [];
+        for (var jarPath in arguments.jarPaths) {
+            var jarFile = createObject("java", "java.io.File").init(jarPath);
+            arrayAppend(urls, jarFile.toURI().toURL());
+        }
+
+        var parentLoader = createObject("java", "java.lang.Thread")
+            .currentThread()
+            .getContextClassLoader();
+        var classLoader = createObject("java", "java.net.URLClassLoader")
+            .init(urls, parentLoader);
+
+        variables.$classLoader = classLoader;
+        variables.$state = "ready";
+    }
+
+    /**
+     * Returns the Browser for the given engine, creating and caching it on first call.
+     *
+     * @engine One of: chromium, firefox, webkit
+     */
+    public any function acquireBrowser(string engine = "chromium") {
+        if (variables.$state != "ready") {
+            throw(
+                type="Wheels.BrowserLauncherNotReady",
+                message="Call $loadJars() first. State: " & variables.$state
+            );
+        }
+
+        if (structKeyExists(variables.$browsers, arguments.engine)) {
+            return variables.$browsers[arguments.engine];
+        }
+
+        if (!isObject(variables.$playwright)) {
+            // Resolve Playwright classes through our URLClassLoader (the servlet's
+            // default classpath doesn't include these JARs). We call Playwright.create()
+            // via reflection to avoid Lucee's createObject("java", ...) path, which
+            // would try to resolve the URLClassLoader as an OSGi bundle.
+            //
+            // Lucee's CFML-to-Java bridge mishandles getMethod's Class<?>... varargs
+            // with no args, so locate the zero-arg create() method by iterating
+            // getDeclaredMethods().
+            var playwrightClass = variables.$classLoader.loadClass("com.microsoft.playwright.Playwright");
+            var createMethod = $findZeroArgMethod(klass=playwrightClass, name="create");
+            variables.$playwright = createMethod.invoke(javaCast("null", ""), javaCast("Object[]", []));
+        }
+
+        var browserType = $getBrowserType(engine=arguments.engine);
+        var launchOptionsClass = variables.$classLoader.loadClass("com.microsoft.playwright.BrowserType$LaunchOptions");
+        var launchOptions = launchOptionsClass.getDeclaredConstructor().newInstance();
+        launchOptions.setHeadless(javaCast("boolean", true));
+
+        var browser = browserType.launch(launchOptions);
+        variables.$browsers[arguments.engine] = browser;
+        return browser;
+    }
+
+    /**
+     * Finds the zero-argument method with the given name on the given class.
+     * Workaround for Lucee's Java-varargs bridge which can't reliably express
+     * an empty `Class<?>[]` to `Class.getMethod(String, Class<?>...)`.
+     */
+    private any function $findZeroArgMethod(required any klass, required string name) {
+        var methods = arguments.klass.getMethods();
+        for (var i = 1; i <= arrayLen(methods); i++) {
+            if (methods[i].getName() == arguments.name && arrayLen(methods[i].getParameterTypes()) == 0) {
+                return methods[i];
+            }
+        }
+        throw(
+            type="Wheels.BrowserLauncherReflectionError",
+            message="No zero-arg method named '" & arguments.name & "' on class " & arguments.klass.getName()
+        );
+    }
+
+    private any function $getBrowserType(required string engine) {
+        switch (arguments.engine) {
+            case "chromium":
+                return variables.$playwright.chromium();
+            case "firefox":
+                return variables.$playwright.firefox();
+            case "webkit":
+                return variables.$playwright.webkit();
+            default:
+                throw(
+                    type="Wheels.BrowserEngineInvalid",
+                    message="Unknown engine: " & arguments.engine
+                        & ". Valid: chromium, firefox, webkit."
+                );
+        }
+    }
+
+    /**
+     * Closes all acquired browsers and the Playwright instance. Call once per
+     * test run (not per spec CFC).
+     */
+    public void function release() {
+        for (var engine in variables.$browsers) {
+            try {
+                variables.$browsers[engine].close();
+            } catch (any e) {
+                // best-effort cleanup
+            }
+        }
+        variables.$browsers = {};
+
+        if (isObject(variables.$playwright)) {
+            try {
+                variables.$playwright.close();
+            } catch (any e) {
+            }
+            variables.$playwright = "";
+        }
+
+        variables.$state = "shut-down";
     }
 }

--- a/vendor/wheels/wheelstest/BrowserLauncher.cfc
+++ b/vendor/wheels/wheelstest/BrowserLauncher.cfc
@@ -156,14 +156,43 @@ component {
             arrayAppend(urls, jarFile.toURI().toURL());
         }
 
-        var parentLoader = createObject("java", "java.lang.Thread")
-            .currentThread()
-            .getContextClassLoader();
+        // PARENT = PlatformClassLoader (not SystemClassLoader / TCCL).
+        // If AppClassLoader is the parent, URLClassLoader fails to resolve
+        // cross-JAR superclass references (e.g. driver-bundle's DriverJar extends
+        // driver.jar's Driver) with a NoClassDefFoundError at defineClass time.
+        // PlatformClassLoader only exposes the JDK stdlib, so our JARs form a
+        // clean self-contained layer.
+        var parentLoader = createObject("java", "java.lang.ClassLoader")
+            .getPlatformClassLoader();
         var classLoader = createObject("java", "java.net.URLClassLoader")
             .init(urls, parentLoader);
 
         variables.$classLoader = classLoader;
         variables.$state = "ready";
+    }
+
+    /**
+     * Swap the current thread's context classloader to our URLClassLoader,
+     * returning the previous one. Callers MUST restore via $restoreTCCL in a
+     * finally block so we don't leak our classloader to unrelated threads.
+     *
+     * Playwright uses `Thread.currentThread().getContextClassLoader()` inside
+     * `DriverJar.getDriverResourceURI()` to locate `driver/<platform>/` resources
+     * in the driver-bundle JAR. Default TCCL is the AppClassLoader — which
+     * doesn't have our JARs — so the lookup returns null and Playwright's init
+     * fails with an NPE. Swap TCCL for the duration of any call that reaches
+     * into Playwright's runtime code.
+     */
+    private any function $pushTCCL() {
+        var thread = createObject("java", "java.lang.Thread").currentThread();
+        var previous = thread.getContextClassLoader();
+        thread.setContextClassLoader(variables.$classLoader);
+        return previous;
+    }
+
+    private void function $popTCCL(required any previousLoader) {
+        createObject("java", "java.lang.Thread").currentThread()
+            .setContextClassLoader(arguments.previousLoader);
     }
 
     /**
@@ -183,26 +212,29 @@ component {
             return variables.$browsers[arguments.engine];
         }
 
-        if (!isObject(variables.$playwright)) {
-            // Resolve Playwright classes through our URLClassLoader (the servlet's
-            // default classpath doesn't include these JARs). We call Playwright.create()
-            // via reflection to avoid Lucee's createObject("java", ...) path, which
-            // would try to resolve the URLClassLoader as an OSGi bundle.
-            //
-            // Lucee's CFML-to-Java bridge mishandles getMethod's Class<?>... varargs
-            // with no args, so locate the zero-arg create() method by iterating
-            // getDeclaredMethods().
-            var playwrightClass = variables.$classLoader.loadClass("com.microsoft.playwright.Playwright");
-            var createMethod = $findZeroArgMethod(klass=playwrightClass, name="create");
-            variables.$playwright = createMethod.invoke(javaCast("null", ""), javaCast("Object[]", []));
+        // Swap TCCL to our URLClassLoader for the duration of Playwright calls —
+        // Playwright's DriverJar uses TCCL to find bundled driver resources, and
+        // default TCCL (AppClassLoader) doesn't have driver-bundle.jar.
+        var previousTCCL = $pushTCCL();
+        try {
+            if (!isObject(variables.$playwright)) {
+                // Playwright.create() via reflection: Lucee's varargs bridge can't
+                // pass an empty Class<?>[] to getMethod(String, Class<?>...) cleanly,
+                // so locate the zero-arg overload by iterating getMethods().
+                var playwrightClass = variables.$classLoader.loadClass("com.microsoft.playwright.Playwright");
+                var createMethod = $findZeroArgMethod(klass=playwrightClass, name="create");
+                variables.$playwright = createMethod.invoke(javaCast("null", ""), javaCast("Object[]", []));
+            }
+
+            var browserType = $getBrowserType(engine=arguments.engine);
+            // LaunchOptions via reflection through URLClassLoader is fragile;
+            // zero-arg launch() defaults to headless=true, which is what we want.
+            var launchMethod = $findZeroArgMethod(klass=browserType.getClass(), name="launch");
+            var browser = launchMethod.invoke(browserType, javaCast("Object[]", []));
+        } finally {
+            $popTCCL(previousLoader=previousTCCL);
         }
 
-        var browserType = $getBrowserType(engine=arguments.engine);
-        var launchOptionsClass = variables.$classLoader.loadClass("com.microsoft.playwright.BrowserType$LaunchOptions");
-        var launchOptions = launchOptionsClass.getDeclaredConstructor().newInstance();
-        launchOptions.setHeadless(javaCast("boolean", true));
-
-        var browser = browserType.launch(launchOptions);
         variables.$browsers[arguments.engine] = browser;
         return browser;
     }

--- a/vendor/wheels/wheelstest/BrowserLauncher.cfc
+++ b/vendor/wheels/wheelstest/BrowserLauncher.cfc
@@ -1,0 +1,89 @@
+/**
+ * Process-level singleton that owns the Playwright instance + Browser
+ * for browser-driven tests. Not instantiated per-spec; the BrowserTest
+ * base class uses the application-scoped instance.
+ *
+ * Responsibilities (split by stage):
+ *   1. JAR path resolution (this task)
+ *   2. Playwright lazy init + Browser acquisition (next task)
+ *   3. Release/shutdown
+ *
+ * Not responsible for: DSL, lifecycle hooks, artifact dumping.
+ */
+component {
+
+    variables.$manifest = "";
+    variables.$playwright = "";        // Java Playwright instance (lazy)
+    variables.$browsers = {};           // cache: engine => Java Browser instance
+    variables.$state = "uninitialized"; // uninitialized | ready | shut-down
+
+    public BrowserLauncher function init() {
+        variables.$manifest = $loadManifest();
+        return this;
+    }
+
+    /**
+     * Reads vendor/wheels/browser-manifest.json.
+     */
+    public struct function $loadManifest() {
+        var manifestPath = expandPath("/wheels/browser-manifest.json");
+        if (!fileExists(manifestPath)) {
+            throw(
+                type="Wheels.BrowserManifestMissing",
+                message="Expected vendor/wheels/browser-manifest.json to exist."
+            );
+        }
+        return deserializeJSON(fileRead(manifestPath));
+    }
+
+    /**
+     * Resolves the install directory based on env var or home dir fallback.
+     * Pure function — passed-in args make it unit-testable.
+     */
+    public string function $resolveInstallDir(
+        required string envVar,
+        required string homeDir
+    ) {
+        if (len(trim(arguments.envVar)) > 0) {
+            return arguments.envVar;
+        }
+        var home = arguments.homeDir;
+        if (right(home, 1) == "/") {
+            home = left(home, len(home) - 1);
+        }
+        return home & "/.wheels/browser";
+    }
+
+    /**
+     * Default entry point — reads env var + home dir from the runtime.
+     */
+    public string function resolveInstallDir() {
+        var envVar = server.system.environment["WHEELS_BROWSER_HOME"] ?: "";
+        return $resolveInstallDir(envVar=envVar, homeDir=getUserHome());
+    }
+
+    public string function $jarPath(
+        required string installDir,
+        required string version
+    ) {
+        return arguments.installDir & "/lib/playwright-" & arguments.version & ".jar";
+    }
+
+    public boolean function $verifyInstall(required string jarPath) {
+        if (!fileExists(arguments.jarPath)) {
+            throw(
+                type="Wheels.BrowserNotInstalled",
+                message="Playwright JAR not found at " & arguments.jarPath
+                    & ". Run `wheels browser:install` to set up browser testing."
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Returns the path to the user's home directory. Override-friendly for tests.
+     */
+    public string function getUserHome() {
+        return createObject("java", "java.lang.System").getProperty("user.home");
+    }
+}

--- a/vendor/wheels/wheelstest/BrowserTest.cfc
+++ b/vendor/wheels/wheelstest/BrowserTest.cfc
@@ -1,0 +1,176 @@
+/**
+ * TestBox base class for browser-driven specs. Wraps BrowserLauncher
+ * lifecycle so individual specs can focus on describe/it blocks:
+ *
+ *     component extends="wheels.wheelstest.BrowserTest" {
+ *         this.browserEngine = "chromium";  // optional (default chromium)
+ *
+ *         function run() {
+ *             describe("signup flow", () => {
+ *                 it("lands on the form", () => {
+ *                     this.browser.visitUrl("data:text/html,<h1>Hi</h1>")
+ *                                 .assertSee("Hi");
+ *                 });
+ *             });
+ *         }
+ *     }
+ *
+ * Lifecycle:
+ *   - beforeAll:  ensure an application-scoped BrowserLauncher is initialized,
+ *                 acquire the shared Browser handle for the requested engine
+ *   - beforeEach: fresh BrowserContext + Page, wrapped in a new BrowserClient,
+ *                 exposed as `this.browser`
+ *   - afterEach:  close the context (cookies, localStorage, etc. reset)
+ *   - afterAll:   drop our handle to the Browser — process-scoped Launcher
+ *                 keeps it alive for the next spec in the run
+ *
+ * Specs that use this base can assume this.browser is populated and
+ * well-isolated without managing Playwright plumbing themselves.
+ *
+ * Deferred (per the browser testing foundation PR scope):
+ *   - viewport / keepSignedInAs / storageState replay — require building
+ *     Playwright option objects (Browser$NewContextOptions, ViewportSize)
+ *     through the URLClassLoader, which hits Lucee's OSGi bundle resolver.
+ *     Resolving that is a reflection-helper pass planned for a follow-up.
+ *     Specs needing these can drop down to the raw Playwright objects via
+ *     getBrowserLauncher() / this.browser.getContext() / getPage().
+ */
+component extends="wheels.WheelsTest" {
+
+    this.browserEngine = "chromium";
+    this.browser = "";
+    this.browserTestSkipped = false;
+
+    variables.$launcher = "";
+    variables.$browser = "";
+    variables.$context = "";
+    variables.$page = "";
+    variables.$baseUrl = "";
+
+    function beforeAll() {
+        try {
+            variables.$launcher = $ensureLauncher();
+        } catch (Wheels.BrowserNotInstalled e) {
+            this.browserTestSkipped = true;
+            return;
+        }
+        variables.$browser = variables.$launcher.acquireBrowser(engine=this.browserEngine);
+        variables.$baseUrl = $resolveBaseUrl();
+    }
+
+    function afterAll() {
+        // Launcher + Browser are process-scoped; the application-scoped
+        // launcher is released when the Lucee app scope clears. We just
+        // drop our local handle.
+        variables.$browser = "";
+    }
+
+    /**
+     * Wraps TestBox's describe() with beforeEach/afterEach closures that
+     * set up and tear down a fresh BrowserContext + Page per `it` block.
+     * TestBox BDD only treats `beforeAll`/`afterAll` as class-level hooks;
+     * beforeEach/afterEach must be registered from INSIDE a describe body.
+     *
+     *     function run() {
+     *         browserDescribe("my feature", () => {
+     *             it("does the thing", () => {
+     *                 this.browser.visit("/").assertSee("...");
+     *             });
+     *         });
+     *     }
+     *
+     * Specs can mix plain describe() (no browser wiring) with
+     * browserDescribe() (browser wiring) freely in the same run().
+     */
+    public void function browserDescribe(
+        required string title,
+        required any body
+    ) {
+        // Capture this + body so the inline closures can reach them.
+        // (CFML `arguments` is per-function; inline closures can't see outer
+        // function's arguments scope directly.)
+        var me = this;
+        var innerBody = arguments.body;
+
+        describe(arguments.title, function() {
+            beforeEach(function() { me.$startBrowserContext(); });
+            afterEach(function() { me.$endBrowserContext(); });
+            innerBody();
+        });
+    }
+
+    /**
+     * Exposed for custom lifecycle patterns — callers who want to write
+     * `describe(..., () => { beforeEach(() => { $startBrowserContext(); }); ...})`
+     * manually instead of using browserDescribe().
+     */
+    public void function $startBrowserContext() {
+        if (this.browserTestSkipped) return;
+        variables.$context = variables.$browser.newContext();
+        variables.$page = variables.$context.newPage();
+        this.browser = new wheels.wheelstest.BrowserClient()
+            .init(
+                page=variables.$page,
+                context=variables.$context,
+                baseUrl=variables.$baseUrl
+            );
+    }
+
+    public void function $endBrowserContext() {
+        if (this.browserTestSkipped) return;
+        if (isObject(variables.$context)) {
+            try { variables.$context.close(); } catch (any e) {}
+            variables.$context = "";
+            variables.$page = "";
+            this.browser = "";
+        }
+    }
+
+    /** Accessor for specs that need to reach Playwright directly. */
+    public any function getBrowserLauncher() {
+        return variables.$launcher;
+    }
+
+    /**
+     * Lazily initialize a process-wide BrowserLauncher in application scope.
+     * A single Playwright instance + Browser handle serves all BrowserTest
+     * subclasses in the run — avoids paying ~1.7s per spec-file startup.
+     *
+     * Throws Wheels.BrowserNotInstalled if any classpath JAR is missing —
+     * callers catch this and skip browser tests gracefully.
+     */
+    private any function $ensureLauncher() {
+        if (!structKeyExists(application, "$wheelsBrowserLauncher")) {
+            var l = new wheels.wheelstest.BrowserLauncher();
+            var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+            for (var p in paths) {
+                if (!fileExists(p)) {
+                    throw(
+                        type="Wheels.BrowserNotInstalled",
+                        message="Playwright JAR missing: " & p
+                            & ". Run tools/install-playwright.sh to set up browser testing."
+                    );
+                }
+            }
+            l.$loadJars(jarPaths=paths);
+            application.$wheelsBrowserLauncher = l;
+        }
+        return application.$wheelsBrowserLauncher;
+    }
+
+    /**
+     * Base URL for `client.visit("/path")`. Defaults to localhost:8080
+     * (the default LuCLI port); override via WHEELS_BROWSER_TEST_BASE_URL env.
+     * For specs that use only `visitUrl(absolute)` (e.g. data:/file:), the
+     * baseUrl is effectively unused.
+     */
+    private string function $resolveBaseUrl() {
+        try {
+            var env = createObject("java", "java.lang.System")
+                .getenv("WHEELS_BROWSER_TEST_BASE_URL");
+            if (!isNull(env) && len(env)) return env;
+        } catch (any e) {}
+        return "http://localhost:8080";
+    }
+
+}

--- a/vendor/wheels/wheelstest/BrowserTest.cfc
+++ b/vendor/wheels/wheelstest/BrowserTest.cfc
@@ -119,7 +119,15 @@ component extends="wheels.WheelsTest" {
     public void function $endBrowserContext() {
         if (this.browserTestSkipped) return;
         if (isObject(variables.$context)) {
-            try { variables.$context.close(); } catch (any e) {}
+            try {
+                variables.$context.close();
+            } catch (any e) {
+                // Best-effort: context.close() can fail if the page crashed
+                // (bad data: URL, JS unhandled error). Test assertions ran
+                // before this, so swallowing here doesn't hide test results.
+                // Continuing to clear refs prevents leaked Page/Context
+                // references between `it` blocks.
+            }
             variables.$context = "";
             variables.$page = "";
             this.browser = "";
@@ -138,9 +146,22 @@ component extends="wheels.WheelsTest" {
      *
      * Throws Wheels.BrowserNotInstalled if any classpath JAR is missing —
      * callers catch this and skip browser tests gracefully.
+     *
+     * Wrapped in cflock to guard the check-then-act on application scope
+     * against parallel beforeAll invocations (relevant if ParallelRunner or
+     * multi-bundle parallelism is ever used; sequential TestBox makes this
+     * a no-op today).
      */
     private any function $ensureLauncher() {
-        if (!structKeyExists(application, "$wheelsBrowserLauncher")) {
+        if (structKeyExists(application, "$wheelsBrowserLauncher")) {
+            return application.$wheelsBrowserLauncher;
+        }
+        lock name="wheelsBrowserLauncherInit" type="exclusive" timeout="60" {
+            // Re-check inside the lock — another thread may have initialized
+            // while we were waiting.
+            if (structKeyExists(application, "$wheelsBrowserLauncher")) {
+                return application.$wheelsBrowserLauncher;
+            }
             var l = new wheels.wheelstest.BrowserLauncher();
             var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
             for (var p in paths) {
@@ -169,7 +190,13 @@ component extends="wheels.WheelsTest" {
             var env = createObject("java", "java.lang.System")
                 .getenv("WHEELS_BROWSER_TEST_BASE_URL");
             if (!isNull(env) && len(env)) return env;
-        } catch (any e) {}
+        } catch (any e) {
+            // Best-effort: SecurityManager could deny env access. Falling
+            // back to the localhost default is correct — if the user actually
+            // configured a different URL but we can't read it, their tests
+            // will fail with connection-refused, surfacing the problem
+            // clearly rather than silently using the wrong URL.
+        }
         return "http://localhost:8080";
     }
 


### PR DESCRIPTION
## Summary

PR 1 of 4 on the v4.0 browser testing rollout. Lands the foundation layer for native browser testing in Wheels — fluent DSL wrapping Playwright Java, TestBox BDD base class, manifest-pinned install bootstrap.

Implementation plan: `docs/superpowers/plans/2026-04-15-browser-testing-foundation.md`

**Status: WIP — ready for review.** Core DSL + lifecycle working end-to-end against real Chromium.

## What landed

### Foundation (Tasks 1-5)
- **`vendor/wheels/browser-manifest.json`** — schemaVersion 2, `classpath[]` array pins all seven Playwright runtime JARs with SHA256 (client + driver + driver-bundle + gson + Java-WebSocket + slf4j-api + slf4j-simple)
- **`tools/install-playwright.sh`** — idempotent bootstrap; downloads JARs, SHA-verifies, installs Chromium (replaced by `wheels browser:install` in PR 2)
- **`vendor/wheels/wheelstest/BrowserLauncher.cfc`** — process-level Playwright owner with URLClassLoader + PlatformClassLoader parent (critical for cross-JAR resolution) + TCCL swap during calls (critical for driver bundle resource lookup) + per-engine Browser cache + state machine
- **`vendor/wheels/tests/fixtures/browserapp/`** — minimal Wheels app (7 files) for future E2E tests

### BrowserClient DSL (Tasks 6-9, 12-14)
~40 chainable methods spanning navigation, interaction, keyboard, waiting, scoping, viewport, script evaluation, and assertions. Integration tests cover each method against real Chromium — 43 specs, all passing.

### BrowserTest base (Task 15)
- `browserDescribe(title, body)` wraps `describe()` with per-`it` beforeEach/afterEach that set up a fresh `BrowserContext` — works around TestBox BDD's lack of class-level `beforeEach`
- Application-scoped launcher singleton: Chromium starts once per test-server lifetime (~1.7s), not per spec file
- `this.browserTestSkipped` flag for graceful CI skip when JARs aren't installed

### Docs (Tasks 18-19)
- `CLAUDE.md` — Browser Testing Quick Reference (between SSE and Reference Docs)
- `.ai/wheels/testing/browser-testing.md` — full guide with architecture, DSL catalog, five gotchas, deferred-functionality table, and PR roadmap

## Deferred to follow-ups

The plan scoped 19 tasks; this PR ships the foundation + ~40 of ~55 DSL methods. Most deferred items share one root blocker: **Playwright's Java API uses inner classes** (`Page$GetByRoleOptions`, `Locator$WaitForOptions`, `Browser$NewContextOptions`, `options.Cookie`, etc.) that Lucee's `createObject("java", ...)` can't construct when those classes are loaded through a URLClassLoader — Lucee's class resolver tries to treat the loader as an OSGi bundle and fails. A single `$buildOption(className, ...)` reflection helper (planned for a follow-up) unblocks most of them in one shot.

| Category | What's missing | Blocker |
|---|---|---|
| Auth | `loginAs(identifier)`, `logout()`, `keepSignedInAs` | Test-only route + fixture server |
| Cookies | `setCookie`, `deleteCookie`, `cookie` | Cookie option object |
| Dialogs | `acceptDialog`, `dismissDialog`, `typeInDialog` | `createDynamicProxy` → `Consumer<Dialog>` |
| Timeouts | Configurable `waitFor` timeout | `Locator$WaitForOptions` |
| Routes | `visitRoute`, `assertRouteIs` | Wheels `urlFor()` outside controller context |
| URL waiting | `waitForUrl` | `Page$WaitForURLOptions` + baseUrl wiring |
| Viewport config | `this.browserViewport` on `BrowserTest` | `ViewportSize` + `Browser$NewContextOptions` |
| Screenshot options | `clip`, `fullPage`, `quality` | `Page$ScreenshotOptions` |
| Auto-artifact dump | screenshot + HTML on failure | TestBox `aroundEach` |

## Key debug wins worth preserving

1. **PlatformClassLoader as URLClassLoader parent** (not SystemClassLoader) — AppClassLoader-as-parent breaks cross-JAR superclass resolution at `defineClass` time. The fix unblocked all classloader-dependent work.
2. **TCCL swap during Playwright calls** — Playwright's `DriverJar.getDriverResourceURI()` uses `Thread.currentThread().getContextClassLoader()` to locate bundled Node runtime. Default TCCL is AppClassLoader, which doesn't see our JARs → NPE (which Lucee was silently eating, making it look like a hang). Fix: swap to our URLClassLoader for the duration of any call reaching Playwright internals.
3. **`client` is a Lucee-reserved scope.** `var client = ...` inside a closure throws "client scope is not enabled". Cost me one spec-debug cycle; now documented in CLAUDE.md gotchas.

## Test plan

- [x] `bash tools/install-playwright.sh` → downloads all 7 JARs + installs Chromium, idempotent on re-run (verified locally)
- [x] `bash tools/test-local.sh` → **3008 pass, 0 fail** (Lucee 7 + SQLite). Baseline was 2960; 48 new browser tests added across Tasks 2-15.
- [x] BrowserLauncher integration tests: all pass (real Chromium launch)
- [x] BrowserClient integration tests: 43 specs, all pass (real Chromium)
- [x] BrowserTest lifecycle tests: 5 specs, all pass
- [x] No regressions in non-browser tests
- [x] Tests skip gracefully on CI (JARs not installed) without emitting failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)