### PR TITLE
Fix/fix for issue 2009

### DIFF
--- a/vendor/wheels/controller/channels.cfc
+++ b/vendor/wheels/controller/channels.cfc
@@ -90,7 +90,7 @@ component {
 	}
 
 	/**
-	 * Generate a <script> tag that creates an EventSource for a channel.
+	 * Generate a 'script' tag that creates an EventSource for a channel.
 	 * Convenience view helper for quickly wiring up SSE in templates.
 	 *
 	 * @channel The channel name.

--- a/vendor/wheels/public/docs/core.cfm
+++ b/vendor/wheels/public/docs/core.cfm
@@ -39,14 +39,6 @@ if (StructKeyExists(application.wheels, "docs")) {
 	// Now safely append to documentScope
 	ArrayAppend(documentScope, {"name" = "model", "scope" = modelInstance});
 	
-	/* 
-		To fix the issue below:
-		https://github.com/wheels-dev/wheels/issues/1132
-		
-		To add the test framework functions in the documentation. Added the Test component in the documentScope.
-	*/
-	ArrayAppend(documentScope, {"name" = "test", "scope" = CreateObject("component", "wheels.tests.Test")});
-
 	ArrayAppend(documentScope, {"name" = "mapper", "scope" = application.wheels.mapper});
 	if (application.wheels.enablePluginsComponent) {
 		ArrayAppend(documentScope, {"name" = "migrator", "scope" = application.wheels.migrator});

--- a/vendor/wheels/view/vite.cfc
+++ b/vendor/wheels/view/vite.cfc
@@ -28,7 +28,7 @@ component {
 	}
 
 	/**
-	 * Returns `<script>` tags for a Vite JS entrypoint. In development, also injects the Vite
+	 * Returns 'script' tags for a Vite JS entrypoint. In development, also injects the Vite
 	 * client for Hot Module Replacement (HMR). In production, includes any associated CSS files
 	 * from the manifest as `<link>` tags.
 	 *


### PR DESCRIPTION
## Summary:
The Wheels Developer API page is causing an error instead of showing the documentation. This happened because the code was trying to load wheels.tests.Test, which is not available in some setups.
Also, some function descriptions had <script> tags, which the browser tried to run as JavaScript. This was breaking the loader at the functions list in the sidebar.

## Changes:
Removed the code that was loading wheels.tests.Test to prevent the error.
Updated function descriptions to remove <script> tags and replace them with plain text (script).
Fixed the loader issue caused by unwanted JavaScript execution.