### PR TITLE
commit: fix for issue #2119

### DIFF
--- a/cli/src/commands/wheels/browser/install.cfc
+++ b/cli/src/commands/wheels/browser/install.cfc
@@ -10,7 +10,7 @@
  *   wheels browser:install --force
  *   wheels browser:install --browser=firefox
  */
-component aliases="wheels browser:install, wheels browser install" extends="../../base" {
+component aliases="wheels browser:install, wheels browser install" extends="../base" {
 
 	property name="browserService" inject="BrowserService@wheels-cli";
 

--- a/cli/src/commands/wheels/browser/test.cfc
+++ b/cli/src/commands/wheels/browser/test.cfc
@@ -9,7 +9,7 @@
  *   wheels browser:test --verbose
  *   wheels browser:test --format=json
  */
-component aliases="wheels browser:test, wheels browser test" extends="../../base" {
+component aliases="wheels browser:test, wheels browser test" extends="../base" {
 
 	property name="browserService" inject="BrowserService@wheels-cli";
 


### PR DESCRIPTION
## Summary:

After installing wheels-cli, CommandBox was throwing an error on startup. This happened because some components were using an incorrect relative path (../../base) in extends, which could not be resolved in the CommandBox module system.

## Changes:
- Fixed incorrect relative path in component extends.
- Updated:
   - cli/src/commands/wheels/browser/install.cfc
   - cli/src/commands/wheels/browser/test.cfc
- Changed extends="../../base" to extends="../base" so CommandBox can correctly resolve the component.