### PR TITLE
feat(test): browser testing CLI + deferred DSL methods (PR 2 of 4)

### DIFF
--- a/.ai/wheels/testing/browser-testing.md
+++ b/.ai/wheels/testing/browser-testing.md
@@ -8,19 +8,28 @@ This PR lands the plumbing. CLI, dogfood specs, and CI matrix integration come i
 
 **What works:** navigation, interaction, keyboard, waiting (default timeout), scoping, viewport, script evaluation, most assertions, most terminals, lifecycle via `browserDescribe`.
 
-**What's deferred:** `loginAs`/`logout` (needs test-only route + fixture server), dialogs, cookies, configurable timeouts, auto-screenshot-on-failure, viewport at `BrowserTest` level. All share one root blocker: Playwright's Java API uses inner classes (`Page$GetByRoleOptions`, `Locator$WaitForOptions`, `Browser$NewContextOptions`, `Cookie`, …) that Lucee's `createObject("java", ...)` path can't build when those classes live inside a URLClassLoader. A reflection-based helper (planned follow-up) unblocks all of them.
+**What's deferred:** `loginAs`/`logout` (needs test-only route + fixture server), dialogs (needs `createDynamicProxy`), `visitRoute`/`assertRouteIs` (needs `urlFor` outside controller), fixture app integration.
 
 ## Installation
 
-Before first use:
-
 ```bash
-bash tools/install-playwright.sh
+wheels browser:install              # recommended (LuCLI or CommandBox)
+bash tools/install-playwright.sh    # legacy fallback (deprecated)
 ```
 
 Idempotent. Downloads seven JARs totalling ~192 MB (client + driver + driver-bundle + gson + Java-WebSocket + slf4j-api + slf4j-simple) from Maven Central, SHA-verifies each, then runs `playwright install chromium` which drops ~170 MB of Chromium under `~/Library/Caches/ms-playwright/` (macOS) or `~/.cache/ms-playwright/` (Linux). Re-running is a no-op once the SHAs match.
 
-**PR 2 replaces this with `wheels browser:install`.**
+## CLI Commands
+
+```bash
+wheels browser:install              # download JARs + browser binaries
+wheels browser:install --force      # re-download even if SHAs match
+wheels browser:install --browser=firefox
+
+wheels browser:test                 # run browser test suite
+wheels browser:test --verbose       # show full spec names
+wheels browser:test --format=json   # JSON output for CI
+```
 
 ## Architecture
 
@@ -117,10 +126,10 @@ this.browser
 ```cfm
 this.browser
     .waitFor("##late-loaded-element")   // waits up to Playwright's default (30s)
-    .waitForText("Loading complete");
+    .waitFor("##late-element", 5)       // custom timeout in seconds
+    .waitForText("Loading complete")
+    .waitForUrl("**/dashboard", 5);     // glob pattern + timeout
 ```
-
-`waitForUrl` and configurable timeouts are **deferred** (need URLClassLoader-constructed option objects).
 
 ### Scoping
 
@@ -185,6 +194,59 @@ this.browser.value("##email");       // input/textarea/select value
 this.browser.screenshot("/tmp/x.png"); // writes PNG; returns this for chaining
 ```
 
+### Cookies
+
+```cfm
+this.browser
+    .setCookie(name="session", value="abc123", url="http://localhost:8080")
+    .deleteCookie("session");
+
+var c = this.browser.cookie("session");  // returns struct {name, value, domain, ...}
+```
+
+Cookies require a real HTTP origin — `data:` URLs are opaque origins.
+
+### Configurable Timeouts
+
+```cfm
+this.browser
+    .waitFor("##late-element", 5)      // 5-second timeout (default: 30)
+    .waitForText("Loaded", 10)
+    .waitForUrl("**/dashboard", 5);
+```
+
+### Screenshot Options
+
+```cfm
+this.browser.screenshot("/tmp/page.png");                           // basic
+this.browser.screenshot(path="/tmp/full.png", fullPage=true);       // full page
+this.browser.screenshot(path="/tmp/q.png", quality=80);             // JPEG quality
+```
+
+### Viewport Config (BrowserTest Level)
+
+```cfm
+component extends="wheels.wheelstest.BrowserTest" {
+    this.browserViewport = "mobile";           // preset: mobile/tablet/desktop
+    // or: this.browserViewport = {width: 1024, height: 768};
+}
+```
+
+Presets: `"mobile"` (375x667), `"tablet"` (768x1024), `"desktop"` (1440x900).
+
+### Auto-Screenshot on Failure
+
+When a browser test fails, a screenshot and HTML dump are automatically saved to `tests/_output/browser/`. Disable per-spec:
+
+```cfm
+this.browserScreenshotOnFailure = false;
+```
+
+Configure artifact directory:
+```cfm
+this.browserArtifactPath = expandPath("/custom/path");
+```
+
 ## Gotchas (keep these in working memory when writing browser specs)
 
 ### `##` in CFML strings
@@ -222,22 +284,14 @@ Playwright's `DriverJar.getDriverResourceURI()` uses `Thread.currentThread().get
 
 ## Deferred functionality
 
-Tracked as follow-ups to this PR:
+Tracked as follow-ups:
 
 | Category | What's missing | Unblocked by |
 |---|---|---|
 | Auth | `loginAs(identifier)`, `logout()`, `keepSignedInAs` | Test-only route (`POST /_browser/login-as`) + running fixture server |
 | Dialogs | `acceptDialog`, `dismissDialog`, `typeInDialog` | `createDynamicProxy` → `Consumer<Dialog>` via URLClassLoader |
-| Cookies | `setCookie`, `deleteCookie`, `cookie` | Cookie option object |
-| Timeouts | Configurable timeout on `waitFor` / `waitForText` | `Locator$WaitForOptions` |
 | Routes | `visitRoute`, `assertRouteIs` | Wheels `urlFor()` outside controller context |
-| URL waiting | `waitForUrl` | `Page$WaitForURLOptions` + baseUrl wiring |
-| Viewport config | `this.browserViewport = "mobile"` on `BrowserTest` | `ViewportSize` + `Browser$NewContextOptions` |
-| Screenshot options | `clip`, `fullPage`, `quality` | `Page$ScreenshotOptions` |
-| Auto-artifact dump | screenshot + HTML on failure | TestBox `aroundEach` hook + failure detection |
 | Fixture app integration | End-to-end flow through Wheels HTTP pipeline | Dedicated fixture-server bootstrap |
-
-Most share the same root blocker (URLClassLoader + OSGi bundle resolver). A single `$buildOption(className, …)` reflection helper unblocks cookies, dialogs, timeouts, waitForUrl, viewport config, and screenshot options in one shot.
 
 ## PR roadmap
 

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -1429,6 +1429,45 @@ component extends="modules.BaseModule" {
 		return runUpgradeCheck(targetVersion);
 	}
 
+	// ─────────────────────────────────────────────────
+	//  browser — Browser testing management
+	// ─────────────────────────────────────────────────
+
+	/**
+	 * hint: Browser testing commands (install, test)
+	 */
+	public string function browser() {
+		var args = getArgs(arguments);
+
+		if (!arrayLen(args)) {
+			out("Usage: wheels browser <command>", "yellow");
+			out("");
+			out("Commands:", "bold");
+			out("  install  Download Playwright JARs and browser binaries");
+			out("  test     Run browser test suite");
+			out("");
+			out("Examples:", "bold");
+			out("  wheels browser install");
+			out("  wheels browser install --force");
+			out("  wheels browser test");
+			out("  wheels browser test --verbose");
+			return "";
+		}
+
+		var subcommand = lCase(args[1]);
+
+		switch (subcommand) {
+			case "install":
+				return browserInstall(args);
+			case "test":
+				return browserTest(args);
+			default:
+				out("Unknown browser command: #subcommand#", "red");
+				out("Valid commands: install, test");
+				return "";
+		}
+	}
+
 	// ═════════════════════════════════════════════════
 	//  PRIVATE — Implementation details
 	// ═════════════════════════════════════════════════
@@ -3465,6 +3504,259 @@ component extends="modules.BaseModule" {
 		var pos = find("=", arg);
 		if (pos == 0) return "";
 		return mid(arg, pos + 1, len(arg));
+	}
+
+	// ── Browser Testing ─────────────────────────────
+
+	private string function browserInstall(array args = []) {
+		var force = false;
+		var browserName = "chromium";
+
+		for (var i = 2; i <= arrayLen(args); i++) {
+			var arg = args[i];
+			if (arg == "--force") {
+				force = true;
+			} else if (reFindNoCase("^--browser=", arg)) {
+				browserName = valueAfterEquals(arg);
+			}
+		}
+
+		var manifestPath = variables.projectRoot & "/vendor/wheels/browser-manifest.json";
+		if (!fileExists(manifestPath)) {
+			out("browser-manifest.json not found at: #manifestPath#", "red");
+			return "";
+		}
+		var manifest = deserializeJSON(fileRead(manifestPath));
+
+		var installDir = $resolveBrowserInstallDir();
+		out("Install directory: #installDir#");
+		out("Playwright version: #manifest.playwrightJavaVersion ?: 'unknown'#");
+		out("");
+
+		var downloaded = 0;
+		var skipped = 0;
+		for (var entry in manifest.classpath) {
+			var jarPath = installDir & "/lib/" & entry.filename;
+			var needsDownload = force;
+
+			if (!fileExists(jarPath)) {
+				needsDownload = true;
+			} else if (!force) {
+				var currentSha = $sha256(jarPath);
+				if (currentSha != lCase(entry.sha256)) {
+					out("  SHA mismatch: #entry.filename# - re-downloading", "yellow");
+					needsDownload = true;
+				}
+			}
+
+			if (needsDownload) {
+				out("  Downloading #entry.filename#...");
+				try {
+					var parentDir = getDirectoryFromPath(jarPath);
+					if (!directoryExists(parentDir)) {
+						directoryCreate(parentDir, true);
+					}
+					cfhttp(
+						url=entry.url,
+						method="GET",
+						getAsBinary="yes",
+						timeout=300,
+						result="local.httpResponse"
+					);
+					if (!findNoCase("200", local.httpResponse.statusCode)) {
+						out("  FAILED: HTTP #local.httpResponse.statusCode#", "red");
+						return "";
+					}
+					fileWrite(jarPath, local.httpResponse.fileContent);
+					var sha = $sha256(jarPath);
+					if (sha != lCase(entry.sha256)) {
+						out("  FAILED (SHA mismatch)", "red");
+						out("    Expected: #lCase(entry.sha256)#", "red");
+						out("    Got:      #sha#", "red");
+						return "";
+					}
+					out("  OK: #entry.filename#", "green");
+					downloaded++;
+				} catch (any e) {
+					out("  FAILED: #e.message#", "red");
+					return "";
+				}
+			} else {
+				out("  #entry.filename#", "green");
+				skipped++;
+			}
+		}
+
+		out("");
+		out("JARs: #downloaded# downloaded, #skipped# up-to-date");
+		out("");
+		out("Installing #browserName# browser binaries...");
+
+		var classpath = "";
+		for (var entry in manifest.classpath) {
+			if (len(classpath)) classpath &= ":";
+			classpath &= installDir & "/lib/" & entry.filename;
+		}
+
+		try {
+			cfexecute(
+				name="java",
+				arguments="-cp #classpath# com.microsoft.playwright.CLI install #browserName#",
+				timeout=300,
+				variable="local.stdout",
+				errorVariable="local.stderr"
+			);
+			out("Browser install OK", "green");
+		} catch (any e) {
+			out("Browser install FAILED", "red");
+			out(local.stderr ?: e.message, "red");
+			return "";
+		}
+
+		out("");
+		out("Browser testing ready. Run: wheels browser test", "green");
+		return "";
+	}
+
+	private string function browserTest(array args = []) {
+		var format = "text";
+		var verboseOutput = false;
+		var directory = "wheels.tests.specs.wheelstest";
+
+		for (var i = 2; i <= arrayLen(args); i++) {
+			var arg = args[i];
+			if (arg == "--verbose" || arg == "-v") {
+				verboseOutput = true;
+			} else if (reFindNoCase("^--format=", arg)) {
+				format = valueAfterEquals(arg);
+			} else if (reFindNoCase("^--directory=", arg)) {
+				directory = valueAfterEquals(arg);
+			} else if (!arg.startsWith("--")) {
+				directory = arg;
+			}
+		}
+
+		// Pre-flight: verify Playwright JARs
+		var manifestPath = variables.projectRoot & "/vendor/wheels/browser-manifest.json";
+		if (!fileExists(manifestPath)) {
+			out("browser-manifest.json not found at: #manifestPath#", "red");
+			return "";
+		}
+		var manifest = deserializeJSON(fileRead(manifestPath));
+		var installDir = $resolveBrowserInstallDir();
+
+		var allInstalled = true;
+		var missingJars = [];
+		var mismatchedJars = [];
+		for (var entry in manifest.classpath) {
+			var jarPath = installDir & "/lib/" & entry.filename;
+			if (!fileExists(jarPath)) {
+				allInstalled = false;
+				arrayAppend(missingJars, entry.filename);
+			} else if ($sha256(jarPath) != lCase(entry.sha256)) {
+				allInstalled = false;
+				arrayAppend(mismatchedJars, entry.filename);
+			}
+		}
+
+		if (!allInstalled) {
+			out("Playwright not installed.", "red");
+			if (arrayLen(missingJars)) {
+				out("Missing: #arrayToList(missingJars, ', ')#", "yellow");
+			}
+			if (arrayLen(mismatchedJars)) {
+				out("SHA mismatch: #arrayToList(mismatchedJars, ', ')#", "yellow");
+			}
+			out("");
+			out("Run: wheels browser install");
+			return "";
+		}
+
+		out("Running browser tests...", "cyan");
+		out("Directory: #directory#");
+		out("");
+
+		var serverPort = $getServerPort();
+		var testUrl = "http://localhost:#serverPort#/wheels/core/tests?db=sqlite&format=json&directory=#directory#";
+
+		try {
+			var httpResult = makeHttpRequest(testUrl);
+		} catch (any e) {
+			out("Failed to reach test runner at: #testUrl#", "red");
+			out("Is the server running? Try: wheels start", "yellow");
+			return "";
+		}
+
+		if (format == "json") {
+			out(httpResult);
+			return "";
+		}
+
+		try {
+			var data = deserializeJSON(httpResult);
+			var totalPass = data.totalPass ?: 0;
+			var totalFail = data.totalFail ?: 0;
+			var totalError = data.totalError ?: 0;
+
+			out("Pass: #totalPass#  Fail: #totalFail#  Error: #totalError#");
+			out("");
+
+			for (var bundle in (data.bundleStats ?: [])) {
+				for (var suite in (bundle.suiteStats ?: [])) {
+					for (var spec in (suite.specStats ?: [])) {
+						if (listFindNoCase("Failed,Error", spec.status ?: "")) {
+							out("  #spec.status ?: ''#: #spec.name ?: 'unknown'#", "red");
+							if (verboseOutput && len(spec.failMessage ?: "")) {
+								out("    #left(spec.failMessage, 200)#", "yellow");
+							}
+						}
+					}
+				}
+			}
+
+			if (totalFail == 0 && totalError == 0) {
+				out("All browser tests passed.", "green");
+			}
+		} catch (any e) {
+			out("Failed to parse test results: #e.message#", "red");
+			if (verboseOutput) {
+				out(left(httpResult ?: "", 500));
+			}
+		}
+
+		return "";
+	}
+
+	private string function $resolveBrowserInstallDir() {
+		var envHome = "";
+		try {
+			envHome = createObject("java", "java.lang.System")
+				.getenv("WHEELS_BROWSER_HOME") ?: "";
+		} catch (any e) {}
+		if (len(trim(envHome))) return envHome;
+		var home = createObject("java", "java.lang.System").getProperty("user.home");
+		return home & "/.wheels/browser";
+	}
+
+	private string function $sha256(required string filePath) {
+		var md = createObject("java", "java.security.MessageDigest")
+			.getInstance("SHA-256");
+		var digest = md.digest(fileReadBinary(arguments.filePath));
+		return lCase(
+			createObject("java", "java.util.HexFormat").of().formatHex(digest)
+		);
+	}
+
+	private string function $getServerPort() {
+		try {
+			if (
+				structKeyExists(server, "lucli")
+				&& structKeyExists(server.lucli, "port")
+			) {
+				return server.lucli.port;
+			}
+		} catch (any e) {}
+		return detectServerPort() ?: "8080";
 	}
 
 	/**

--- a/cli/src/commands/wheels/browser/install.cfc
+++ b/cli/src/commands/wheels/browser/install.cfc
@@ -1,0 +1,109 @@
+/**
+ * Install Playwright browser binaries for E2E testing.
+ *
+ * Downloads 7 JARs from Maven Central (Playwright client + driver +
+ * driver-bundle + transitive deps), verifies SHA-256 hashes, then
+ * installs browser binaries via the Playwright CLI.
+ *
+ * Examples:
+ *   wheels browser:install
+ *   wheels browser:install --force
+ *   wheels browser:install --browser=firefox
+ */
+component aliases="wheels browser:install, wheels browser install" extends="../../base" {
+
+	property name="browserService" inject="BrowserService@wheels-cli";
+
+	/**
+	 * @force     Re-download JARs even if SHAs match
+	 * @browser   Which browser to install (chromium, firefox, webkit)
+	 */
+	function run(
+		boolean force = false,
+		string browser = "chromium"
+	) {
+		var projectRoot = getCWD();
+		var manifest = {};
+		try {
+			manifest = browserService.getManifest(projectRoot);
+		} catch (any e) {
+			print.redLine("Error: " & e.message);
+			return;
+		}
+
+		var installDir = browserService.resolveInstallDir();
+		print.line("Install directory: " & installDir);
+		print.line("Playwright version: " & (manifest.playwrightJavaVersion ?: "unknown"));
+		print.line("");
+
+		var downloaded = 0;
+		var skipped = 0;
+		for (var entry in manifest.classpath) {
+			var jarPath = installDir & "/lib/" & entry.filename;
+			var needsDownload = arguments.force;
+
+			if (!fileExists(jarPath)) {
+				needsDownload = true;
+			} else if (!arguments.force) {
+				var currentSha = browserService.sha256(jarPath);
+				if (currentSha != lCase(entry.sha256)) {
+					print.yellowLine("  SHA mismatch: " & entry.filename & " - re-downloading");
+					needsDownload = true;
+				}
+			}
+
+			if (needsDownload) {
+				print.text("  Downloading " & entry.filename & "...");
+				try {
+					browserService.downloadJar(url=entry.url, targetPath=jarPath);
+					var sha = browserService.sha256(jarPath);
+					if (sha != lCase(entry.sha256)) {
+						print.redLine(" FAILED (SHA mismatch)");
+						print.redLine("    Expected: " & lCase(entry.sha256));
+						print.redLine("    Got:      " & sha);
+						return;
+					}
+					print.greenLine(" OK");
+					downloaded++;
+				} catch (any e) {
+					print.redLine(" FAILED: " & e.message);
+					return;
+				}
+			} else {
+				print.line("  " & chr(10003) & " " & entry.filename);
+				skipped++;
+			}
+		}
+
+		print.line("");
+		print.line("JARs: " & downloaded & " downloaded, " & skipped & " up-to-date");
+
+		print.line("");
+		print.text("Installing " & arguments.browser & " browser binaries...");
+
+		var classpath = "";
+		for (var entry in manifest.classpath) {
+			if (len(classpath)) classpath &= ":";
+			classpath &= installDir & "/lib/" & entry.filename;
+		}
+
+		try {
+			cfexecute(
+				name="java",
+				arguments="-cp " & classpath & " com.microsoft.playwright.CLI install " & arguments.browser,
+				timeout=300,
+				variable="local.stdout",
+				errorVariable="local.stderr"
+			);
+			print.greenLine(" OK");
+		} catch (any e) {
+			print.redLine(" FAILED");
+			print.redLine(local.stderr ?: e.message);
+			return;
+		}
+
+		print.line("");
+		print.greenLine("Browser testing ready. Run: wheels browser:test");
+	}
+
+}

--- a/cli/src/commands/wheels/browser/test.cfc
+++ b/cli/src/commands/wheels/browser/test.cfc
@@ -1,0 +1,111 @@
+/**
+ * Run browser-based E2E tests.
+ *
+ * Pre-flight checks that Playwright JARs are installed, then hits
+ * the test runner URL scoped to browser test specs.
+ *
+ * Examples:
+ *   wheels browser:test
+ *   wheels browser:test --verbose
+ *   wheels browser:test --format=json
+ */
+component aliases="wheels browser:test, wheels browser test" extends="../../base" {
+
+	property name="browserService" inject="BrowserService@wheels-cli";
+
+	/**
+	 * @format    Output format: text or json
+	 * @verbose   Show full spec names
+	 * @directory Test directory (dot-notation, relative to vendor/wheels/)
+	 */
+	function run(
+		string format = "text",
+		boolean verbose = false,
+		string directory = "wheels.tests.specs.wheelstest"
+	) {
+		var projectRoot = getCWD();
+
+		try {
+			var manifest = browserService.getManifest(projectRoot);
+			var installDir = browserService.resolveInstallDir();
+			var status = browserService.verifyInstall(
+				manifest=manifest,
+				installDir=installDir
+			);
+			if (!status.installed) {
+				print.redLine("Playwright not installed.");
+				if (arrayLen(status.missing)) {
+					print.yellowLine("Missing: " & arrayToList(status.missing, ", "));
+				}
+				if (arrayLen(status.mismatched)) {
+					print.yellowLine("SHA mismatch: " & arrayToList(status.mismatched, ", "));
+				}
+				print.line("");
+				print.line("Run: wheels browser:install");
+				return;
+			}
+		} catch (any e) {
+			print.redLine("Error: " & e.message);
+			return;
+		}
+
+		print.line("Running browser tests...");
+		print.line("Directory: " & arguments.directory);
+		print.line("");
+
+		var serverInfo = command("server info").params(property="host").run(returnOutput=true);
+		var port = command("server info").params(property="port").run(returnOutput=true);
+		var host = trim(serverInfo) ?: "localhost";
+		var portNum = trim(port) ?: "8080";
+		var baseUrl = "http://" & host & ":" & portNum;
+
+		var testUrl = baseUrl
+			& "/wheels/core/tests?db=sqlite&format=json&directory="
+			& arguments.directory;
+
+		try {
+			cfhttp(url=testUrl, method="GET", timeout=300, result="local.response");
+		} catch (any e) {
+			print.redLine("Failed to reach test runner at: " & testUrl);
+			print.redLine("Is the server running? Try: server start");
+			return;
+		}
+
+		if (arguments.format == "json") {
+			print.line(local.response.fileContent);
+			return;
+		}
+
+		try {
+			var data = deserializeJSON(local.response.fileContent);
+			print.line("Pass: " & data.totalPass & "  Fail: " & data.totalFail & "  Error: " & data.totalError);
+			print.line("");
+
+			for (var bundle in (data.bundleStats ?: [])) {
+				for (var suite in (bundle.suiteStats ?: [])) {
+					for (var spec in (suite.specStats ?: [])) {
+						if (listFindNoCase("Failed,Error", spec.status ?: "")) {
+							print.redLine(
+								"  " & (spec.status ?: "") & ": "
+								& (spec.name ?: "unknown")
+							);
+							if (arguments.verbose && len(spec.failMessage ?: "")) {
+								print.line("    " & left(spec.failMessage, 200));
+							}
+						}
+					}
+				}
+			}
+
+			if (data.totalFail == 0 && data.totalError == 0) {
+				print.greenLine("All browser tests passed.");
+			}
+		} catch (any e) {
+			print.redLine("Failed to parse test results: " & e.message);
+			if (arguments.verbose) {
+				print.line(left(local.response.fileContent ?: "", 500));
+			}
+		}
+	}
+
+}

--- a/cli/src/models/BrowserService.cfc
+++ b/cli/src/models/BrowserService.cfc
@@ -1,0 +1,80 @@
+/**
+ * Shared service for Playwright browser JAR management.
+ * Used by both browser:install and browser:test CLI commands.
+ */
+component {
+
+	public struct function getManifest(required string projectRoot) {
+		var manifestPath = arguments.projectRoot & "/vendor/wheels/browser-manifest.json";
+		if (!fileExists(manifestPath)) {
+			throw(
+				type="BrowserService.ManifestMissing",
+				message="browser-manifest.json not found at: " & manifestPath
+			);
+		}
+		return deserializeJSON(fileRead(manifestPath));
+	}
+
+	public string function resolveInstallDir() {
+		var envHome = "";
+		try {
+			envHome = createObject("java", "java.lang.System")
+				.getenv("WHEELS_BROWSER_HOME") ?: "";
+		} catch (any e) {}
+		if (len(trim(envHome))) return envHome;
+		var home = createObject("java", "java.lang.System").getProperty("user.home");
+		return home & "/.wheels/browser";
+	}
+
+	public struct function verifyInstall(
+		required struct manifest,
+		required string installDir
+	) {
+		var result = {installed: true, missing: [], mismatched: []};
+		for (var entry in arguments.manifest.classpath) {
+			var jarPath = arguments.installDir & "/lib/" & entry.filename;
+			if (!fileExists(jarPath)) {
+				result.installed = false;
+				arrayAppend(result.missing, entry.filename);
+			} else if (sha256(jarPath) != lCase(entry.sha256)) {
+				result.installed = false;
+				arrayAppend(result.mismatched, entry.filename);
+			}
+		}
+		return result;
+	}
+
+	public void function downloadJar(
+		required string url,
+		required string targetPath
+	) {
+		var parentDir = getDirectoryFromPath(arguments.targetPath);
+		if (!directoryExists(parentDir)) {
+			directoryCreate(parentDir, true);
+		}
+		cfhttp(
+			url=arguments.url,
+			method="GET",
+			getAsBinary="yes",
+			timeout=300,
+			result="local.response"
+		);
+		if (!findNoCase("200", local.response.statusCode)) {
+			throw(
+				type="BrowserService.DownloadFailed",
+				message="HTTP " & local.response.statusCode & " downloading " & arguments.url
+			);
+		}
+		fileWrite(arguments.targetPath, local.response.fileContent);
+	}
+
+	public string function sha256(required string filePath) {
+		var md = createObject("java", "java.security.MessageDigest")
+			.getInstance("SHA-256");
+		var digest = md.digest(fileReadBinary(arguments.filePath));
+		return lCase(
+			createObject("java", "java.util.HexFormat").of().formatHex(digest)
+		);
+	}
+
+}

--- a/docs/superpowers/plans/2026-04-15-browser-testing-pr2.md
+++ b/docs/superpowers/plans/2026-04-15-browser-testing-pr2.md
@@ -1,0 +1,2130 @@
+# Browser Testing PR 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `$buildOption` reflection helper to unblock deferred DSL methods (cookies, configurable timeouts, waitForUrl, screenshot options, viewport config), CLI commands (`wheels browser:install`, `wheels browser:test`), and auto-screenshot on test failure.
+
+**Architecture:** `$buildOption` on BrowserLauncher loads Playwright inner classes via URLClassLoader reflection, constructs option objects, and applies fluent setters. BrowserClient wraps these in thin DSL methods. CLI commands delegate to a shared BrowserService for JAR management. Auto-screenshot uses TestBox `aroundEach` to capture artifacts on failure.
+
+**Tech Stack:** CFML (Lucee), Playwright Java 1.52.0, TestBox BDD, Java reflection API, URLClassLoader
+
+**Spec:** `docs/superpowers/specs/2026-04-15-browser-testing-pr2-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|----------------|
+| `cli/src/commands/wheels/browser/install.cfc` | CommandBox `wheels browser:install` command |
+| `cli/src/commands/wheels/browser/test.cfc` | CommandBox `wheels browser:test` command |
+| `cli/src/models/BrowserService.cfc` | Shared JAR download, SHA verification, pre-flight checks |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `vendor/wheels/wheelstest/BrowserLauncher.cfc` | Add `$buildOption`, `$findSetter`, `$castForParam` |
+| `vendor/wheels/wheelstest/BrowserClient.cfc` | Accept launcher in init; add cookies, waitForUrl; update waitFor, waitForText, screenshot |
+| `vendor/wheels/wheelstest/BrowserTest.cfc` | Pass launcher to BrowserClient; add viewport config; add aroundEach + `$captureFailureArtifacts` |
+| `cli/lucli/Module.cfc` | Add `browser()` public function with install/test subcommand dispatch |
+| `tools/install-playwright.sh` | Add deprecation notice |
+| `vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc` | Tests for `$buildOption`, `$findSetter`, `$castForParam` |
+| `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc` | Tests for new/updated DSL methods |
+| `vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc` | Tests for viewport config, auto-screenshot |
+| `.ai/wheels/testing/browser-testing.md` | Document new DSL methods + CLI commands |
+
+### Verified Playwright Java 1.52.0 API
+
+| Class | Constructor | Key Setters |
+|-------|------------|-------------|
+| `options.Cookie` | `(String name, String value)` — two-arg only | `setUrl(String)`, `setDomain(String)`, `setPath(String)`, `setExpires(double)`, `setHttpOnly(boolean)`, `setSecure(boolean)` |
+| `BrowserContext$ClearCookiesOptions` | zero-arg | `setName(String)`, `setDomain(String)`, `setPath(String)` (also Pattern overloads) |
+| `options.ViewportSize` | `(int width, int height)` — no zero-arg | public fields `width`, `height` |
+| `Browser$NewContextOptions` | zero-arg | `setViewportSize(ViewportSize)`, `setViewportSize(int, int)` |
+| `Page$ScreenshotOptions` | zero-arg | `setPath(Path)`, `setFullPage(boolean)`, `setQuality(int)`, `setTimeout(double)` |
+| `Locator$WaitForOptions` | zero-arg | `setTimeout(double)` |
+| `Page$WaitForURLOptions` | zero-arg | `setTimeout(double)` |
+
+---
+
+## Task 1: `$buildOption` Reflection Helper
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserLauncher.cfc`
+- Test: `vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc`
+
+### Sub-helpers first: `$findSetter` and `$castForParam`
+
+- [ ] **Step 1: Write failing tests for `$findSetter`**
+
+Add to `BrowserLauncherSpec.cfc` inside a new `describe("$findSetter")` block after the existing `$findZeroArgMethod` tests:
+
+```cfm
+describe("$findSetter", () => {
+
+    it("finds a one-arg setter by name on a JDK class", () => {
+        // java.util.Date has setTime(long) — one-arg setter
+        var klass = createObject("java", "java.util.Date").getClass();
+        var method = launcher.$findSetter(klass=klass, name="setTime");
+        expect(method.getName()).toBe("setTime");
+        expect(arrayLen(method.getParameterTypes())).toBe(1);
+    });
+
+    it("throws BrowserOptionError for nonexistent setter", () => {
+        var klass = createObject("java", "java.util.Date").getClass();
+        expect(() => {
+            launcher.$findSetter(klass=klass, name="setNonexistent");
+        }).toThrow("Wheels.BrowserOptionError");
+    });
+
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+```bash
+curl -sf "http://localhost:8080/wheels/core/tests?db=sqlite&format=json&directory=wheels.tests.specs.wheelstest" | python3 -c "
+import json,sys; d=json.load(sys.stdin)
+print(f'{d[\"totalPass\"]} pass, {d[\"totalFail\"]} fail, {d[\"totalError\"]} error')
+for b in d.get('bundleStats',[]):
+  for s in b.get('suiteStats',[]):
+    for sp in s.get('specStats',[]):
+      if sp.get('status') in ('Failed','Error'):
+        print(f'  {sp[\"status\"]}: {sp[\"name\"]}: {sp.get(\"failMessage\",\"\")[:120]}')
+"
+```
+
+Expected: FAIL — `$findSetter` method does not exist.
+
+- [ ] **Step 3: Implement `$findSetter` and `$castForParam`**
+
+Add to `BrowserLauncher.cfc` after the existing `$findZeroArgMethod` method:
+
+```cfm
+/**
+ * Finds a one-argument method with the given name on the given class.
+ * Used to locate fluent setters on Playwright option objects.
+ */
+public any function $findSetter(required any klass, required string name) {
+    var methods = arguments.klass.getMethods();
+    for (var i = 1; i <= arrayLen(methods); i++) {
+        if (
+            methods[i].getName() == arguments.name
+            && arrayLen(methods[i].getParameterTypes()) == 1
+        ) {
+            return methods[i];
+        }
+    }
+    throw(
+        type="Wheels.BrowserOptionError",
+        message="No one-arg method named '" & arguments.name
+            & "' on class " & arguments.klass.getName()
+    );
+}
+
+/**
+ * Cast a CFML value to the Java type expected by a method parameter.
+ * Reads the parameter's declared type and applies the appropriate javaCast.
+ * Java objects (e.g., nested option objects from $buildOption) pass through.
+ */
+public any function $castForParam(required any value, required any paramType) {
+    var typeName = arguments.paramType.getName();
+    switch (typeName) {
+        case "double":
+        case "java.lang.Double":
+            return javaCast("double", arguments.value);
+        case "int":
+        case "java.lang.Integer":
+            return javaCast("int", arguments.value);
+        case "long":
+        case "java.lang.Long":
+            return javaCast("long", arguments.value);
+        case "boolean":
+        case "java.lang.Boolean":
+            return javaCast("boolean", arguments.value);
+        case "java.lang.String":
+            return javaCast("string", arguments.value);
+        default:
+            return arguments.value;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Same curl command as Step 2. Expected: `$findSetter` tests PASS.
+
+- [ ] **Step 5: Write failing test for `$castForParam`**
+
+Add to `BrowserLauncherSpec.cfc`:
+
+```cfm
+describe("$castForParam", () => {
+
+    it("casts numeric to java.lang.Double for double param type", () => {
+        var paramType = createObject("java", "java.lang.Double").TYPE;
+        var result = launcher.$castForParam(value=5000, paramType=paramType);
+        expect(result.getClass().getName()).toBe("java.lang.Double");
+    });
+
+    it("casts numeric to java.lang.Integer for int param type", () => {
+        var paramType = createObject("java", "java.lang.Integer").TYPE;
+        var result = launcher.$castForParam(value=42, paramType=paramType);
+        expect(result.getClass().getName()).toBe("java.lang.Integer");
+    });
+
+    it("passes Java objects through unchanged", () => {
+        var obj = createObject("java", "java.util.Date").init();
+        var paramType = createObject("java", "java.util.Date").getClass();
+        var result = launcher.$castForParam(value=obj, paramType=paramType);
+        expect(result).toBe(obj);
+    });
+
+});
+```
+
+- [ ] **Step 6: Run tests, verify pass**
+
+These should pass immediately since `$castForParam` was already implemented. Expected: all PASS.
+
+### Core method: `$buildOption`
+
+- [ ] **Step 7: Write failing integration test for `$buildOption`**
+
+Add to `BrowserLauncherSpec.cfc` inside a new `describe("$buildOption")` block. This goes in the integration test section (guarded by JAR-present skip):
+
+```cfm
+describe("$buildOption", () => {
+
+    it("throws BrowserOptionError when classloader not initialized", () => {
+        var freshLauncher = new wheels.wheelstest.BrowserLauncher();
+        expect(() => {
+            freshLauncher.$buildOption(className="java.util.Date");
+        }).toThrow("Wheels.BrowserOptionError");
+    });
+
+    it("builds a zero-arg Playwright option with setters", () => {
+        if (skipBrowserTests) return;
+        var opts = launcher.$buildOption(
+            className="com.microsoft.playwright.Locator$WaitForOptions",
+            setterMap={setTimeout: 5000}
+        );
+        expect(isObject(opts)).toBeTrue();
+    });
+
+    it("builds an option with constructor args", () => {
+        if (skipBrowserTests) return;
+        var viewport = launcher.$buildOption(
+            className="com.microsoft.playwright.options.ViewportSize",
+            constructorArgs=[375, 667]
+        );
+        expect(isObject(viewport)).toBeTrue();
+        expect(viewport.width).toBe(375);
+        expect(viewport.height).toBe(667);
+    });
+
+    it("builds an option with constructor args AND setters", () => {
+        if (skipBrowserTests) return;
+        var cookie = launcher.$buildOption(
+            className="com.microsoft.playwright.options.Cookie",
+            constructorArgs=["testName", "testValue"],
+            setterMap={setUrl: "http://localhost"}
+        );
+        expect(isObject(cookie)).toBeTrue();
+        expect(cookie.name).toBe("testName");
+        expect(cookie.value).toBe("testValue");
+    });
+
+    it("passes nested Java objects through setters", () => {
+        if (skipBrowserTests) return;
+        var viewport = launcher.$buildOption(
+            className="com.microsoft.playwright.options.ViewportSize",
+            constructorArgs=[375, 667]
+        );
+        var contextOpts = launcher.$buildOption(
+            className="com.microsoft.playwright.Browser$NewContextOptions",
+            setterMap={setViewportSize: viewport}
+        );
+        expect(isObject(contextOpts)).toBeTrue();
+    });
+
+});
+```
+
+- [ ] **Step 8: Run tests, verify failure**
+
+Expected: FAIL — `$buildOption` method does not exist.
+
+- [ ] **Step 9: Implement `$buildOption`**
+
+Add to `BrowserLauncher.cfc`:
+
+```cfm
+/**
+ * Construct a Playwright option object via reflection through our URLClassLoader.
+ *
+ * Lucee's createObject("java", "InnerClass") fails when the class lives in a
+ * URLClassLoader — it tries to resolve via OSGi bundles. This helper bypasses
+ * that by using loadClass() + reflection directly.
+ *
+ * @className   Fully-qualified Java class name (use $ for inner classes)
+ * @setterMap   Struct of setter-name => value. Values auto-cast to match parameter type.
+ * @constructorArgs  Array of constructor arguments. Matched by arity; auto-cast per param type.
+ */
+public any function $buildOption(
+    required string className,
+    struct setterMap = {},
+    array constructorArgs = []
+) {
+    if (!structKeyExists(variables, "$classLoader")) {
+        throw(
+            type="Wheels.BrowserOptionError",
+            message="Cannot build option: classloader not initialized. Call $loadJars() first."
+        );
+    }
+
+    var klass = "";
+    try {
+        klass = variables.$classLoader.loadClass(arguments.className);
+    } catch (any e) {
+        throw(
+            type="Wheels.BrowserOptionError",
+            message="Class not found: " & arguments.className & ". " & e.message
+        );
+    }
+
+    // Construct instance
+    var instance = "";
+    if (arrayLen(arguments.constructorArgs)) {
+        instance = $constructWithArgs(klass=klass, args=arguments.constructorArgs);
+    } else {
+        try {
+            instance = klass.getDeclaredConstructor().newInstance();
+        } catch (any e) {
+            throw(
+                type="Wheels.BrowserOptionError",
+                message="Failed to construct " & arguments.className
+                    & " with zero-arg constructor: " & e.message
+            );
+        }
+    }
+
+    // Apply setters
+    for (var setterName in arguments.setterMap) {
+        var value = arguments.setterMap[setterName];
+        try {
+            var setter = $findSetter(klass=klass, name=setterName);
+            var paramType = setter.getParameterTypes()[1];
+            var castedValue = $castForParam(value=value, paramType=paramType);
+            setter.invoke(instance, javaCast("Object[]", [castedValue]));
+        } catch (any e) {
+            if (findNoCase("Wheels.", e.type ?: "")) rethrow;
+            throw(
+                type="Wheels.BrowserOptionError",
+                message="Failed to call " & setterName & " on "
+                    & arguments.className & ": " & e.message
+            );
+        }
+    }
+
+    return instance;
+}
+
+/**
+ * Construct an instance using a constructor matched by argument count.
+ * Tries each constructor with matching arity until one succeeds.
+ */
+private any function $constructWithArgs(required any klass, required array args) {
+    var constructors = arguments.klass.getDeclaredConstructors();
+    var targetArity = arrayLen(arguments.args);
+
+    for (var i = 1; i <= arrayLen(constructors); i++) {
+        var paramTypes = constructors[i].getParameterTypes();
+        if (arrayLen(paramTypes) != targetArity) continue;
+
+        try {
+            var castedArgs = [];
+            for (var j = 1; j <= targetArity; j++) {
+                arrayAppend(castedArgs, $castForParam(
+                    value=arguments.args[j],
+                    paramType=paramTypes[j]
+                ));
+            }
+            return constructors[i].newInstance(javaCast("Object[]", castedArgs));
+        } catch (any e) {
+            // Type mismatch — try next constructor with same arity
+        }
+    }
+
+    throw(
+        type="Wheels.BrowserOptionError",
+        message="No constructor with " & targetArity & " arg(s) found on "
+            & arguments.klass.getName()
+    );
+}
+```
+
+- [ ] **Step 10: Run tests, verify all pass**
+
+Expected: all `$buildOption` tests PASS. Run the full browser test suite to check for regressions:
+
+```bash
+curl -sf "http://localhost:8080/wheels/core/tests?db=sqlite&format=json&directory=wheels.tests.specs.wheelstest" | python3 -c "
+import json,sys; d=json.load(sys.stdin)
+print(f'{d[\"totalPass\"]} pass, {d[\"totalFail\"]} fail, {d[\"totalError\"]} error')
+"
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserLauncher.cfc vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
+git commit -m "feat(test): add \$buildOption reflection helper to BrowserLauncher
+
+Enables construction of Playwright inner-class option objects through
+the URLClassLoader, bypassing Lucee's OSGi bundle resolver. Supports
+zero-arg + setter, multi-arg constructor, and nested objects."
+```
+
+---
+
+## Task 2: Wire Launcher into BrowserClient
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Modify: `vendor/wheels/wheelstest/BrowserTest.cfc`
+- Test: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `BrowserIntegrationSpec.cfc` inside the existing navigation describe block (or a new "launcher wiring" describe):
+
+```cfm
+it("exposes launcher via getLauncher()", () => {
+    if (skipBrowserTests) return;
+    expect(isObject(bc.getLauncher())).toBeTrue();
+    expect(bc.getLauncher().getState()).toBe("ready");
+});
+```
+
+Note: `bc` is the BrowserClient instance used by integration tests. If integration tests create their own BrowserClient, the launcher needs to be passed in. Check how `bc` is currently initialized in the spec and update accordingly.
+
+- [ ] **Step 2: Run test, verify failure**
+
+Expected: FAIL — `getLauncher()` method does not exist.
+
+- [ ] **Step 3: Update BrowserClient.init to accept launcher**
+
+In `BrowserClient.cfc`, update the `init` method and add `getLauncher`:
+
+```cfm
+variables.page = "";
+variables.context = "";
+variables.baseUrl = "";
+variables.$launcher = "";
+
+public BrowserClient function init(
+    any page = "",
+    any context = "",
+    string baseUrl = "",
+    any launcher = ""
+) {
+    variables.page = arguments.page;
+    variables.context = arguments.context;
+    variables.baseUrl = arguments.baseUrl;
+    variables.$launcher = arguments.launcher;
+    return this;
+}
+
+public any function getLauncher() {
+    return variables.$launcher;
+}
+```
+
+- [ ] **Step 4: Update BrowserTest to pass launcher**
+
+In `BrowserTest.cfc`, update `$startBrowserContext` to pass the launcher:
+
+```cfm
+this.browser = new wheels.wheelstest.BrowserClient().init(
+    page=variables.$page,
+    context=variables.$context,
+    baseUrl=variables.$baseUrl,
+    launcher=variables.$launcher
+);
+```
+
+Also update `within()` in `BrowserClient.cfc` to propagate the launcher to scoped clients:
+
+```cfm
+public BrowserClient function within(
+    required string selector,
+    required any callback
+) {
+    var scoped = new wheels.wheelstest.BrowserClient()
+        .init(
+            page=variables.page,
+            context=variables.context,
+            baseUrl=variables.baseUrl,
+            launcher=variables.$launcher
+        );
+    scoped.$setScope(variables.page.locator(arguments.selector).first());
+    arguments.callback(scoped);
+    return this;
+}
+```
+
+- [ ] **Step 5: Update integration test setup to pass launcher**
+
+In `BrowserIntegrationSpec.cfc`, find where BrowserClient `bc` is created in the integration test setup. Update it to pass the launcher. The launcher is the same application-scoped instance used by BrowserTest. Access it via:
+
+```cfm
+var launcherRef = application.wheelsBrowserLauncher ?: "";
+// When creating bc for integration tests:
+bc = new wheels.wheelstest.BrowserClient().init(
+    page=testPage,
+    context=testContext,
+    baseUrl="",
+    launcher=launcherRef
+);
+```
+
+- [ ] **Step 6: Run tests, verify pass**
+
+Expected: all tests PASS including new `getLauncher()` test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc vendor/wheels/wheelstest/BrowserTest.cfc vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): wire launcher reference into BrowserClient
+
+BrowserClient.init now accepts a launcher parameter. BrowserTest passes
+the application-scoped launcher, and within() propagates it to scoped
+clients. Enables DSL methods to call \$buildOption for Playwright options."
+```
+
+---
+
+## Task 3: Configurable Timeouts on waitFor / waitForText
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Test: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `BrowserIntegrationSpec.cfc` inside the existing "waiting" describe:
+
+```cfm
+it("waitFor honors custom timeout (short timeout fails on missing element)", () => {
+    if (skipBrowserTests) return;
+    bc.visitUrl("data:text/html,<h1>No target here</h1>");
+    expect(() => {
+        bc.waitFor("##never-exists", 1);
+    }).toThrow();
+});
+
+it("waitForText honors custom timeout (short timeout fails on missing text)", () => {
+    if (skipBrowserTests) return;
+    bc.visitUrl("data:text/html,<h1>Hello</h1>");
+    expect(() => {
+        bc.waitForText("never appears", 1);
+    }).toThrow();
+});
+```
+
+- [ ] **Step 2: Run test, verify behavior**
+
+These tests might already pass with the current default 30s timeout (Playwright would wait 30s then fail). But with `seconds=1`, the test should fail/timeout much faster — within ~1s instead of ~30s. The test verifies the timeout is actually applied. If the test takes ~30s, the custom timeout isn't being honored.
+
+Run and time it:
+```bash
+time curl -sf "http://localhost:8080/wheels/core/tests?db=sqlite&format=json&directory=wheels.tests.specs.wheelstest" > /dev/null
+```
+
+- [ ] **Step 3: Update waitFor and waitForText**
+
+In `BrowserClient.cfc`, replace the existing `waitFor` method:
+
+```cfm
+public BrowserClient function waitFor(
+    required string selector,
+    numeric seconds = 30
+) {
+    var loc = $locator(arguments.selector).first();
+    if (arguments.seconds != 30 && isObject(variables.$launcher)) {
+        var opts = variables.$launcher.$buildOption(
+            className="com.microsoft.playwright.Locator$WaitForOptions",
+            setterMap={setTimeout: arguments.seconds * 1000}
+        );
+        loc.waitFor(opts);
+    } else {
+        loc.waitFor();
+    }
+    return this;
+}
+```
+
+Replace the existing `waitForText` method:
+
+```cfm
+public BrowserClient function waitForText(
+    required string text,
+    numeric seconds = 30
+) {
+    var loc = variables.page.getByText(arguments.text).first();
+    if (arguments.seconds != 30 && isObject(variables.$launcher)) {
+        var opts = variables.$launcher.$buildOption(
+            className="com.microsoft.playwright.Locator$WaitForOptions",
+            setterMap={setTimeout: arguments.seconds * 1000}
+        );
+        loc.waitFor(opts);
+    } else {
+        loc.waitFor();
+    }
+    return this;
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+The timeout tests should now complete in ~1s (not 30s) and throw as expected. All existing waitFor/waitForText tests should still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): add configurable timeouts to waitFor and waitForText
+
+Uses \$buildOption to construct Locator\$WaitForOptions when a non-default
+timeout is specified. Zero-arg fast path preserved for default 30s."
+```
+
+---
+
+## Task 4: waitForUrl
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Test: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `BrowserIntegrationSpec.cfc`:
+
+```cfm
+describe("waitForUrl", () => {
+
+    it("resolves immediately when URL already matches", () => {
+        if (skipBrowserTests) return;
+        bc.visitUrl("data:text/html,<h1>Here</h1>");
+        bc.waitForUrl("data:text/html,*", 5);
+        // No throw = success
+    });
+
+    it("throws on timeout when URL does not match", () => {
+        if (skipBrowserTests) return;
+        bc.visitUrl("data:text/html,<h1>Here</h1>");
+        expect(() => {
+            bc.waitForUrl("http://will-never-match.example.com/**", 1);
+        }).toThrow();
+    });
+
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Expected: FAIL — `waitForUrl` method does not exist.
+
+- [ ] **Step 3: Implement waitForUrl**
+
+Add to `BrowserClient.cfc` after the `waitForText` method:
+
+```cfm
+/**
+ * Waits for the page URL to match the given pattern. Supports exact
+ * strings and glob patterns (Playwright native).
+ */
+public BrowserClient function waitForUrl(
+    required string url,
+    numeric seconds = 30
+) {
+    if (arguments.seconds != 30 && isObject(variables.$launcher)) {
+        var opts = variables.$launcher.$buildOption(
+            className="com.microsoft.playwright.Page$WaitForURLOptions",
+            setterMap={setTimeout: arguments.seconds * 1000}
+        );
+        variables.page.waitForURL(arguments.url, opts);
+    } else {
+        variables.page.waitForURL(arguments.url);
+    }
+    return this;
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Expected: both waitForUrl tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): add waitForUrl DSL method
+
+Waits for page URL to match a string or glob pattern. Uses
+Page\$WaitForURLOptions for configurable timeout via \$buildOption."
+```
+
+---
+
+## Task 5: Screenshot Options
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Test: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `BrowserIntegrationSpec.cfc` in the existing "screenshot" describe:
+
+```cfm
+it("screenshot with fullPage option writes a PNG file", () => {
+    if (skipBrowserTests) return;
+    bc.visitUrl("data:text/html,<div style='height:2000px'>Tall page</div>");
+    var outPath = expandPath("/tests/_output/test_fullpage_screenshot.png");
+    bc.screenshot(path=outPath, fullPage=true);
+    expect(fileExists(outPath)).toBeTrue();
+    expect(fileReadBinary(outPath).len()).toBeGT(0);
+    // Cleanup
+    fileDelete(outPath);
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Expected: FAIL — `screenshot` doesn't accept `fullPage` argument (or it's ignored and no option is built).
+
+- [ ] **Step 3: Update screenshot method**
+
+In `BrowserClient.cfc`, replace the existing `screenshot` method:
+
+```cfm
+/**
+ * Screenshot to `path`. When fullPage or quality are specified, builds
+ * Page$ScreenshotOptions via $buildOption. Otherwise uses the fast path
+ * (no-arg screenshot → byte[] → fileWrite).
+ */
+public BrowserClient function screenshot(
+    required string path,
+    boolean fullPage = false,
+    numeric quality = 0
+) {
+    if ((arguments.fullPage || arguments.quality > 0) && isObject(variables.$launcher)) {
+        var emptyStringArr = javaCast("String[]", []);
+        var pathObj = createObject("java", "java.nio.file.Paths")
+            .get(arguments.path, emptyStringArr);
+        var setters = {setPath: pathObj};
+        if (arguments.fullPage) {
+            setters["setFullPage"] = true;
+        }
+        if (arguments.quality > 0) {
+            setters["setQuality"] = arguments.quality;
+        }
+        var opts = variables.$launcher.$buildOption(
+            className="com.microsoft.playwright.Page$ScreenshotOptions",
+            setterMap=setters
+        );
+        variables.page.screenshot(opts);
+    } else {
+        var bytes = variables.page.screenshot();
+        fileWrite(arguments.path, bytes);
+    }
+    return this;
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Expected: new fullPage test PASS, existing screenshot test still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): add screenshot options (fullPage, quality)
+
+Builds Page\$ScreenshotOptions via \$buildOption when non-default options
+are specified. Zero-arg fast path preserved for simple screenshots."
+```
+
+---
+
+## Task 6: Cookie DSL Methods
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserClient.cfc`
+- Test: `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc`
+
+Cookie tests require a real HTTP origin (not `data:` URLs). They use `baseUrl` (the test runner at localhost:8080) which is always running during test execution.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `BrowserIntegrationSpec.cfc`:
+
+```cfm
+describe("cookies", () => {
+
+    it("setCookie sets a cookie and cookie() reads it back", () => {
+        if (skipBrowserTests) return;
+        // Need a real HTTP origin for cookies — use the test runner
+        var testUrl = bc.getBaseUrl();
+        if (!len(testUrl)) {
+            // No server running — skip
+            return;
+        }
+        bc.visitUrl(testUrl);
+        bc.setCookie(name="testCookie", value="hello123", url=testUrl);
+        var c = bc.cookie("testCookie");
+        expect(c.name).toBe("testCookie");
+        expect(c.value).toBe("hello123");
+    });
+
+    it("deleteCookie removes a specific cookie", () => {
+        if (skipBrowserTests) return;
+        var testUrl = bc.getBaseUrl();
+        if (!len(testUrl)) return;
+        bc.visitUrl(testUrl);
+        bc.setCookie(name="toDelete", value="bye", url=testUrl);
+        // Verify it exists
+        var c = bc.cookie("toDelete");
+        expect(c.value).toBe("bye");
+        // Delete it
+        bc.deleteCookie("toDelete");
+        // Verify it's gone
+        expect(() => {
+            bc.cookie("toDelete");
+        }).toThrow("Wheels.BrowserAssertionFailed");
+    });
+
+    it("cookie() throws when cookie not found", () => {
+        if (skipBrowserTests) return;
+        var testUrl = bc.getBaseUrl();
+        if (!len(testUrl)) return;
+        bc.visitUrl(testUrl);
+        expect(() => {
+            bc.cookie("nonexistent_cookie_xyz");
+        }).toThrow("Wheels.BrowserAssertionFailed");
+    });
+
+    it("setCookie is chainable", () => {
+        if (skipBrowserTests) return;
+        var testUrl = bc.getBaseUrl();
+        if (!len(testUrl)) return;
+        bc.visitUrl(testUrl);
+        var result = bc.setCookie(name="chain1", value="a", url=testUrl)
+            .setCookie(name="chain2", value="b", url=testUrl);
+        expect(result).toBeInstanceOf("wheels.wheelstest.BrowserClient");
+    });
+
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Expected: FAIL — `setCookie`, `deleteCookie`, `cookie` methods do not exist.
+
+- [ ] **Step 3: Implement cookie methods**
+
+Add to `BrowserClient.cfc` after the scoping section:
+
+```cfm
+// ─── Cookies ─────────────────────────────────────────────────────
+
+/**
+ * Set a cookie on the current browser context. Requires the page to
+ * have been navigated to a real HTTP origin (not data: URLs).
+ */
+public BrowserClient function setCookie(
+    required string name,
+    required string value,
+    required string url
+) {
+    var cookieObj = variables.$launcher.$buildOption(
+        className="com.microsoft.playwright.options.Cookie",
+        constructorArgs=[arguments.name, arguments.value],
+        setterMap={setUrl: arguments.url}
+    );
+    var cookieList = createObject("java", "java.util.Collections")
+        .singletonList(cookieObj);
+    variables.context.addCookies(cookieList);
+    return this;
+}
+
+/**
+ * Delete a specific cookie by name from the browser context.
+ */
+public BrowserClient function deleteCookie(required string name) {
+    var opts = variables.$launcher.$buildOption(
+        className="com.microsoft.playwright.BrowserContext$ClearCookiesOptions",
+        setterMap={setName: arguments.name}
+    );
+    variables.context.clearCookies(opts);
+    return this;
+}
+
+/**
+ * Read a cookie by name from the browser context. Returns a struct
+ * with name, value, domain, path, expires, httpOnly, secure.
+ * Throws BrowserAssertionFailed if cookie not found.
+ */
+public struct function cookie(required string name) {
+    var cookies = variables.context.cookies();
+    for (var i = 0; i < cookies.size(); i++) {
+        var c = cookies.get(javaCast("int", i));
+        if (c.name == arguments.name) {
+            return {
+                name: c.name,
+                value: c.value,
+                domain: c.domain ?: "",
+                path: c.path ?: "",
+                expires: c.expires ?: -1,
+                httpOnly: c.httpOnly ?: false,
+                secure: c.secure ?: false
+            };
+        }
+    }
+    $assertFail("Cookie '" & arguments.name & "' not found");
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Expected: all cookie tests PASS (requires Playwright installed AND test runner server running).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserClient.cfc vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+git commit -m "feat(test): add cookie DSL methods (setCookie, deleteCookie, cookie)
+
+Uses \$buildOption to construct Cookie and ClearCookiesOptions objects.
+Requires a real HTTP origin; data: URLs don't support cookies."
+```
+
+---
+
+## Task 7: Viewport Config at BrowserTest Level
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserTest.cfc`
+- Test: `vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `BrowserTestLifecycleSpec.cfc`:
+
+```cfm
+describe("viewport config", () => {
+
+    it("applies mobile viewport preset when this.browserViewport is set", () => {
+        if (this.browserTestSkipped) return;
+        // Save original and set viewport
+        var original = this.browserViewport ?: "";
+        this.browserViewport = "mobile";
+
+        // Re-create browser context with viewport config
+        this.$endBrowserContext();
+        this.$startBrowserContext();
+
+        this.browser.visitUrl("data:text/html,<h1>Test</h1>");
+        var width = this.browser.script("() => window.innerWidth");
+        expect(width).toBe(375);
+
+        // Restore
+        this.browserViewport = original;
+        this.$endBrowserContext();
+        this.$startBrowserContext();
+    });
+
+    it("applies custom viewport dimensions from struct", () => {
+        if (this.browserTestSkipped) return;
+        var original = this.browserViewport ?: "";
+        this.browserViewport = {width: 800, height: 600};
+
+        this.$endBrowserContext();
+        this.$startBrowserContext();
+
+        this.browser.visitUrl("data:text/html,<h1>Test</h1>");
+        var width = this.browser.script("() => window.innerWidth");
+        expect(width).toBe(800);
+
+        this.browserViewport = original;
+        this.$endBrowserContext();
+        this.$startBrowserContext();
+    });
+
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Expected: FAIL — viewport is not applied (dimensions don't match).
+
+- [ ] **Step 3: Implement viewport config**
+
+In `BrowserTest.cfc`, update `$startBrowserContext`:
+
+```cfm
+public void function $startBrowserContext() {
+    if (this.browserTestSkipped) return;
+
+    // Build context options if viewport is configured
+    var contextOpts = $buildContextOptions();
+
+    if (isObject(contextOpts)) {
+        variables.$context = variables.$browser.newContext(contextOpts);
+    } else {
+        variables.$context = variables.$browser.newContext();
+    }
+    variables.$page = variables.$context.newPage();
+    this.browser = new wheels.wheelstest.BrowserClient().init(
+        page=variables.$page,
+        context=variables.$context,
+        baseUrl=variables.$baseUrl,
+        launcher=variables.$launcher
+    );
+}
+```
+
+Add the viewport resolution helper:
+
+```cfm
+/**
+ * Builds Browser$NewContextOptions if viewport config is set.
+ * Returns the options object, or empty string if no config.
+ */
+private any function $buildContextOptions() {
+    if (!structKeyExists(this, "browserViewport") || !len(this.browserViewport ?: "")) {
+        return "";
+    }
+
+    var dims = $resolveViewportDims(this.browserViewport);
+
+    var viewport = variables.$launcher.$buildOption(
+        className="com.microsoft.playwright.options.ViewportSize",
+        constructorArgs=[dims.width, dims.height]
+    );
+
+    return variables.$launcher.$buildOption(
+        className="com.microsoft.playwright.Browser$NewContextOptions",
+        setterMap={setViewportSize: viewport}
+    );
+}
+
+/**
+ * Resolve viewport config to {width, height} struct.
+ * Accepts preset strings ("mobile", "tablet", "desktop") or a struct.
+ */
+private struct function $resolveViewportDims(required any viewport) {
+    if (isSimpleValue(arguments.viewport)) {
+        switch (lCase(arguments.viewport)) {
+            case "mobile":
+                return {width: 375, height: 667};
+            case "tablet":
+                return {width: 768, height: 1024};
+            case "desktop":
+                return {width: 1440, height: 900};
+            default:
+                throw(
+                    type="Wheels.BrowserViewportInvalid",
+                    message="Unknown viewport preset: " & arguments.viewport
+                        & ". Valid: mobile, tablet, desktop"
+                );
+        }
+    }
+    return {
+        width: arguments.viewport.width ?: 1440,
+        height: arguments.viewport.height ?: 900
+    };
+}
+```
+
+Also add the default property at the top of `BrowserTest.cfc` (near `this.browserEngine`):
+
+```cfm
+this.browserViewport = "";  // empty = use Playwright default; "mobile"/"tablet"/"desktop" or {width:N, height:N}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Expected: viewport tests PASS. All existing lifecycle tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserTest.cfc vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc
+git commit -m "feat(test): add viewport config at BrowserTest level
+
+Spec CFCs can set this.browserViewport to a preset string or
+{width, height} struct. Builds ViewportSize + NewContextOptions
+via \$buildOption for each new browser context."
+```
+
+---
+
+## Task 8: Auto-Screenshot on Failure
+
+**Files:**
+- Modify: `vendor/wheels/wheelstest/BrowserTest.cfc`
+- Test: `vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `BrowserTestLifecycleSpec.cfc`:
+
+```cfm
+describe("auto-screenshot on failure", () => {
+
+    it("$captureFailureArtifacts writes screenshot and HTML", () => {
+        if (this.browserTestSkipped) return;
+        this.browser.visitUrl("data:text/html,<h1>Capture Me</h1>");
+
+        var testDir = expandPath("/tests/_output/browser_capture_test");
+        this.browserArtifactPath = testDir;
+
+        var fakeSpec = {name: "test_capture_verification"};
+        this.$captureFailureArtifacts(fakeSpec);
+
+        expect(directoryExists(testDir)).toBeTrue();
+        var files = directoryList(testDir, false, "name");
+        var hasPng = false;
+        var hasHtml = false;
+        for (var f in files) {
+            if (findNoCase(".png", f)) hasPng = true;
+            if (findNoCase(".html", f)) hasHtml = true;
+        }
+        expect(hasPng).toBeTrue();
+        expect(hasHtml).toBeTrue();
+
+        // Cleanup
+        directoryDelete(testDir, true);
+        structDelete(this, "browserArtifactPath");
+    });
+
+    it("respects browserScreenshotOnFailure=false", () => {
+        if (this.browserTestSkipped) return;
+        this.browser.visitUrl("data:text/html,<h1>No Capture</h1>");
+
+        var testDir = expandPath("/tests/_output/browser_optout_test");
+        this.browserArtifactPath = testDir;
+        this.browserScreenshotOnFailure = false;
+
+        var fakeSpec = {name: "test_optout"};
+        this.$captureFailureArtifacts(fakeSpec);
+
+        expect(directoryExists(testDir)).toBeFalse();
+
+        // Restore
+        this.browserScreenshotOnFailure = true;
+        structDelete(this, "browserArtifactPath");
+    });
+
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Expected: FAIL — `$captureFailureArtifacts` does not exist.
+
+- [ ] **Step 3: Implement `$captureFailureArtifacts` and aroundEach**
+
+Add default property at top of `BrowserTest.cfc`:
+
+```cfm
+this.browserScreenshotOnFailure = true;
+```
+
+Add the capture method:
+
+```cfm
+/**
+ * Best-effort capture of screenshot + HTML on test failure.
+ * Called from aroundEach catch block. Swallows all errors to avoid
+ * masking the real test failure.
+ */
+public void function $captureFailureArtifacts(required any spec) {
+    if (!(this.browserScreenshotOnFailure ?: true)) return;
+    if (!isObject(this.browser) || this.browserTestSkipped) return;
+
+    try {
+        var artifactDir = this.browserArtifactPath
+            ?: expandPath("/tests/_output/browser");
+
+        if (!directoryExists(artifactDir)) {
+            directoryCreate(artifactDir, true);
+        }
+
+        var rawName = arguments.spec.name ?: "unknown_spec";
+        var safeName = reReplace(rawName, "[^a-zA-Z0-9_\-]", "_", "all");
+        if (len(safeName) > 80) safeName = left(safeName, 80);
+        var ts = dateFormat(now(), "yyyymmdd") & "_" & timeFormat(now(), "HHmmss");
+        var baseName = safeName & "-" & ts;
+
+        this.browser.screenshot(path=artifactDir & "/" & baseName & ".png");
+        fileWrite(artifactDir & "/" & baseName & ".html", this.browser.pageSource());
+    } catch (any e) {
+        // Best-effort: page may have crashed, context may be closed.
+        // Swallow to avoid masking the real test failure.
+    }
+}
+```
+
+Update `browserDescribe` to add `aroundEach`:
+
+```cfm
+public void function browserDescribe(required string title, required any body) {
+    var me = this;
+    var innerBody = arguments.body;
+
+    describe(arguments.title, () => {
+        beforeEach(() => {
+            me.$startBrowserContext();
+        });
+
+        aroundEach(function(spec, suite) {
+            if (me.browserTestSkipped) {
+                arguments.spec.body();
+                return;
+            }
+            try {
+                arguments.spec.body();
+            } catch (any e) {
+                me.$captureFailureArtifacts(arguments.spec);
+                rethrow;
+            }
+        });
+
+        afterEach(() => {
+            me.$endBrowserContext();
+        });
+
+        innerBody();
+    });
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Expected: both auto-screenshot tests PASS. All existing lifecycle tests still PASS.
+
+**Fallback note:** If `aroundEach` doesn't work inside `browserDescribe`'s dynamically-registered describe body, fall back to setting a caught-error flag in `afterEach`:
+
+```cfm
+// Alternative: track failure in afterEach instead of aroundEach
+afterEach(() => {
+    // TestBox sets spec.status before afterEach runs
+    // Check if the current spec failed and capture if so
+    me.$endBrowserContext();
+});
+```
+
+But try `aroundEach` first — it's cleaner and follows the same registration pattern as `beforeEach`/`afterEach` which already work.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vendor/wheels/wheelstest/BrowserTest.cfc vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc
+git commit -m "feat(test): add auto-screenshot and HTML dump on test failure
+
+browserDescribe registers aroundEach to capture artifacts on failure.
+Screenshot + HTML written to tests/_output/browser/. Opt-out via
+this.browserScreenshotOnFailure = false."
+```
+
+---
+
+## Task 9: BrowserService for CLI
+
+**Files:**
+- Create: `cli/src/models/BrowserService.cfc`
+
+- [ ] **Step 1: Create BrowserService.cfc**
+
+```bash
+ls /Users/peter/GitHub/wheels-dev/wheels/cli/src/models/
+```
+
+Verify the models directory exists, then create:
+
+```cfm
+/**
+ * Shared service for Playwright browser JAR management.
+ * Used by both browser:install and browser:test CLI commands.
+ */
+component {
+
+    /**
+     * Read and parse browser-manifest.json from the project.
+     */
+    public struct function getManifest(required string projectRoot) {
+        var manifestPath = arguments.projectRoot & "/vendor/wheels/browser-manifest.json";
+        if (!fileExists(manifestPath)) {
+            throw(
+                type="BrowserService.ManifestMissing",
+                message="browser-manifest.json not found at: " & manifestPath
+            );
+        }
+        return deserializeJSON(fileRead(manifestPath));
+    }
+
+    /**
+     * Resolve install directory from env var or default.
+     */
+    public string function resolveInstallDir() {
+        var envHome = "";
+        try {
+            envHome = createObject("java", "java.lang.System")
+                .getenv("WHEELS_BROWSER_HOME") ?: "";
+        } catch (any e) {}
+        if (len(trim(envHome))) return envHome;
+
+        var home = createObject("java", "java.lang.System").getProperty("user.home");
+        return home & "/.wheels/browser";
+    }
+
+    /**
+     * Check if all JARs are installed and SHAs match.
+     * Returns {installed: boolean, missing: [], mismatched: []}.
+     */
+    public struct function verifyInstall(
+        required struct manifest,
+        required string installDir
+    ) {
+        var result = {installed: true, missing: [], mismatched: []};
+        for (var entry in arguments.manifest.classpath) {
+            var jarPath = arguments.installDir & "/lib/" & entry.filename;
+            if (!fileExists(jarPath)) {
+                result.installed = false;
+                arrayAppend(result.missing, entry.filename);
+            } else if (sha256(jarPath) != lCase(entry.sha256)) {
+                result.installed = false;
+                arrayAppend(result.mismatched, entry.filename);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Download a single JAR from its manifest URL to the target path.
+     */
+    public void function downloadJar(
+        required string url,
+        required string targetPath
+    ) {
+        var parentDir = getDirectoryFromPath(arguments.targetPath);
+        if (!directoryExists(parentDir)) {
+            directoryCreate(parentDir, true);
+        }
+        cfhttp(
+            url=arguments.url,
+            method="GET",
+            getAsBinary="yes",
+            timeout=300,
+            result="local.response"
+        );
+        if (!findNoCase("200", local.response.statusCode)) {
+            throw(
+                type="BrowserService.DownloadFailed",
+                message="HTTP " & local.response.statusCode & " downloading " & arguments.url
+            );
+        }
+        fileWrite(arguments.targetPath, local.response.fileContent);
+    }
+
+    /**
+     * SHA-256 hash of a file, lowercase hex.
+     */
+    public string function sha256(required string filePath) {
+        var md = createObject("java", "java.security.MessageDigest")
+            .getInstance("SHA-256");
+        var digest = md.digest(fileReadBinary(arguments.filePath));
+        return lCase(
+            createObject("java", "java.util.HexFormat").of().formatHex(digest)
+        );
+    }
+
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add cli/src/models/BrowserService.cfc
+git commit -m "feat(cli): add BrowserService for JAR management
+
+Shared service for manifest reading, install verification, JAR download
+with SHA-256 verification. Used by browser:install and browser:test."
+```
+
+---
+
+## Task 10: CommandBox `wheels browser:install`
+
+**Files:**
+- Create: `cli/src/commands/wheels/browser/install.cfc`
+
+- [ ] **Step 1: Create the command**
+
+First verify the directory:
+```bash
+ls /Users/peter/GitHub/wheels-dev/wheels/cli/src/commands/wheels/
+mkdir -p /Users/peter/GitHub/wheels-dev/wheels/cli/src/commands/wheels/browser
+```
+
+Create `cli/src/commands/wheels/browser/install.cfc`:
+
+```cfm
+/**
+ * Install Playwright browser binaries for E2E testing.
+ *
+ * Downloads 7 JARs from Maven Central (Playwright client + driver +
+ * driver-bundle + transitive deps), verifies SHA-256 hashes, then
+ * installs browser binaries via the Playwright CLI.
+ *
+ * Examples:
+ *   wheels browser:install
+ *   wheels browser:install --force
+ *   wheels browser:install --browser=firefox
+ */
+component aliases="wheels browser:install, wheels browser install" extends="../../base" {
+
+    property name="browserService" inject="BrowserService@wheels-cli";
+
+    /**
+     * @force     Re-download JARs even if SHAs match
+     * @browser   Which browser to install (chromium, firefox, webkit)
+     */
+    function run(
+        boolean force = false,
+        string browser = "chromium"
+    ) {
+        var projectRoot = getCWD();
+        var manifest = {};
+        try {
+            manifest = browserService.getManifest(projectRoot);
+        } catch (any e) {
+            print.redLine("Error: " & e.message);
+            return;
+        }
+
+        var installDir = browserService.resolveInstallDir();
+        print.line("Install directory: " & installDir);
+        print.line("Playwright version: " & (manifest.playwrightJavaVersion ?: "unknown"));
+        print.line("");
+
+        // Download JARs
+        var downloaded = 0;
+        var skipped = 0;
+        for (var entry in manifest.classpath) {
+            var jarPath = installDir & "/lib/" & entry.filename;
+            var needsDownload = arguments.force;
+
+            if (!fileExists(jarPath)) {
+                needsDownload = true;
+            } else if (!arguments.force) {
+                var currentSha = browserService.sha256(jarPath);
+                if (currentSha != lCase(entry.sha256)) {
+                    print.yellowLine("  SHA mismatch: " & entry.filename & " — re-downloading");
+                    needsDownload = true;
+                }
+            }
+
+            if (needsDownload) {
+                print.text("  Downloading " & entry.filename & "...");
+                try {
+                    browserService.downloadJar(url=entry.url, targetPath=jarPath);
+                    // Verify SHA after download
+                    var sha = browserService.sha256(jarPath);
+                    if (sha != lCase(entry.sha256)) {
+                        print.redLine(" FAILED (SHA mismatch)");
+                        print.redLine("    Expected: " & lCase(entry.sha256));
+                        print.redLine("    Got:      " & sha);
+                        return;
+                    }
+                    print.greenLine(" OK");
+                    downloaded++;
+                } catch (any e) {
+                    print.redLine(" FAILED: " & e.message);
+                    return;
+                }
+            } else {
+                print.line("  " & chr(10003) & " " & entry.filename);
+                skipped++;
+            }
+        }
+
+        print.line("");
+        print.line("JARs: #downloaded# downloaded, #skipped# up-to-date");
+
+        // Install browser binaries
+        print.line("");
+        print.text("Installing #arguments.browser# browser binaries...");
+
+        var classpath = "";
+        for (var entry in manifest.classpath) {
+            if (len(classpath)) classpath &= (server.os.name contains "Windows" ? ";" : ":");
+            classpath &= installDir & "/lib/" & entry.filename;
+        }
+
+        try {
+            cfexecute(
+                name="java",
+                arguments="-cp #classpath# com.microsoft.playwright.CLI install #arguments.browser#",
+                timeout=300,
+                variable="local.stdout",
+                errorVariable="local.stderr"
+            );
+            print.greenLine(" OK");
+        } catch (any e) {
+            print.redLine(" FAILED");
+            print.redLine(local.stderr ?: e.message);
+            return;
+        }
+
+        print.line("");
+        print.greenLine("Browser testing ready. Run: wheels browser:test");
+    }
+
+}
+```
+
+- [ ] **Step 2: Test manually**
+
+```bash
+cd /Users/peter/GitHub/wheels-dev/wheels
+box reload
+box wheels browser:install
+```
+
+Expected: Downloads JARs (or shows checkmarks if already installed), installs Chromium.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cli/src/commands/wheels/browser/install.cfc
+git commit -m "feat(cli): add wheels browser:install command
+
+Downloads Playwright JARs with SHA-256 verification and installs
+browser binaries. Replaces tools/install-playwright.sh."
+```
+
+---
+
+## Task 11: CommandBox `wheels browser:test`
+
+**Files:**
+- Create: `cli/src/commands/wheels/browser/test.cfc`
+
+- [ ] **Step 1: Create the command**
+
+Create `cli/src/commands/wheels/browser/test.cfc`:
+
+```cfm
+/**
+ * Run browser-based E2E tests.
+ *
+ * Pre-flight checks that Playwright JARs are installed, then hits
+ * the test runner URL scoped to browser test specs.
+ *
+ * Examples:
+ *   wheels browser:test
+ *   wheels browser:test --verbose
+ *   wheels browser:test --format=json
+ */
+component aliases="wheels browser:test, wheels browser test" extends="../../base" {
+
+    property name="browserService" inject="BrowserService@wheels-cli";
+
+    /**
+     * @format    Output format: text or json
+     * @verbose   Show full spec names
+     * @directory Test directory (dot-notation, relative to vendor/wheels/)
+     */
+    function run(
+        string format = "text",
+        boolean verbose = false,
+        string directory = "wheels.tests.specs.wheelstest"
+    ) {
+        var projectRoot = getCWD();
+
+        // Pre-flight: verify JARs installed
+        try {
+            var manifest = browserService.getManifest(projectRoot);
+            var installDir = browserService.resolveInstallDir();
+            var status = browserService.verifyInstall(
+                manifest=manifest,
+                installDir=installDir
+            );
+            if (!status.installed) {
+                print.redLine("Playwright not installed.");
+                if (arrayLen(status.missing)) {
+                    print.yellowLine("Missing: " & arrayToList(status.missing, ", "));
+                }
+                if (arrayLen(status.mismatched)) {
+                    print.yellowLine("SHA mismatch: " & arrayToList(status.mismatched, ", "));
+                }
+                print.line("");
+                print.line("Run: wheels browser:install");
+                return;
+            }
+        } catch (any e) {
+            print.redLine("Error: " & e.message);
+            return;
+        }
+
+        print.line("Running browser tests...");
+        print.line("Directory: " & arguments.directory);
+        print.line("");
+
+        // Determine server URL
+        var serverInfo = command("server info").params(property="host").run(returnOutput=true);
+        var port = command("server info").params(property="port").run(returnOutput=true);
+        var host = trim(serverInfo) ?: "localhost";
+        var portNum = trim(port) ?: "8080";
+        var baseUrl = "http://#host#:#portNum#";
+
+        var testUrl = baseUrl
+            & "/wheels/core/tests?db=sqlite&format=json&directory="
+            & arguments.directory;
+
+        try {
+            cfhttp(url=testUrl, method="GET", timeout=300, result="local.response");
+        } catch (any e) {
+            print.redLine("Failed to reach test runner at: " & testUrl);
+            print.redLine("Is the server running? Try: server start");
+            return;
+        }
+
+        if (arguments.format == "json") {
+            print.line(local.response.fileContent);
+            return;
+        }
+
+        // Parse and display results
+        try {
+            var data = deserializeJSON(local.response.fileContent);
+            print.line("Pass: #data.totalPass#  Fail: #data.totalFail#  Error: #data.totalError#");
+            print.line("");
+
+            // Show failures
+            for (var bundle in (data.bundleStats ?: [])) {
+                for (var suite in (bundle.suiteStats ?: [])) {
+                    for (var spec in (suite.specStats ?: [])) {
+                        if (listFindNoCase("Failed,Error", spec.status ?: "")) {
+                            print.redLine(
+                                "  " & (spec.status ?: "") & ": "
+                                & (spec.name ?: "unknown")
+                            );
+                            if (arguments.verbose && len(spec.failMessage ?: "")) {
+                                print.line("    " & left(spec.failMessage, 200));
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (data.totalFail == 0 && data.totalError == 0) {
+                print.greenLine("All browser tests passed.");
+            }
+        } catch (any e) {
+            print.redLine("Failed to parse test results: " & e.message);
+            if (arguments.verbose) {
+                print.line(left(local.response.fileContent ?: "", 500));
+            }
+        }
+    }
+
+}
+```
+
+- [ ] **Step 2: Test manually**
+
+```bash
+box reload
+box wheels browser:test
+box wheels browser:test --verbose
+box wheels browser:test --format=json
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cli/src/commands/wheels/browser/test.cfc
+git commit -m "feat(cli): add wheels browser:test command
+
+Pre-flight JAR verification, then runs browser test directory via
+the test runner URL. Supports text/json output and verbose mode."
+```
+
+---
+
+## Task 12: LuCLI `browser` Subcommand
+
+**Files:**
+- Modify: `cli/lucli/Module.cfc`
+
+- [ ] **Step 1: Add `browser()` public function**
+
+Find the end of the existing public functions in `Module.cfc` (after the last `public string function`) and add:
+
+```cfm
+// ─────────────────────────────────────────────────
+//  browser — Browser testing management
+// ─────────────────────────────────────────────────
+
+/**
+ * hint: Browser testing commands (install, test)
+ */
+public string function browser() {
+    var args = getArgs(arguments);
+
+    if (!arrayLen(args)) {
+        out("Usage: wheels browser <command>", "yellow");
+        out("");
+        out("Commands:", "bold");
+        out("  install  Download Playwright JARs and browser binaries");
+        out("  test     Run browser test suite");
+        out("");
+        out("Examples:", "bold");
+        out("  wheels browser install");
+        out("  wheels browser install --force");
+        out("  wheels browser test");
+        out("  wheels browser test --verbose");
+        return "";
+    }
+
+    var subcommand = lCase(args[1]);
+
+    switch (subcommand) {
+        case "install":
+            return browserInstall(args);
+        case "test":
+            return browserTest(args);
+        default:
+            out("Unknown browser command: #subcommand#", "red");
+            out("Valid commands: install, test");
+            return "";
+    }
+}
+```
+
+- [ ] **Step 2: Add `browserInstall()` private method**
+
+```cfm
+/**
+ * Download Playwright JARs and install browser binaries.
+ */
+private string function browserInstall(array args = []) {
+    var force = false;
+    var browserName = "chromium";
+    for (var arg in arguments.args) {
+        if (arg == "--force") force = true;
+        if (left(arg, 10) == "--browser=") browserName = mid(arg, 11, len(arg));
+    }
+
+    var manifestPath = variables.projectRoot & "/vendor/wheels/browser-manifest.json";
+    if (!fileExists(manifestPath)) {
+        out("browser-manifest.json not found at: #manifestPath#", "red");
+        return "";
+    }
+    var manifest = deserializeJSON(fileRead(manifestPath));
+
+    var installDir = $resolveBrowserInstallDir();
+    out("Install directory: #installDir#");
+    out("Playwright version: #manifest.playwrightJavaVersion ?: 'unknown'#");
+    out("");
+
+    var libDir = installDir & "/lib";
+    if (!directoryExists(libDir)) directoryCreate(libDir, true);
+
+    var downloaded = 0;
+    var skipped = 0;
+    for (var entry in manifest.classpath) {
+        var jarPath = libDir & "/" & entry.filename;
+        var needsDownload = force;
+
+        if (!fileExists(jarPath)) {
+            needsDownload = true;
+        } else if (!force && $sha256(jarPath) != lCase(entry.sha256)) {
+            out("  SHA mismatch: #entry.filename# - re-downloading", "yellow");
+            needsDownload = true;
+        }
+
+        if (needsDownload) {
+            out("  Downloading #entry.filename#...", "");
+            try {
+                cfhttp(url=entry.url, method="GET", getAsBinary="yes", timeout=300, result="local.dl");
+                if (!findNoCase("200", local.dl.statusCode)) {
+                    out(" FAILED (HTTP #local.dl.statusCode#)", "red");
+                    return "";
+                }
+                fileWrite(jarPath, local.dl.fileContent);
+                if ($sha256(jarPath) != lCase(entry.sha256)) {
+                    out(" FAILED (SHA mismatch after download)", "red");
+                    return "";
+                }
+                out("  #entry.filename# OK", "green");
+                downloaded++;
+            } catch (any e) {
+                out(" FAILED: #e.message#", "red");
+                return "";
+            }
+        } else {
+            out("  #chr(10003)# #entry.filename#");
+            skipped++;
+        }
+    }
+
+    out("");
+    out("JARs: #downloaded# downloaded, #skipped# up-to-date");
+
+    // Install browser
+    out("");
+    out("Installing #browserName# browser binaries...");
+    var cp = "";
+    for (var entry in manifest.classpath) {
+        if (len(cp)) cp &= ":";
+        cp &= libDir & "/" & entry.filename;
+    }
+    try {
+        cfexecute(
+            name="java",
+            arguments="-cp #cp# com.microsoft.playwright.CLI install #browserName#",
+            timeout=300,
+            variable="local.stdout",
+            errorVariable="local.stderr"
+        );
+        out("Browser install complete.", "green");
+    } catch (any e) {
+        out("Browser install failed: #local.stderr ?: e.message#", "red");
+        return "";
+    }
+
+    out("");
+    out("Browser testing ready. Run: wheels browser test", "green");
+    return "";
+}
+```
+
+- [ ] **Step 3: Add `browserTest()` private method**
+
+```cfm
+/**
+ * Run browser test suite.
+ */
+private string function browserTest(array args = []) {
+    var format = "text";
+    var verboseOutput = false;
+    var directory = "wheels.tests.specs.wheelstest";
+    for (var arg in arguments.args) {
+        if (arg == "--verbose") verboseOutput = true;
+        if (arg == "--json" || arg == "--format=json") format = "json";
+        if (left(arg, 12) == "--directory=") directory = mid(arg, 13, len(arg));
+    }
+
+    // Pre-flight: check JARs
+    var manifestPath = variables.projectRoot & "/vendor/wheels/browser-manifest.json";
+    if (!fileExists(manifestPath)) {
+        out("browser-manifest.json not found.", "red");
+        return "";
+    }
+    var manifest = deserializeJSON(fileRead(manifestPath));
+    var installDir = $resolveBrowserInstallDir();
+    for (var entry in manifest.classpath) {
+        if (!fileExists(installDir & "/lib/" & entry.filename)) {
+            out("Playwright not installed. Missing: #entry.filename#", "red");
+            out("Run: wheels browser install");
+            return "";
+        }
+    }
+
+    // Resolve server URL
+    var port = $getServerPort();
+    var testUrl = "http://localhost:#port#/wheels/core/tests?db=sqlite&format=json&directory=#directory#";
+
+    out("Running browser tests...");
+    out("URL: #testUrl#");
+    out("");
+
+    try {
+        cfhttp(url=testUrl, method="GET", timeout=300, result="local.response");
+    } catch (any e) {
+        out("Failed to reach test runner. Is the server running?", "red");
+        return "";
+    }
+
+    if (format == "json") {
+        out(local.response.fileContent);
+        return "";
+    }
+
+    try {
+        var data = deserializeJSON(local.response.fileContent);
+        out("Pass: #data.totalPass#  Fail: #data.totalFail#  Error: #data.totalError#");
+        out("");
+
+        for (var bundle in (data.bundleStats ?: [])) {
+            for (var suite in (bundle.suiteStats ?: [])) {
+                for (var spec in (suite.specStats ?: [])) {
+                    if (listFindNoCase("Failed,Error", spec.status ?: "")) {
+                        out("  #spec.status ?: ''#: #spec.name ?: 'unknown'#", "red");
+                        if (verboseOutput && len(spec.failMessage ?: "")) {
+                            out("    #left(spec.failMessage, 200)#");
+                        }
+                    }
+                }
+            }
+        }
+
+        if (data.totalFail == 0 && data.totalError == 0) {
+            out("All browser tests passed.", "green");
+        }
+    } catch (any e) {
+        out("Failed to parse results: #e.message#", "red");
+    }
+    return "";
+}
+```
+
+- [ ] **Step 4: Add helper methods**
+
+Add these private helpers to `Module.cfc` (near other private helpers):
+
+```cfm
+private string function $resolveBrowserInstallDir() {
+    var envHome = "";
+    try {
+        envHome = createObject("java", "java.lang.System")
+            .getenv("WHEELS_BROWSER_HOME") ?: "";
+    } catch (any e) {}
+    if (len(trim(envHome))) return envHome;
+    var home = createObject("java", "java.lang.System").getProperty("user.home");
+    return home & "/.wheels/browser";
+}
+
+private string function $sha256(required string filePath) {
+    var md = createObject("java", "java.security.MessageDigest")
+        .getInstance("SHA-256");
+    var digest = md.digest(fileReadBinary(arguments.filePath));
+    return lCase(
+        createObject("java", "java.util.HexFormat").of().formatHex(digest)
+    );
+}
+
+private string function $getServerPort() {
+    // Check for running LuCLI server port
+    try {
+        if (
+            structKeyExists(server, "lucli")
+            && structKeyExists(server.lucli, "port")
+        ) {
+            return server.lucli.port;
+        }
+    } catch (any e) {}
+    return "8080";
+}
+```
+
+- [ ] **Step 5: Test manually**
+
+```bash
+wheels browser install
+wheels browser test
+wheels browser test --verbose
+wheels browser test --json
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/lucli/Module.cfc
+git commit -m "feat(cli): add LuCLI browser subcommand dispatch
+
+wheels browser install — download JARs + browser binaries
+wheels browser test — run browser test suite with pre-flight check"
+```
+
+---
+
+## Task 13: Deprecation Notice + Docs Update
+
+**Files:**
+- Modify: `tools/install-playwright.sh`
+- Modify: `.ai/wheels/testing/browser-testing.md`
+
+- [ ] **Step 1: Add deprecation notice to install script**
+
+Add after the shebang line in `tools/install-playwright.sh`:
+
+```bash
+echo ""
+echo "⚠  DEPRECATED: This script is replaced by 'wheels browser:install'."
+echo "   This script still works but will be removed in a future release."
+echo ""
+```
+
+- [ ] **Step 2: Update browser-testing.md**
+
+Update the Installation section to show `wheels browser:install` as primary:
+
+```markdown
+## Installation
+
+```bash
+wheels browser:install              # recommended (LuCLI or CommandBox)
+bash tools/install-playwright.sh    # legacy fallback (deprecated)
+```
+```
+
+Add new sections documenting:
+
+**Cookies:**
+```markdown
+### Cookies
+
+```cfm
+this.browser
+    .setCookie(name="session", value="abc123", url="http://localhost:8080")
+    .deleteCookie("session");
+
+var c = this.browser.cookie("session");  // returns struct {name, value, domain, ...}
+```
+
+Cookies require a real HTTP origin — `data:` URLs are opaque origins.
+```
+
+**Configurable Timeouts:**
+```markdown
+### Configurable Timeouts
+
+```cfm
+this.browser
+    .waitFor("##late-element", 5)      // 5-second timeout (default: 30)
+    .waitForText("Loaded", 10)
+    .waitForUrl("**/dashboard", 5);
+```
+```
+
+**Screenshot Options:**
+```markdown
+### Screenshot Options
+
+```cfm
+this.browser.screenshot("/tmp/page.png");                           // basic
+this.browser.screenshot(path="/tmp/full.png", fullPage=true);       // full page
+this.browser.screenshot(path="/tmp/q.png", quality=80);             // JPEG quality
+```
+```
+
+**Viewport Config:**
+```markdown
+### Viewport Config (BrowserTest Level)
+
+```cfm
+component extends="wheels.wheelstest.BrowserTest" {
+    this.browserViewport = "mobile";           // preset: mobile/tablet/desktop
+    // or: this.browserViewport = {width: 1024, height: 768};
+```
+```
+
+**Auto-Screenshot on Failure:**
+```markdown
+### Auto-Screenshot on Failure
+
+When a browser test fails, a screenshot and HTML dump are automatically saved to `tests/_output/browser/`. Disable per-spec:
+
+```cfm
+this.browserScreenshotOnFailure = false;
+```
+
+Configure artifact directory:
+```cfm
+this.browserArtifactPath = expandPath("/custom/path");
+```
+```
+
+**CLI Commands:**
+```markdown
+## CLI Commands
+
+```bash
+wheels browser:install              # download JARs + browser binaries
+wheels browser:install --force      # re-download even if SHAs match
+wheels browser:install --browser=firefox
+
+wheels browser:test                 # run browser test suite
+wheels browser:test --verbose       # show full spec names
+wheels browser:test --format=json   # JSON output for CI
+```
+```
+
+Update the "Deferred functionality" table — move implemented items out and mark them as shipped.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/install-playwright.sh .ai/wheels/testing/browser-testing.md
+git commit -m "docs(test): update browser testing docs and deprecate install script
+
+Document new DSL methods (cookies, timeouts, waitForUrl, screenshot
+options, viewport config), CLI commands, and auto-screenshot. Mark
+tools/install-playwright.sh as deprecated."
+```
+
+---
+
+## Final Verification
+
+- [ ] **Run full test suite**
+
+```bash
+bash tools/test-local.sh
+```
+
+Expected: all tests pass (browser tests included if Playwright installed, skipped otherwise).
+
+- [ ] **Run browser-specific tests**
+
+```bash
+curl -sf "http://localhost:8080/wheels/core/tests?db=sqlite&format=json&directory=wheels.tests.specs.wheelstest" | python3 -c "
+import json,sys; d=json.load(sys.stdin)
+print(f'{d[\"totalPass\"]} pass, {d[\"totalFail\"]} fail, {d[\"totalError\"]} error')
+for b in d.get('bundleStats',[]):
+  for s in b.get('suiteStats',[]):
+    for sp in s.get('specStats',[]):
+      if sp.get('status') in ('Failed','Error'):
+        print(f'  {sp[\"status\"]}: {sp[\"name\"]}: {sp.get(\"failMessage\",\"\")[:120]}')
+"
+```
+
+Expected: 0 fail, 0 error. New tests bring the browser spec count from ~62 to ~80+.
+
+- [ ] **Test CLI commands**
+
+```bash
+wheels browser install
+wheels browser test
+```
+
+- [ ] **Verify no regressions in non-browser tests**
+
+```bash
+bash tools/test-local.sh model
+bash tools/test-local.sh controller
+```

--- a/docs/superpowers/specs/2026-04-15-browser-testing-pr2-design.md
+++ b/docs/superpowers/specs/2026-04-15-browser-testing-pr2-design.md
@@ -1,0 +1,236 @@
+# Browser Testing PR 2 — CLI + Deferred DSL Methods
+
+**Date:** 2026-04-15
+**Status:** Approved
+**Prereq:** PR 1 merged as #2113 (foundation — BrowserLauncher, BrowserClient, BrowserTest, install script, 62 specs)
+
+## Scope
+
+PR 2 delivers three themes:
+1. `$buildOption` reflection helper + all DSL methods it unblocks
+2. CLI commands (`wheels browser:install`, `wheels browser:test`)
+3. Auto-screenshot/HTML dump on test failure
+
+Deferred to PR 3: loginAs/logout, fixture-server bootstrap, dialogs (`createDynamicProxy`), visitRoute/assertRouteIs.
+
+## 1. `$buildOption` Reflection Helper
+
+### Location
+
+`BrowserLauncher.cfc` — new public method.
+
+### Signature
+
+```cfm
+public any function $buildOption(required string className, struct setterMap = {})
+```
+
+### Behavior
+
+1. Load class via `variables.$classLoader.loadClass(className)`
+2. Call `getDeclaredConstructor().newInstance()` (all Playwright option classes have zero-arg constructors)
+3. Iterate `setterMap`: for each key (setter name) + value, find the setter method on the class, auto-cast the value to match the setter's parameter type, invoke it
+4. Return the constructed option object
+
+### Type Casting
+
+Auto-detect from setter's `getParameterTypes()[1]`:
+- `java.lang.Double` / `double` → `javaCast("double", value)`
+- `java.lang.Boolean` / `boolean` → `javaCast("boolean", value)`
+- `java.lang.Integer` / `int` → `javaCast("int", value)`
+- `java.lang.String` → `javaCast("string", value)`
+- Anything else (including Java objects from nested `$buildOption` calls) → pass through untouched
+
+### TCCL
+
+Not needed. `loadClass()` + `newInstance()` + setter calls don't trigger Playwright's driver resource lookup. TCCL is only required for `Playwright.create()` and `BrowserType.launch()`.
+
+### Error Handling
+
+Wraps reflection failures in `Wheels.BrowserOptionError` with class name + setter name for debuggability.
+
+### Tests
+
+- Unit tests using a known JDK class to verify reflection mechanics
+- Integration tests building real Playwright option objects (guarded by JAR-present skip logic)
+
+## 2. Deferred DSL Methods
+
+Each method lives in `BrowserClient.cfc`. A `variables.$launcher` field is added, set during `init()` (BrowserTest already has the launcher in scope when creating the client).
+
+### 2.1 Cookies
+
+```cfm
+setCookie(name, value, url)  → BrowserClient (chainable)
+deleteCookie(name)           → BrowserClient (chainable)
+cookie(name)                 → struct {name, value, domain, path, ...}
+```
+
+- `setCookie`: builds `com.microsoft.playwright.options.Cookie` via `$buildOption`, calls `context.addCookies(List.of(cookie))`
+- `deleteCookie`: builds `BrowserContext$ClearCookiesOptions` with name filter (available since Playwright 1.43), calls `context.clearCookies(options)`
+- `cookie`: calls `context.cookies()`, iterates returned `List<Cookie>` to find by name, returns struct with cookie properties. Throws `Wheels.BrowserAssertionFailed` if not found.
+
+Cookies require a real HTTP origin (not `data:` URLs). Tests for these methods need either the fixture server (PR 3) or a minimal inline HTTP server. If too complex, tests can use `visitUrl("about:blank")` + JavaScript `document.cookie` as a workaround for basic coverage, with full HTTP-based tests deferred to PR 3.
+
+### 2.2 Configurable Timeouts
+
+Update existing `waitFor(selector, seconds)` and `waitForText(text, seconds)`:
+- When `seconds != 30` (non-default): build `Locator$WaitForOptions` via `$buildOption({setTimeout: seconds * 1000})`, call `waitFor(options)`
+- When `seconds == 30`: use zero-arg overload (fast path, no reflection)
+
+### 2.3 waitForUrl
+
+```cfm
+waitForUrl(url, seconds=30)  → BrowserClient (chainable)
+```
+
+Builds `Page$WaitForURLOptions` with timeout via `$buildOption`. Calls `page.waitForURL(url, options)`. Supports exact URL strings and glob patterns (Playwright native).
+
+### 2.4 Screenshot Options
+
+Update existing `screenshot(path)`:
+
+```cfm
+screenshot(path, fullPage=false, quality=0)
+```
+
+When non-default options are passed, builds `Page$ScreenshotOptions` via `$buildOption`. Zero-arg fast path preserved when only `path` is given with defaults.
+
+### 2.5 Viewport Config at BrowserTest Level
+
+New property on spec CFCs:
+
+```cfm
+this.browserViewport = "mobile";          // preset
+this.browserViewport = {width: 1024, height: 768};  // custom
+```
+
+`BrowserTest.$startBrowserContext()` reads `this.browserViewport`. If set:
+1. Build `ViewportSize` via `$buildOption` with width/height
+2. Build `Browser$NewContextOptions` via `$buildOption` with `{setViewportSize: viewportObj}`
+3. Pass options to `browser.newContext(options)` instead of zero-arg overload
+
+Presets: `"mobile"` (375x667), `"tablet"` (768x1024), `"desktop"` (1440x900).
+
+### 2.6 Not in PR 2
+
+| Feature | Reason | Target |
+|---------|--------|--------|
+| Dialogs (acceptDialog, dismissDialog, typeInDialog) | Needs `createDynamicProxy` for `Consumer<Dialog>` | PR 3 |
+| loginAs / logout | Needs fixture server + test-only routes | PR 3 |
+| visitRoute / assertRouteIs | Needs `urlFor` outside controller context | PR 3 |
+
+## 3. CLI Commands
+
+### 3.1 `wheels browser:install`
+
+Replaces `tools/install-playwright.sh` with a framework-native command.
+
+**CommandBox:** `cli/src/commands/wheels/browser/install.cfc` extending `../base`
+**LuCLI:** `public string function browser()` on `Module.cfc` dispatching `install` subcommand to private `browserInstall(args)`
+
+**Behavior:**
+1. Read `vendor/wheels/browser-manifest.json`
+2. Resolve install dir (env var `WHEELS_BROWSER_HOME` or `~/.wheels/browser`)
+3. For each JAR in `classpath[]`: check if exists + SHA matches → skip; otherwise download via `cfhttp`/`curl`, verify SHA256 via `java.security.MessageDigest`
+4. Run `java -cp <jars> com.microsoft.playwright.CLI install <browser>`
+5. Print summary
+
+**Flags:**
+- `--force` — re-download even if SHAs match
+- `--browser=chromium` — which browser (default: chromium)
+
+**`tools/install-playwright.sh`:** Kept as fallback, deprecation notice added pointing to `wheels browser:install`.
+
+### 3.2 `wheels browser:test`
+
+Runs browser test directory with proper setup.
+
+**CommandBox:** `cli/src/commands/wheels/browser/test.cfc`
+**LuCLI:** Private `browserTest(args)` dispatched from `browser()`
+
+**Behavior:**
+1. Pre-flight: verify Playwright JARs installed. If missing, print helpful message and exit.
+2. Hit test runner URL with `directory=wheels.tests.specs.wheelstest` (or user-specified) and `format=json`
+3. Parse results, print summary
+
+**Flags:**
+- `--filter=<pattern>` — filter spec names
+- `--format=json|text` — output format
+- `--verbose` — full spec names
+
+### 3.3 Shared Service
+
+JAR download + SHA logic lives in `cli/src/models/BrowserService.cfc` (CommandBox) so both `install` and `test` (pre-flight) reuse it. LuCLI inlines the logic in Module.cfc private methods (no WireBox DI).
+
+## 4. Auto-Screenshot + HTML Dump on Failure
+
+### Mechanism
+
+`browserDescribe()` registers an `aroundEach` hook alongside the existing `beforeEach`/`afterEach`:
+
+```
+aroundEach flow:
+  1. beforeEach (creates context/page/client) — unchanged
+  2. aroundEach:
+     try { spec.body(data=arguments.data) }
+     catch (any e) { capture screenshot + HTML; rethrow }
+  3. afterEach (closes context) — unchanged
+```
+
+Rethrow preserves TestBox's normal failure reporting. Capture is additive.
+
+### Artifact Output
+
+- **Directory:** `tests/_output/browser/` (convention, created on first failure)
+- **Configurable via:** `this.browserArtifactPath` on the spec CFC
+- **Naming:** `<specName>-<timestamp>.png` and `<specName>-<timestamp>.html`
+- **Spec name sanitized:** non-alphanumeric → underscore, truncated to 80 chars
+
+### Guards
+
+- Only captures if `this.browser` is populated and page is alive
+- Nested try/catch around capture itself — swallows failures silently (don't mask real test failure)
+- Checks `browserTestSkipped` flag — no capture when Playwright not installed
+
+### Opt-out
+
+```cfm
+this.browserScreenshotOnFailure = false;  // default: true
+```
+
+## File Inventory
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `cli/src/commands/wheels/browser/install.cfc` | CommandBox browser:install command |
+| `cli/src/commands/wheels/browser/test.cfc` | CommandBox browser:test command |
+| `cli/src/models/BrowserService.cfc` | Shared JAR download + SHA verification |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `vendor/wheels/wheelstest/BrowserLauncher.cfc` | Add `$buildOption()` |
+| `vendor/wheels/wheelstest/BrowserClient.cfc` | Add cookies, waitForUrl, update waitFor/waitForText/screenshot; accept `$launcher` in init |
+| `vendor/wheels/wheelstest/BrowserTest.cfc` | Add `aroundEach` failure capture, viewport config, pass launcher to BrowserClient |
+| `cli/lucli/Module.cfc` | Add `browser()` public function with install/test dispatch |
+| `tools/install-playwright.sh` | Add deprecation notice |
+| `vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc` | Tests for `$buildOption` |
+| `vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc` | Tests for new DSL methods |
+| `vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc` | Tests for auto-screenshot, viewport config |
+
+### Untouched
+
+| File | Why |
+|------|-----|
+| `browser-manifest.json` | No version bump needed |
+| `vendor/wheels/tests/fixtures/browserapp/` | Expanded in PR 3 (loginAs, fixture server) |
+
+## Unresolved Questions
+
+1. **Cookie tests without fixture server** — can we get meaningful coverage with `about:blank` + `document.cookie`, or should we defer cookie tests to PR 3 when the fixture server lands?
+2. **`aroundEach` + TestBox compatibility** — need to verify `aroundEach` works inside a dynamically-registered describe body (same pattern as beforeEach/afterEach in `browserDescribe`). If not, fallback is wrapping in afterEach with a caught-error flag.
+3. **`BrowserContext$ClearCookiesOptions`** — need to verify the exact inner-class path in Playwright 1.52. If the API changed, `deleteCookie` may need to clear-all + re-add others.

--- a/tools/install-playwright.sh
+++ b/tools/install-playwright.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+echo ""
+echo "NOTE: This script is replaced by 'wheels browser:install'."
+echo "      This script still works but will be removed in a future release."
+echo ""
 # Temporary bootstrap for browser testing. Replaced by `wheels browser:install`
 # once PR 2 lands. Reads vendor/wheels/browser-manifest.json for pinned versions.
 #

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -54,6 +54,17 @@ component extends="wheels.WheelsTest" {
             });
         });
 
+        describe("BrowserClient — launcher wiring", () => {
+
+            it("exposes launcher via getLauncher()", () => {
+                if (variables.skipBrowserTests) return;
+                var bc = new wheels.wheelstest.BrowserClient()
+                    .init(baseUrl="", launcher=variables.launcher);
+                expect(isObject(bc.getLauncher())).toBeTrue();
+                expect(bc.getLauncher().getState()).toBe("ready");
+            });
+        });
+
         describe("BrowserClient — navigation against real Chromium (data: URLs)", () => {
 
             // data: URLs avoid needing a fixture server; still exercises real
@@ -116,7 +127,7 @@ component extends="wheels.WheelsTest" {
                 variables.ctx = variables.browser.newContext();
                 variables.pg = variables.ctx.newPage();
                 variables.bc = new wheels.wheelstest.BrowserClient()
-                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="", launcher=variables.launcher);
             });
 
             afterEach(() => {
@@ -189,7 +200,7 @@ component extends="wheels.WheelsTest" {
                 variables.ctx = variables.browser.newContext();
                 variables.pg = variables.ctx.newPage();
                 variables.bc = new wheels.wheelstest.BrowserClient()
-                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="", launcher=variables.launcher);
             });
 
             afterEach(() => {
@@ -266,7 +277,7 @@ component extends="wheels.WheelsTest" {
                 variables.ctx = variables.browser.newContext();
                 variables.pg = variables.ctx.newPage();
                 variables.bc = new wheels.wheelstest.BrowserClient()
-                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="", launcher=variables.launcher);
             });
 
             afterEach(() => {
@@ -318,7 +329,7 @@ component extends="wheels.WheelsTest" {
                 variables.ctx = variables.browser.newContext();
                 variables.pg = variables.ctx.newPage();
                 variables.bc = new wheels.wheelstest.BrowserClient()
-                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="", launcher=variables.launcher);
             });
 
             afterEach(() => {
@@ -375,7 +386,7 @@ component extends="wheels.WheelsTest" {
                 variables.ctx = variables.browser.newContext();
                 variables.pg = variables.ctx.newPage();
                 variables.bc = new wheels.wheelstest.BrowserClient()
-                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="", launcher=variables.launcher);
             });
 
             afterEach(() => {
@@ -421,7 +432,7 @@ component extends="wheels.WheelsTest" {
                 variables.ctx = variables.browser.newContext();
                 variables.pg = variables.ctx.newPage();
                 variables.bc = new wheels.wheelstest.BrowserClient()
-                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="", launcher=variables.launcher);
             });
 
             afterEach(() => {
@@ -505,7 +516,7 @@ component extends="wheels.WheelsTest" {
                 variables.ctx = variables.browser.newContext();
                 variables.pg = variables.ctx.newPage();
                 variables.bc = new wheels.wheelstest.BrowserClient()
-                    .init(page=variables.pg, context=variables.ctx, baseUrl="");
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="", launcher=variables.launcher);
             });
 
             afterEach(() => {

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -553,6 +553,19 @@ component extends="wheels.WheelsTest" {
                     if (fileExists(tmpPath)) fileDelete(tmpPath);
                 }
             });
+
+            it("screenshot with fullPage option writes a PNG file", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<div style='height:2000px'>Tall page</div>");
+                var tmpPath = getTempDirectory() & "wheels-bc-fullpage-" & createUUID() & ".png";
+                try {
+                    variables.bc.screenshot(path=tmpPath, fullPage=true);
+                    expect(fileExists(tmpPath)).toBeTrue();
+                    expect(getFileInfo(tmpPath).size).toBeGT(0);
+                } finally {
+                    if (fileExists(tmpPath)) fileDelete(tmpPath);
+                }
+            });
         });
 
         describe("BrowserClient — additional negative-path + coverage gaps", () => {

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -286,6 +286,36 @@ component extends="wheels.WheelsTest" {
             });
         });
 
+        describe("BrowserClient — waitForUrl", () => {
+
+            beforeEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx = variables.browser.newContext();
+                variables.pg = variables.ctx.newPage();
+                variables.bc = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl="", launcher=variables.launcher);
+            });
+
+            afterEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx.close();
+            });
+
+            it("resolves immediately when URL already matches", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>Here</h1>");
+                variables.bc.waitForUrl("data:text/html,*", 5);
+            });
+
+            it("throws on timeout when URL does not match", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>Here</h1>");
+                expect(() => {
+                    variables.bc.waitForUrl("http://will-never-match.example.com/**", 1);
+                }).toThrow();
+            });
+        });
+
         describe("BrowserClient — viewport + script", () => {
 
             beforeEach(() => {

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -255,6 +255,22 @@ component extends="wheels.WheelsTest" {
                 expect(variables.pg.locator("##root").textContent()).toBe("Delayed Text");
             });
 
+            it("waitFor honors custom timeout (short timeout fails on missing element)", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>No target here</h1>");
+                expect(() => {
+                    variables.bc.waitFor("##never-exists", 1);
+                }).toThrow();
+            });
+
+            it("waitForText honors custom timeout (short timeout fails on missing text)", () => {
+                if (variables.skipBrowserTests) return;
+                variables.bc.visitUrl("data:text/html,<h1>Hello</h1>");
+                expect(() => {
+                    variables.bc.waitForText("never appears", 1);
+                }).toThrow();
+            });
+
             it("within(selector, callback) scopes interactions to a subtree", () => {
                 if (variables.skipBrowserTests) return;
                 // Two forms with same-id inputs. within() should restrict

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -303,8 +303,11 @@ component extends="wheels.WheelsTest" {
 
             it("resolves immediately when URL already matches", () => {
                 if (variables.skipBrowserTests) return;
-                variables.bc.visitUrl("data:text/html,<h1>Here</h1>");
-                variables.bc.waitForUrl("data:text/html,*", 5);
+                var targetUrl = "data:text/html,<h1>Here</h1>";
+                variables.bc.visitUrl(targetUrl);
+                // Use the exact URL rather than a glob — data: URLs don't
+                // follow path-based glob conventions.
+                variables.bc.waitForUrl(variables.bc.currentUrl(), 5);
             });
 
             it("throws on timeout when URL does not match", () => {

--- a/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserIntegrationSpec.cfc
@@ -663,5 +663,75 @@ component extends="wheels.WheelsTest" {
                 expect(variables.pg.locator("##o").textContent()).toBe("ESC");
             });
         });
+
+        describe("BrowserClient — cookies", () => {
+
+            // Cookie operations require a real HTTP origin — data: URLs do not
+            // support cookies. We detect the test server at http://localhost and
+            // the port from CGI or default to 8080. Tests skip if no server is
+            // reachable.
+
+            beforeEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx = variables.browser.newContext();
+                variables.pg = variables.ctx.newPage();
+                // Detect the test server port from CGI (the request that runs
+                // this spec is itself served by the test server).
+                var testPort = cgi.server_port ?: "8080";
+                variables.testBaseUrl = "http://localhost:" & testPort;
+                variables.bc = new wheels.wheelstest.BrowserClient()
+                    .init(page=variables.pg, context=variables.ctx, baseUrl=variables.testBaseUrl, launcher=variables.launcher);
+            });
+
+            afterEach(() => {
+                if (variables.skipBrowserTests) return;
+                variables.ctx.close();
+            });
+
+            it("setCookie sets a cookie and cookie() reads it back", () => {
+                if (variables.skipBrowserTests) return;
+                var testUrl = variables.bc.getBaseUrl();
+                if (!len(testUrl)) return;
+                variables.bc.visitUrl(testUrl);
+                variables.bc.setCookie(name="testCookie", value="hello123", url=testUrl);
+                var c = variables.bc.cookie("testCookie");
+                expect(c.name).toBe("testCookie");
+                expect(c.value).toBe("hello123");
+            });
+
+            it("deleteCookie removes a specific cookie", () => {
+                if (variables.skipBrowserTests) return;
+                var testUrl = variables.bc.getBaseUrl();
+                if (!len(testUrl)) return;
+                variables.bc.visitUrl(testUrl);
+                variables.bc.setCookie(name="toDelete", value="bye", url=testUrl);
+                var c = variables.bc.cookie("toDelete");
+                expect(c.value).toBe("bye");
+                variables.bc.deleteCookie("toDelete");
+                expect(() => {
+                    variables.bc.cookie("toDelete");
+                }).toThrow("Wheels.BrowserAssertionFailed");
+            });
+
+            it("cookie() throws when cookie not found", () => {
+                if (variables.skipBrowserTests) return;
+                var testUrl = variables.bc.getBaseUrl();
+                if (!len(testUrl)) return;
+                variables.bc.visitUrl(testUrl);
+                expect(() => {
+                    variables.bc.cookie("nonexistent_cookie_xyz");
+                }).toThrow("Wheels.BrowserAssertionFailed");
+            });
+
+            it("setCookie is chainable", () => {
+                if (variables.skipBrowserTests) return;
+                var testUrl = variables.bc.getBaseUrl();
+                if (!len(testUrl)) return;
+                variables.bc.visitUrl(testUrl);
+                var result = variables.bc.setCookie(name="chain1", value="a", url=testUrl)
+                    .setCookie(name="chain2", value="b", url=testUrl);
+                expect(result).toBeInstanceOf("wheels.wheelstest.BrowserClient");
+            });
+        });
     }
 }

--- a/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
@@ -239,6 +239,26 @@ component extends="wheels.WheelsTest" {
         });
 
         describe("$buildOption", () => {
+            var skipOptionTests = false;
+            var optLauncher = "";
+
+            beforeEach(() => {
+                optLauncher = new wheels.wheelstest.BrowserLauncher();
+                var paths = optLauncher.$classpathJarPaths(installDir=optLauncher.resolveInstallDir());
+                for (var p in paths) {
+                    if (!fileExists(p)) {
+                        skipOptionTests = true;
+                        return;
+                    }
+                }
+                optLauncher.$loadJars(jarPaths=paths);
+            });
+
+            afterEach(() => {
+                if (isObject(optLauncher) && optLauncher.getState() == "ready") {
+                    optLauncher.release();
+                }
+            });
 
             it("throws BrowserOptionError when classloader not initialized", () => {
                 var freshLauncher = new wheels.wheelstest.BrowserLauncher();
@@ -248,88 +268,46 @@ component extends="wheels.WheelsTest" {
             });
 
             it("builds a zero-arg Playwright option with setters", () => {
-                var l = new wheels.wheelstest.BrowserLauncher();
-                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
-                for (var p in paths) {
-                    if (!fileExists(p)) return;
-                }
-                l.$loadJars(jarPaths=paths);
-                try {
-                    var opts = l.$buildOption(
-                        className="com.microsoft.playwright.Locator$WaitForOptions",
-                        setterMap={setTimeout: 5000}
-                    );
-                    expect(isObject(opts)).toBeTrue();
-                } finally {
-                    l.release();
-                }
+                if (skipOptionTests) return;
+                var opts = optLauncher.$buildOption(
+                    className="com.microsoft.playwright.Locator$WaitForOptions",
+                    setterMap={setTimeout: 5000}
+                );
+                expect(isObject(opts)).toBeTrue();
             });
 
             it("builds an option with constructor args", () => {
-                var l = new wheels.wheelstest.BrowserLauncher();
-                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
-                for (var p in paths) {
-                    if (!fileExists(p)) return;
-                }
-                l.$loadJars(jarPaths=paths);
-                try {
-                    var viewport = l.$buildOption(
-                        className="com.microsoft.playwright.options.ViewportSize",
-                        constructorArgs=[375, 667]
-                    );
-                    expect(isObject(viewport)).toBeTrue();
-                    expect(viewport.width).toBe(375);
-                    expect(viewport.height).toBe(667);
-                } finally {
-                    l.release();
-                }
+                if (skipOptionTests) return;
+                var viewport = optLauncher.$buildOption(
+                    className="com.microsoft.playwright.options.ViewportSize",
+                    constructorArgs=[375, 667]
+                );
+                expect(isObject(viewport)).toBeTrue();
+                expect(viewport.width).toBe(375);
+                expect(viewport.height).toBe(667);
             });
 
-            it("builds an option with constructor args AND setters", () => {
-                var l = new wheels.wheelstest.BrowserLauncher();
-                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
-                for (var p in paths) {
-                    if (!fileExists(p)) return;
-                }
-                l.$loadJars(jarPaths=paths);
-                try {
-                    // WaitForOptions has a zero-arg constructor; build it then
-                    // apply setTimeout as a setter. ViewportSize covers the
-                    // constructor-args-only path; this covers zero-arg + setter.
-                    // Cookie's constructor varies across Playwright versions so
-                    // we avoid it for portability.
-                    var opts = l.$buildOption(
-                        className="com.microsoft.playwright.Locator$WaitForOptions",
-                        setterMap={setTimeout: 5000}
-                    );
-                    expect(isObject(opts)).toBeTrue();
-                    // Verify the setter took effect by reading the public field
-                    expect(opts.timeout).toBe(5000);
-                } finally {
-                    l.release();
-                }
+            it("verifies setter side-effect is observable via public field", () => {
+                if (skipOptionTests) return;
+                var opts = optLauncher.$buildOption(
+                    className="com.microsoft.playwright.Locator$WaitForOptions",
+                    setterMap={setTimeout: 5000}
+                );
+                expect(isObject(opts)).toBeTrue();
+                expect(opts.timeout).toBe(5000);
             });
 
             it("passes nested Java objects through setters", () => {
-                var l = new wheels.wheelstest.BrowserLauncher();
-                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
-                for (var p in paths) {
-                    if (!fileExists(p)) return;
-                }
-                l.$loadJars(jarPaths=paths);
-                try {
-                    var viewport = l.$buildOption(
-                        className="com.microsoft.playwright.options.ViewportSize",
-                        constructorArgs=[375, 667]
-                    );
-                    var contextOpts = l.$buildOption(
-                        className="com.microsoft.playwright.Browser$NewContextOptions",
-                        setterMap={setViewportSize: viewport}
-                    );
-                    expect(isObject(contextOpts)).toBeTrue();
-                } finally {
-                    l.release();
-                }
+                if (skipOptionTests) return;
+                var viewport = optLauncher.$buildOption(
+                    className="com.microsoft.playwright.options.ViewportSize",
+                    constructorArgs=[375, 667]
+                );
+                var contextOpts = optLauncher.$buildOption(
+                    className="com.microsoft.playwright.Browser$NewContextOptions",
+                    setterMap={setViewportSize: viewport}
+                );
+                expect(isObject(contextOpts)).toBeTrue();
             });
 
         });

--- a/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserLauncherSpec.cfc
@@ -195,5 +195,143 @@ component extends="wheels.WheelsTest" {
                     .toThrow(type="Wheels.BrowserLauncherReflectionError");
             });
         });
+
+        describe("$findSetter", () => {
+
+            it("finds a one-arg setter by name on a JDK class", () => {
+                // java.util.Date has setTime(long) — one-arg setter
+                var klass = createObject("java", "java.util.Date").getClass();
+                var method = launcher.$findSetter(klass=klass, name="setTime");
+                expect(method.getName()).toBe("setTime");
+                expect(arrayLen(method.getParameterTypes())).toBe(1);
+            });
+
+            it("throws BrowserOptionError for nonexistent setter", () => {
+                var klass = createObject("java", "java.util.Date").getClass();
+                expect(() => {
+                    launcher.$findSetter(klass=klass, name="setNonexistent");
+                }).toThrow("Wheels.BrowserOptionError");
+            });
+
+        });
+
+        describe("$castForParam", () => {
+
+            it("casts numeric to java.lang.Double for double param type", () => {
+                var paramType = createObject("java", "java.lang.Double").TYPE;
+                var result = launcher.$castForParam(value=5000, paramType=paramType);
+                expect(result.getClass().getName()).toBe("java.lang.Double");
+            });
+
+            it("casts numeric to java.lang.Integer for int param type", () => {
+                var paramType = createObject("java", "java.lang.Integer").TYPE;
+                var result = launcher.$castForParam(value=42, paramType=paramType);
+                expect(result.getClass().getName()).toBe("java.lang.Integer");
+            });
+
+            it("passes Java objects through unchanged", () => {
+                var obj = createObject("java", "java.util.Date").init();
+                var paramType = createObject("java", "java.util.Date").getClass();
+                var result = launcher.$castForParam(value=obj, paramType=paramType);
+                expect(result).toBe(obj);
+            });
+
+        });
+
+        describe("$buildOption", () => {
+
+            it("throws BrowserOptionError when classloader not initialized", () => {
+                var freshLauncher = new wheels.wheelstest.BrowserLauncher();
+                expect(() => {
+                    freshLauncher.$buildOption(className="java.util.Date");
+                }).toThrow("Wheels.BrowserOptionError");
+            });
+
+            it("builds a zero-arg Playwright option with setters", () => {
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+                for (var p in paths) {
+                    if (!fileExists(p)) return;
+                }
+                l.$loadJars(jarPaths=paths);
+                try {
+                    var opts = l.$buildOption(
+                        className="com.microsoft.playwright.Locator$WaitForOptions",
+                        setterMap={setTimeout: 5000}
+                    );
+                    expect(isObject(opts)).toBeTrue();
+                } finally {
+                    l.release();
+                }
+            });
+
+            it("builds an option with constructor args", () => {
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+                for (var p in paths) {
+                    if (!fileExists(p)) return;
+                }
+                l.$loadJars(jarPaths=paths);
+                try {
+                    var viewport = l.$buildOption(
+                        className="com.microsoft.playwright.options.ViewportSize",
+                        constructorArgs=[375, 667]
+                    );
+                    expect(isObject(viewport)).toBeTrue();
+                    expect(viewport.width).toBe(375);
+                    expect(viewport.height).toBe(667);
+                } finally {
+                    l.release();
+                }
+            });
+
+            it("builds an option with constructor args AND setters", () => {
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+                for (var p in paths) {
+                    if (!fileExists(p)) return;
+                }
+                l.$loadJars(jarPaths=paths);
+                try {
+                    // WaitForOptions has a zero-arg constructor; build it then
+                    // apply setTimeout as a setter. ViewportSize covers the
+                    // constructor-args-only path; this covers zero-arg + setter.
+                    // Cookie's constructor varies across Playwright versions so
+                    // we avoid it for portability.
+                    var opts = l.$buildOption(
+                        className="com.microsoft.playwright.Locator$WaitForOptions",
+                        setterMap={setTimeout: 5000}
+                    );
+                    expect(isObject(opts)).toBeTrue();
+                    // Verify the setter took effect by reading the public field
+                    expect(opts.timeout).toBe(5000);
+                } finally {
+                    l.release();
+                }
+            });
+
+            it("passes nested Java objects through setters", () => {
+                var l = new wheels.wheelstest.BrowserLauncher();
+                var paths = l.$classpathJarPaths(installDir=l.resolveInstallDir());
+                for (var p in paths) {
+                    if (!fileExists(p)) return;
+                }
+                l.$loadJars(jarPaths=paths);
+                try {
+                    var viewport = l.$buildOption(
+                        className="com.microsoft.playwright.options.ViewportSize",
+                        constructorArgs=[375, 667]
+                    );
+                    var contextOpts = l.$buildOption(
+                        className="com.microsoft.playwright.Browser$NewContextOptions",
+                        setterMap={setViewportSize: viewport}
+                    );
+                    expect(isObject(contextOpts)).toBeTrue();
+                } finally {
+                    l.release();
+                }
+            });
+
+        });
     }
 }

--- a/vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc
@@ -43,5 +43,43 @@ component extends="wheels.wheelstest.BrowserTest" {
                 expect(launcher.getState()).toBe("ready");
             });
         });
+
+        browserDescribe("viewport config", () => {
+
+            it("applies mobile viewport preset when this.browserViewport is set", () => {
+                if (this.browserTestSkipped) return;
+                var original = this.browserViewport ?: "";
+                this.browserViewport = "mobile";
+
+                this.$endBrowserContext();
+                this.$startBrowserContext();
+
+                this.browser.visitUrl("data:text/html,<h1>Test</h1>");
+                var width = this.browser.script("() => window.innerWidth");
+                expect(width).toBe(375);
+
+                this.browserViewport = original;
+                this.$endBrowserContext();
+                this.$startBrowserContext();
+            });
+
+            it("applies custom viewport dimensions from struct", () => {
+                if (this.browserTestSkipped) return;
+                var original = this.browserViewport ?: "";
+                this.browserViewport = {width: 800, height: 600};
+
+                this.$endBrowserContext();
+                this.$startBrowserContext();
+
+                this.browser.visitUrl("data:text/html,<h1>Test</h1>");
+                var width = this.browser.script("() => window.innerWidth");
+                expect(width).toBe(800);
+
+                this.browserViewport = original;
+                this.$endBrowserContext();
+                this.$startBrowserContext();
+            });
+
+        });
     }
 }

--- a/vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserTestLifecycleSpec.cfc
@@ -81,5 +81,51 @@ component extends="wheels.wheelstest.BrowserTest" {
             });
 
         });
+
+        browserDescribe("auto-screenshot on failure", () => {
+
+            it("$captureFailureArtifacts writes screenshot and HTML", () => {
+                if (this.browserTestSkipped) return;
+                this.browser.visitUrl("data:text/html,<h1>Capture Me</h1>");
+
+                var testDir = expandPath("/tests/_output/browser_capture_test");
+                this.browserArtifactPath = testDir;
+
+                var fakeSpec = {name: "test_capture_verification"};
+                this.$captureFailureArtifacts(fakeSpec);
+
+                expect(directoryExists(testDir)).toBeTrue();
+                var files = directoryList(testDir, false, "name");
+                var hasPng = false;
+                var hasHtml = false;
+                for (var f in files) {
+                    if (findNoCase(".png", f)) hasPng = true;
+                    if (findNoCase(".html", f)) hasHtml = true;
+                }
+                expect(hasPng).toBeTrue();
+                expect(hasHtml).toBeTrue();
+
+                directoryDelete(testDir, true);
+                structDelete(this, "browserArtifactPath");
+            });
+
+            it("respects browserScreenshotOnFailure=false", () => {
+                if (this.browserTestSkipped) return;
+                this.browser.visitUrl("data:text/html,<h1>No Capture</h1>");
+
+                var testDir = expandPath("/tests/_output/browser_optout_test");
+                this.browserArtifactPath = testDir;
+                this.browserScreenshotOnFailure = false;
+
+                var fakeSpec = {name: "test_optout"};
+                this.$captureFailureArtifacts(fakeSpec);
+
+                expect(directoryExists(testDir)).toBeFalse();
+
+                this.browserScreenshotOnFailure = true;
+                structDelete(this, "browserArtifactPath");
+            });
+
+        });
     }
 }

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -183,30 +183,48 @@ component {
     // ─── Waiting ─────────────────────────────────────────────────────
 
     /**
-     * Waits for a selector to become visible. Uses Playwright's default
-     * timeout (30s). seconds param is accepted for API compatibility with
-     * the plan, but not currently honored — configurable timeout requires
-     * building Locator$WaitForOptions through the URLClassLoader, which is
-     * fragile (see Task 7 press() commentary). Uses .first() so selectors
+     * Waits for a selector to become visible. Default timeout is 30s
+     * (Playwright's default). When a non-default timeout is specified and
+     * a launcher is available, builds Locator$WaitForOptions via
+     * $buildOption to honor the custom timeout. Uses .first() so selectors
      * that match multiple elements resolve to the first one.
      */
     public BrowserClient function waitFor(
         required string selector,
         numeric seconds = 30
     ) {
-        $locator(arguments.selector).first().waitFor();
+        var loc = $locator(arguments.selector).first();
+        if (arguments.seconds != 30 && isObject(variables.$launcher)) {
+            var opts = variables.$launcher.$buildOption(
+                className="com.microsoft.playwright.Locator$WaitForOptions",
+                setterMap={setTimeout: arguments.seconds * 1000}
+            );
+            loc.waitFor(opts);
+        } else {
+            loc.waitFor();
+        }
         return this;
     }
 
     /**
-     * Waits for visible text to appear anywhere on the page. Same timeout
-     * caveat as waitFor().
+     * Waits for visible text to appear anywhere on the page. Default timeout
+     * is 30s. When a non-default timeout is specified and a launcher is
+     * available, builds Locator$WaitForOptions via $buildOption.
      */
     public BrowserClient function waitForText(
         required string text,
         numeric seconds = 30
     ) {
-        variables.page.getByText(arguments.text).first().waitFor();
+        var loc = variables.page.getByText(arguments.text).first();
+        if (arguments.seconds != 30 && isObject(variables.$launcher)) {
+            var opts = variables.$launcher.$buildOption(
+                className="com.microsoft.playwright.Locator$WaitForOptions",
+                setterMap={setTimeout: arguments.seconds * 1000}
+            );
+            loc.waitFor(opts);
+        } else {
+            loc.waitFor();
+        }
         return this;
     }
 
@@ -514,8 +532,7 @@ component {
     /**
      * Screenshot to `path`. Uses the no-arg screenshot() → byte[] overload
      * rather than Page$ScreenshotOptions, since building the options class
-     * through the URLClassLoader hits Lucee's OSGi-bundle resolver (same
-     * trap documented on press() / waitFor() earlier in this file).
+     * through the URLClassLoader hits Lucee's OSGi-bundle resolver.
      */
     public BrowserClient function screenshot(required string path) {
         var bytes = variables.page.screenshot();

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -392,12 +392,18 @@ component {
 
     /**
      * Delete a specific cookie by name from the browser context.
+     * Constructs ClearCookiesOptions and sets the public `name` field
+     * directly (bypassing the overloaded setter) to avoid reflection
+     * ambiguity between setName(String) and setName(Pattern).
      */
     public BrowserClient function deleteCookie(required string name) {
         var opts = variables.$launcher.$buildOption(
-            className="com.microsoft.playwright.BrowserContext$ClearCookiesOptions",
-            setterMap={setName: arguments.name}
+            className="com.microsoft.playwright.BrowserContext$ClearCookiesOptions"
         );
+        // Set the public `name` field directly rather than calling the
+        // overloaded setName() setter. The field type is Object, so a
+        // CFML string assignment works without type-mismatch issues.
+        opts.name = arguments.name;
         variables.context.clearCookies(opts);
         return this;
     }

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -550,13 +550,35 @@ component {
     }
 
     /**
-     * Screenshot to `path`. Uses the no-arg screenshot() → byte[] overload
-     * rather than Page$ScreenshotOptions, since building the options class
-     * through the URLClassLoader hits Lucee's OSGi-bundle resolver.
+     * Screenshot to `path`. When fullPage or quality are specified, builds
+     * Page$ScreenshotOptions via $buildOption. Otherwise uses the fast path
+     * (no-arg screenshot → byte[] → fileWrite).
      */
-    public BrowserClient function screenshot(required string path) {
-        var bytes = variables.page.screenshot();
-        fileWrite(arguments.path, bytes);
+    public BrowserClient function screenshot(
+        required string path,
+        boolean fullPage = false,
+        numeric quality = 0
+    ) {
+        if ((arguments.fullPage || arguments.quality > 0) && isObject(variables.$launcher)) {
+            var emptyStringArr = javaCast("String[]", []);
+            var pathObj = createObject("java", "java.nio.file.Paths")
+                .get(arguments.path, emptyStringArr);
+            var setters = {setPath: pathObj};
+            if (arguments.fullPage) {
+                setters["setFullPage"] = true;
+            }
+            if (arguments.quality > 0) {
+                setters["setQuality"] = arguments.quality;
+            }
+            var opts = variables.$launcher.$buildOption(
+                className="com.microsoft.playwright.Page$ScreenshotOptions",
+                setterMap=setters
+            );
+            variables.page.screenshot(opts);
+        } else {
+            var bytes = variables.page.screenshot();
+            fileWrite(arguments.path, bytes);
+        }
         return this;
     }
 

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -368,6 +368,64 @@ component {
         variables.$scope = arguments.rootLocator;
     }
 
+    // ─── Cookies ─────────────────────────────────────────────────────
+
+    /**
+     * Set a cookie on the current browser context. Requires the page to
+     * have been navigated to a real HTTP origin (not data: URLs).
+     */
+    public BrowserClient function setCookie(
+        required string name,
+        required string value,
+        required string url
+    ) {
+        var cookieObj = variables.$launcher.$buildOption(
+            className="com.microsoft.playwright.options.Cookie",
+            constructorArgs=[arguments.name, arguments.value],
+            setterMap={setUrl: arguments.url}
+        );
+        var cookieList = createObject("java", "java.util.Collections")
+            .singletonList(cookieObj);
+        variables.context.addCookies(cookieList);
+        return this;
+    }
+
+    /**
+     * Delete a specific cookie by name from the browser context.
+     */
+    public BrowserClient function deleteCookie(required string name) {
+        var opts = variables.$launcher.$buildOption(
+            className="com.microsoft.playwright.BrowserContext$ClearCookiesOptions",
+            setterMap={setName: arguments.name}
+        );
+        variables.context.clearCookies(opts);
+        return this;
+    }
+
+    /**
+     * Read a cookie by name from the browser context. Returns a struct
+     * with name, value, domain, path, expires, httpOnly, secure.
+     * Throws BrowserAssertionFailed if cookie not found.
+     */
+    public struct function cookie(required string name) {
+        var cookies = variables.context.cookies();
+        for (var i = 0; i < cookies.size(); i++) {
+            var c = cookies.get(javaCast("int", i));
+            if (c.name == arguments.name) {
+                return {
+                    name: c.name,
+                    value: c.value,
+                    domain: c.domain ?: "",
+                    path: c.path ?: "",
+                    expires: c.expires ?: -1,
+                    httpOnly: c.httpOnly ?: false,
+                    secure: c.secure ?: false
+                };
+            }
+        }
+        $assertFail("Cookie '" & arguments.name & "' not found");
+    }
+
     // ─── Assertions: text + visibility + presence ────────────────────
 
     public BrowserClient function assertSee(required string text) {

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -228,6 +228,26 @@ component {
         return this;
     }
 
+    /**
+     * Waits for the page URL to match the given pattern. Supports exact
+     * strings and glob patterns (Playwright native).
+     */
+    public BrowserClient function waitForUrl(
+        required string url,
+        numeric seconds = 30
+    ) {
+        if (arguments.seconds != 30 && isObject(variables.$launcher)) {
+            var opts = variables.$launcher.$buildOption(
+                className="com.microsoft.playwright.Page$WaitForURLOptions",
+                setterMap={setTimeout: arguments.seconds * 1000}
+            );
+            variables.page.waitForURL(arguments.url, opts);
+        } else {
+            variables.page.waitForURL(arguments.url);
+        }
+        return this;
+    }
+
     // ─── Viewport ────────────────────────────────────────────────────
 
     /**

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -12,15 +12,18 @@ component {
     variables.page = "";
     variables.context = "";
     variables.baseUrl = "";
+    variables.$launcher = "";
 
     public BrowserClient function init(
         any page = "",
         any context = "",
-        string baseUrl = ""
+        string baseUrl = "",
+        any launcher = ""
     ) {
         variables.page = arguments.page;
         variables.context = arguments.context;
         variables.baseUrl = arguments.baseUrl;
+        variables.$launcher = arguments.launcher;
         return this;
     }
 
@@ -311,7 +314,8 @@ component {
             .init(
                 page=variables.page,
                 context=variables.context,
-                baseUrl=variables.baseUrl
+                baseUrl=variables.baseUrl,
+                launcher=variables.$launcher
             );
         scoped.$setScope(variables.page.locator(arguments.selector).first());
         arguments.callback(scoped);
@@ -531,6 +535,10 @@ component {
 
     public string function getBaseUrl() {
         return variables.baseUrl;
+    }
+
+    public any function getLauncher() {
+        return variables.$launcher;
     }
 
     // ─── Internal helpers ────────────────────────────────────────────

--- a/vendor/wheels/wheelstest/BrowserLauncher.cfc
+++ b/vendor/wheels/wheelstest/BrowserLauncher.cfc
@@ -434,6 +434,7 @@ component {
     private any function $constructWithArgs(required any klass, required array args) {
         var constructors = arguments.klass.getDeclaredConstructors();
         var targetArity = arrayLen(arguments.args);
+        var lastError = "";
 
         for (var i = 1; i <= arrayLen(constructors); i++) {
             var paramTypes = constructors[i].getParameterTypes();
@@ -449,14 +450,15 @@ component {
                 }
                 return constructors[i].newInstance(javaCast("Object[]", castedArgs));
             } catch (any e) {
-                // Type mismatch — try next constructor with same arity
+                lastError = e.message;
             }
         }
 
         throw(
             type="Wheels.BrowserOptionError",
-            message="No constructor with " & targetArity & " arg(s) found on "
+            message="No constructor with " & targetArity & " arg(s) succeeded on "
                 & arguments.klass.getName()
+                & (len(lastError) ? ". Last error: " & lastError : "")
         );
     }
 

--- a/vendor/wheels/wheelstest/BrowserLauncher.cfc
+++ b/vendor/wheels/wheelstest/BrowserLauncher.cfc
@@ -288,6 +288,178 @@ component {
         );
     }
 
+    /**
+     * Finds a one-argument method with the given name on the given class.
+     * Used to locate fluent setters on Playwright option objects.
+     */
+    public any function $findSetter(required any klass, required string name) {
+        var methods = arguments.klass.getMethods();
+        for (var i = 1; i <= arrayLen(methods); i++) {
+            if (
+                methods[i].getName() == arguments.name
+                && arrayLen(methods[i].getParameterTypes()) == 1
+            ) {
+                return methods[i];
+            }
+        }
+        throw(
+            type="Wheels.BrowserOptionError",
+            message="No one-arg method named '" & arguments.name
+                & "' on class " & arguments.klass.getName()
+        );
+    }
+
+    /**
+     * Cast a CFML value to the Java type expected by a method parameter.
+     * Reads the parameter's declared type and applies the appropriate javaCast.
+     * Java objects (e.g., nested option objects from $buildOption) pass through.
+     */
+    public any function $castForParam(required any value, required any paramType) {
+        var typeName = arguments.paramType.getName();
+        switch (typeName) {
+            case "double":
+            case "java.lang.Double":
+                return javaCast("double", arguments.value);
+            case "int":
+            case "java.lang.Integer":
+                return javaCast("int", arguments.value);
+            case "long":
+            case "java.lang.Long":
+                return javaCast("long", arguments.value);
+            case "boolean":
+            case "java.lang.Boolean":
+                return javaCast("boolean", arguments.value);
+            case "java.lang.String":
+                return javaCast("string", arguments.value);
+            default:
+                return arguments.value;
+        }
+    }
+
+    /**
+     * Construct a Playwright option object via reflection through our URLClassLoader.
+     *
+     * Lucee's createObject("java", "InnerClass") fails when the class lives in a
+     * URLClassLoader — it tries to resolve via OSGi bundles. This helper bypasses
+     * that by using loadClass() + reflection directly.
+     *
+     * @className   Fully-qualified Java class name (use $ for inner classes)
+     * @setterMap   Struct of setter-name => value. Values auto-cast to match parameter type.
+     * @constructorArgs  Array of constructor arguments. Matched by arity; auto-cast per param type.
+     */
+    public any function $buildOption(
+        required string className,
+        struct setterMap = {},
+        array constructorArgs = []
+    ) {
+        if (!structKeyExists(variables, "$classLoader")) {
+            throw(
+                type="Wheels.BrowserOptionError",
+                message="Cannot build option: classloader not initialized. Call $loadJars() first."
+            );
+        }
+
+        var klass = "";
+        try {
+            klass = variables.$classLoader.loadClass(arguments.className);
+        } catch (any e) {
+            throw(
+                type="Wheels.BrowserOptionError",
+                message="Class not found: " & arguments.className & ". " & e.message
+            );
+        }
+
+        // Construct instance
+        var instance = "";
+        if (arrayLen(arguments.constructorArgs)) {
+            instance = $constructWithArgs(klass=klass, args=arguments.constructorArgs);
+        } else {
+            // Lucee's varargs bridge can't call getDeclaredConstructor() with
+            // zero args (same issue as getMethod). Find the zero-arg constructor
+            // by iterating getDeclaredConstructors().
+            instance = $constructZeroArg(klass=klass, className=arguments.className);
+        }
+
+        // Apply setters
+        for (var setterName in arguments.setterMap) {
+            var value = arguments.setterMap[setterName];
+            try {
+                var setter = $findSetter(klass=klass, name=setterName);
+                var paramType = setter.getParameterTypes()[1];
+                var castedValue = $castForParam(value=value, paramType=paramType);
+                setter.invoke(instance, javaCast("Object[]", [castedValue]));
+            } catch (any e) {
+                if (findNoCase("Wheels.", e.type ?: "")) rethrow;
+                throw(
+                    type="Wheels.BrowserOptionError",
+                    message="Failed to call " & setterName & " on "
+                        & arguments.className & ": " & e.message
+                );
+            }
+        }
+
+        return instance;
+    }
+
+    /**
+     * Construct an instance using the zero-arg constructor found by iterating
+     * getDeclaredConstructors(). Workaround for Lucee's varargs bridge which
+     * can't call getDeclaredConstructor() with zero args.
+     */
+    private any function $constructZeroArg(required any klass, required string className) {
+        var constructors = arguments.klass.getDeclaredConstructors();
+        for (var i = 1; i <= arrayLen(constructors); i++) {
+            if (arrayLen(constructors[i].getParameterTypes()) == 0) {
+                try {
+                    return constructors[i].newInstance(javaCast("Object[]", []));
+                } catch (any e) {
+                    throw(
+                        type="Wheels.BrowserOptionError",
+                        message="Failed to construct " & arguments.className
+                            & " with zero-arg constructor: " & e.message
+                    );
+                }
+            }
+        }
+        throw(
+            type="Wheels.BrowserOptionError",
+            message="No zero-arg constructor found on " & arguments.className
+        );
+    }
+
+    /**
+     * Construct an instance using a constructor matched by argument count.
+     * Tries each constructor with matching arity until one succeeds.
+     */
+    private any function $constructWithArgs(required any klass, required array args) {
+        var constructors = arguments.klass.getDeclaredConstructors();
+        var targetArity = arrayLen(arguments.args);
+
+        for (var i = 1; i <= arrayLen(constructors); i++) {
+            var paramTypes = constructors[i].getParameterTypes();
+            if (arrayLen(paramTypes) != targetArity) continue;
+
+            try {
+                var castedArgs = [];
+                for (var j = 1; j <= targetArity; j++) {
+                    arrayAppend(castedArgs, $castForParam(
+                        value=arguments.args[j],
+                        paramType=paramTypes[j]
+                    ));
+                }
+                return constructors[i].newInstance(javaCast("Object[]", castedArgs));
+            } catch (any e) {
+                // Type mismatch — try next constructor with same arity
+            }
+        }
+
+        throw(
+            type="Wheels.BrowserOptionError",
+            message="No constructor with " & targetArity & " arg(s) found on "
+                & arguments.klass.getName()
+        );
+    }
+
     private any function $getBrowserType(required string engine) {
         switch (arguments.engine) {
             case "chromium":

--- a/vendor/wheels/wheelstest/BrowserTest.cfc
+++ b/vendor/wheels/wheelstest/BrowserTest.cfc
@@ -112,7 +112,8 @@ component extends="wheels.WheelsTest" {
             .init(
                 page=variables.$page,
                 context=variables.$context,
-                baseUrl=variables.$baseUrl
+                baseUrl=variables.$baseUrl,
+                launcher=variables.$launcher
             );
     }
 

--- a/vendor/wheels/wheelstest/BrowserTest.cfc
+++ b/vendor/wheels/wheelstest/BrowserTest.cfc
@@ -28,16 +28,15 @@
  * well-isolated without managing Playwright plumbing themselves.
  *
  * Deferred (per the browser testing foundation PR scope):
- *   - viewport / keepSignedInAs / storageState replay — require building
- *     Playwright option objects (Browser$NewContextOptions, ViewportSize)
- *     through the URLClassLoader, which hits Lucee's OSGi bundle resolver.
- *     Resolving that is a reflection-helper pass planned for a follow-up.
+ *   - keepSignedInAs / storageState replay — require building additional
+ *     Playwright option objects through the URLClassLoader.
  *     Specs needing these can drop down to the raw Playwright objects via
  *     getBrowserLauncher() / this.browser.getContext() / getPage().
  */
 component extends="wheels.WheelsTest" {
 
     this.browserEngine = "chromium";
+    this.browserViewport = "";  // empty = Playwright default; "mobile"/"tablet"/"desktop" or {width:N, height:N}
     this.browser = "";
     this.browserTestSkipped = false;
 
@@ -106,7 +105,14 @@ component extends="wheels.WheelsTest" {
      */
     public void function $startBrowserContext() {
         if (this.browserTestSkipped) return;
-        variables.$context = variables.$browser.newContext();
+
+        var contextOpts = $buildContextOptions();
+
+        if (isObject(contextOpts)) {
+            variables.$context = variables.$browser.newContext(contextOpts);
+        } else {
+            variables.$context = variables.$browser.newContext();
+        }
         variables.$page = variables.$context.newPage();
         this.browser = new wheels.wheelstest.BrowserClient()
             .init(
@@ -199,6 +205,54 @@ component extends="wheels.WheelsTest" {
             // clearly rather than silently using the wrong URL.
         }
         return "http://localhost:8080";
+    }
+
+    /**
+     * Builds Browser$NewContextOptions if viewport config is set.
+     * Returns the options object, or empty string if no config.
+     */
+    private any function $buildContextOptions() {
+        if (!structKeyExists(this, "browserViewport") || !len(this.browserViewport ?: "")) {
+            return "";
+        }
+
+        var dims = $resolveViewportDims(this.browserViewport);
+
+        var viewport = variables.$launcher.$buildOption(
+            className="com.microsoft.playwright.options.ViewportSize",
+            constructorArgs=[dims.width, dims.height]
+        );
+
+        return variables.$launcher.$buildOption(
+            className="com.microsoft.playwright.Browser$NewContextOptions",
+            setterMap={setViewportSize: viewport}
+        );
+    }
+
+    /**
+     * Resolve viewport config to {width, height} struct.
+     */
+    private struct function $resolveViewportDims(required any viewport) {
+        if (isSimpleValue(arguments.viewport)) {
+            switch (lCase(arguments.viewport)) {
+                case "mobile":
+                    return {width: 375, height: 667};
+                case "tablet":
+                    return {width: 768, height: 1024};
+                case "desktop":
+                    return {width: 1440, height: 900};
+                default:
+                    throw(
+                        type="Wheels.BrowserViewportInvalid",
+                        message="Unknown viewport preset: " & arguments.viewport
+                            & ". Valid: mobile, tablet, desktop"
+                    );
+            }
+        }
+        return {
+            width: arguments.viewport.width ?: 1440,
+            height: arguments.viewport.height ?: 900
+        };
     }
 
 }

--- a/vendor/wheels/wheelstest/BrowserTest.cfc
+++ b/vendor/wheels/wheelstest/BrowserTest.cfc
@@ -37,6 +37,7 @@ component extends="wheels.WheelsTest" {
 
     this.browserEngine = "chromium";
     this.browserViewport = "";  // empty = Playwright default; "mobile"/"tablet"/"desktop" or {width:N, height:N}
+    this.browserScreenshotOnFailure = true;
     this.browser = "";
     this.browserTestSkipped = false;
 
@@ -93,6 +94,20 @@ component extends="wheels.WheelsTest" {
 
         describe(arguments.title, function() {
             beforeEach(function() { me.$startBrowserContext(); });
+
+            aroundEach(function(spec, suite) {
+                if (me.browserTestSkipped) {
+                    arguments.spec.body();
+                    return;
+                }
+                try {
+                    arguments.spec.body();
+                } catch (any e) {
+                    me.$captureFailureArtifacts(arguments.spec);
+                    rethrow;
+                }
+            });
+
             afterEach(function() { me.$endBrowserContext(); });
             innerBody();
         });
@@ -205,6 +220,37 @@ component extends="wheels.WheelsTest" {
             // clearly rather than silently using the wrong URL.
         }
         return "http://localhost:8080";
+    }
+
+    /**
+     * Best-effort capture of screenshot + HTML on test failure.
+     * Called from aroundEach catch block. Swallows all errors to avoid
+     * masking the real test failure.
+     */
+    public void function $captureFailureArtifacts(required any spec) {
+        if (!(this.browserScreenshotOnFailure ?: true)) return;
+        if (!isObject(this.browser) || this.browserTestSkipped) return;
+
+        try {
+            var artifactDir = this.browserArtifactPath
+                ?: expandPath("/tests/_output/browser");
+
+            if (!directoryExists(artifactDir)) {
+                directoryCreate(artifactDir, true);
+            }
+
+            var rawName = arguments.spec.name ?: "unknown_spec";
+            var safeName = reReplace(rawName, "[^a-zA-Z0-9_\-]", "_", "all");
+            if (len(safeName) > 80) safeName = left(safeName, 80);
+            var ts = dateFormat(now(), "yyyymmdd") & "_" & timeFormat(now(), "HHmmss");
+            var baseName = safeName & "-" & ts;
+
+            this.browser.screenshot(path=artifactDir & "/" & baseName & ".png");
+            fileWrite(artifactDir & "/" & baseName & ".html", this.browser.pageSource());
+        } catch (any e) {
+            // Best-effort: page may have crashed, context may be closed.
+            // Swallow to avoid masking the real test failure.
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

PR 2 of the v4.0 browser testing trail (follows #2113). Delivers three themes:

- **`$buildOption` reflection helper** — constructs Playwright inner-class option objects through the URLClassLoader, bypassing Lucee's OSGi bundle resolver. Supports zero-arg + setter, multi-arg constructor, and nested object patterns.
- **Deferred DSL methods** — cookies (`setCookie`, `deleteCookie`, `cookie`), configurable timeouts on `waitFor`/`waitForText`, `waitForUrl`, screenshot options (`fullPage`, `quality`), viewport config at `BrowserTest` level (`this.browserViewport`), auto-screenshot + HTML dump on test failure
- **CLI commands** — `wheels browser:install` (replaces `tools/install-playwright.sh`), `wheels browser:test` (pre-flight JAR check + test runner). Both CommandBox and LuCLI.

## Test plan

- [x] 3045 pass, 0 fail, 1 error (pre-existing SQLite migration issue) on Lucee 7 + SQLite
- [ ] Verify `wheels browser:install` downloads JARs and installs Chromium
- [ ] Verify `wheels browser:test` runs browser specs with pre-flight check
- [ ] CI matrix (Lucee 5/6/7, Adobe 2021/2023/2025) — browser specs skip gracefully when Playwright not installed

## Deferred to PR 3

- `loginAs`/`logout` + fixture-server bootstrap
- Dialogs (`createDynamicProxy` for `Consumer<Dialog>`)
- `visitRoute`/`assertRouteIs` (needs `urlFor` outside controller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)