### PR TITLE
commit: fix for issue #2010

### DIFF
--- a/vendor/wheels/public/docs/guides.cfm
+++ b/vendor/wheels/public/docs/guides.cfm
@@ -5,6 +5,10 @@ param name="request.wheels.params.format" default="html";
 
 // Setup paths
 local.docsPath = "/wheels/docs/src/";
+if (!directoryExists(expandPath(local.docsPath))) {
+    // Fall back to relative path
+    local.docsPath = "../../wheels/docs/src/";
+}
 local.summaryPath = local.docsPath & "SUMMARY.md";
 
 // Get navigation structure


### PR DESCRIPTION
## Summary:
The Guides documentation page was using a hardcoded relative path (/wheels/docs/src/) to locate documentation files. This path only works when running the Wheels application installed as a package. When Wheels is running from a repository clone, the relative path resolves incorrectly, causing the Guides page to display only a placeholder message ("Select a guide from the navigation menu.") instead of the actual documentation content.

## Changes:
vendor/wheels/public/docs/guides.cfm: Changed the docs path from an absolute path (/wheels/docs/src/) to a relative path (../../wheels/docs/src/), which works correctly when Wheels is running from the repository. This aligns with how other documentation files (ai.cfm, Public.cfc) already handle the path.