### PR TITLE
docs: rename TestBox to WheelsTest in 4.0 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 - LuCLI Phase 2: service layer, generators, MCP annotations (#1941)
 - LuCLI Phase 3–4: scaffold, seed, in-process services (#2065)
 - LuCLI-native Lucee 7 + SQLite CI pipeline (#2032)
-- LuCLI tier 1 commands module + TestBox test suite (#2092, #2093)
+- LuCLI tier 1 commands module + WheelsTest test suite (#2092, #2093)
 - Playwright CLI commands for browser testing (#2013, #2021)
 
 **Configuration & developer experience**
@@ -106,7 +106,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 - **Breaking:** RateLimiter `trustProxy` default changed from `true` to `false` (#2024)
 - **Breaking:** RateLimiter proxy strategy default changed to `last` (#2088)
 - **Breaking:** `wheels snippets` CLI command renamed to `wheels code` (#1852)
-- **Breaking:** TestBox test base class namespace renamed: new tests extend `wheels.WheelsTest` (old `wheels.Test` preserved during 4.0 as a deprecation path) (#1889)
+- **Breaking:** Test base class namespace renamed: new tests extend `wheels.WheelsTest` (old `wheels.Test` preserved during 4.0 as a deprecation path) (#1889)
 - **Breaking:** Tests directory `tests/specs/functions/` renamed to `tests/specs/functional/` (#1872)
 - **Breaking:** `application.wirebox` renamed to `application.wheelsdi` (#1888)
 - CFWheels branding removed from active code and metadata (continuation of the 3.0 rebrand) (#2064)
@@ -120,7 +120,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 ### Deprecated
 
 - Legacy `plugins/` folder — superseded by the new `packages/` → `vendor/` activation model. Plugins still load, with a deprecation warning. (#1995)
-- RocketUnit test style for new tests — TestBox BDD is required going forward. Existing RocketUnit specs continue to run. (#1925)
+- RocketUnit test style for new tests — BDD syntax (via WheelsTest) is required going forward. Existing RocketUnit specs continue to run. (#1925)
 - `wheels.Test` test base class — extend `wheels.WheelsTest` instead (#1889)
 
 ### Removed

--- a/docs/releases/wheels-4.0-audit.md
+++ b/docs/releases/wheels-4.0-audit.md
@@ -115,7 +115,7 @@
 - **Browser testing via Playwright Java** (#2113, #2115, #2116, #2121, #2122) — `BrowserTest` base class with fluent DSL wrapping Playwright Java. Methods: navigation (`visit`, `visitRoute`, `back`, `forward`), interaction (`click`, `fill`, `type`, `select`, `check`, `attach`, `dragAndDrop`), keyboard (`keys`, `pressEnter`, `pressTab`, `pressEscape`), waiting (`waitFor`, `waitForText`, `waitForUrl`), scoping (`within`), cookies (`setCookie`, `cookie`, `clearCookies`), auth (`loginAs`, `logout`), dialogs (`acceptDialog`, `dismissDialog`, `dialogMessage`), viewport (`resize`, `resizeToMobile`, `resizeToTablet`, `resizeToDesktop`), script (`script`, `pause`), screenshots, full assertion suite. `wheels browser:install` downloads JARs + Chromium (~370MB). CI workflow runs browser specs across pr.yml and snapshot.yml.
 - **`testbox` → `wheelstest` namespace rename** (#1889) — `extends="wheels.WheelsTest"` replaces `extends="wheels.Test"` (legacy still works during 4.0).
 - **`tests/specs/functions/` → `tests/specs/functional/` rename** (#1872).
-- **Legacy RocketUnit removal** (#1925) — TestBox BDD is the only supported style for new tests in 4.0. Existing RocketUnit specs continue to run; no new ones.
+- **Legacy RocketUnit removal** (#1925) — WheelsTest (BDD syntax) is the only supported style for new tests in 4.0. Existing RocketUnit specs continue to run; no new ones.
 - **RocketUnit wildcard filter** (#1857) — improves test selection for the remaining legacy specs.
 
 ### 13. CLI (Wheels CLI) + LuCLI
@@ -134,7 +134,7 @@
 - **Phase 2 service layer, generators, MCP annotations** (#1941).
 - **LuCLI-native CI pipeline** (#2032) — Lucee 7 + SQLite in CI, matching local inner loop.
 - **LuCLI module distribution via wheels-cli-lucli repo** (#2018).
-- **Tier 1 commands ported to LuCLI** (#2092) + TestBox test suite for the module (#2093).
+- **Tier 1 commands ported to LuCLI** (#2092) + WheelsTest test suite for the module (#2093).
 
 **CLI security hardening:**
 
@@ -233,7 +233,7 @@ Items that require migration notes for users upgrading from 3.x. These should ha
 2. **CFWheels → Wheels rebrand in active code** (#2064) — callers referencing old namespaces (e.g., `cfwheels.*`) must update. Most user code unaffected; internal reference.
 3. **`testbox` → `wheelstest` namespace** (#1889) — test CFCs should extend `wheels.WheelsTest` (old `wheels.Test` continues to work but is legacy).
 4. **Tests directory `tests/specs/functions/` → `tests/specs/functional/`** (#1872).
-5. **Legacy RocketUnit removed from core** (#1925) — existing RocketUnit specs in app repos continue to run; TestBox BDD is mandatory for new tests.
+5. **Legacy RocketUnit removed from core** (#1925) — existing RocketUnit specs in app repos continue to run; WheelsTest (BDD syntax) is mandatory for new tests.
 6. **CORS default: wildcard → deny-all** (#2039) — apps relying on the wildcard default must explicitly configure `allowOrigins`.
 7. **`allowEnvironmentSwitchViaUrl` default: true → false in production** (#2076) — and reload password must be non-empty for env switching in production (#2082).
 


### PR DESCRIPTION
## Summary

Follow-up to #2123 (audit) and #2124 (CHANGELOG catch-up), which both merged while inline rename edits were being prepared. Applies a targeted three-bucket rename rubric to the content those two PRs added.

**Why:** Wheels consumed TestBox to drive its own destiny and call it WheelsTest. Forward-looking references in the 4.0 release docs should use WheelsTest; historical / rename-event references stay as-is for provenance.

## The three-bucket rubric

| Bucket | Example | Treatment |
|---|---|---|
| Current framework identity | "TestBox test suite" | Rename → `WheelsTest test suite` |
| BDD style/pattern name | "TestBox BDD is required" | Drop qualifier → `BDD syntax (via WheelsTest)` |
| Historical / event references | "testbox → wheelstest namespace rename" (describes the rename); "WireBox/TestBox replaced" (describes replacement); 3.0 dep mentions | **Preserved** — factual history |

## Edits (6 lines across 2 files)

**CHANGELOG.md** — 3 forward-looking edits
- L88: `TestBox test suite` → `WheelsTest test suite`
- L109: `**Breaking:** TestBox test base class namespace renamed` → drops "TestBox" (redundant with the sentence that follows)
- L123: `TestBox BDD is required` → `BDD syntax (via WheelsTest) is required`

**docs/releases/wheels-4.0-audit.md** — 3 forward-looking edits
- L118: `TestBox BDD is the only supported style` → `WheelsTest (BDD syntax) is the only supported style`
- L137: `TestBox test suite for the module` → `WheelsTest test suite for the module`
- L236: `TestBox BDD is mandatory` → `WheelsTest (BDD syntax) is mandatory`

## Historical references deliberately preserved

- `CHANGELOG.md:114` — "WireBox/TestBox replaced" (describes the replacement event)
- `CHANGELOG.md:237` — 3.0.0 dep section "Updated WireBox (^7.0.0) and TestBox (^6.0.0) requirements" (factual history)
- `audit:116` — "testbox → wheelstest namespace rename" (describes the rename itself)
- `audit:205` — "WireBox replaced + TestBox replaced" (rim modernization event)
- `audit:292` — "WireBox/TestBox replacement" (blog theme context mentioning the event)

Matches the same principle the CHANGELOG uses at lines 11-17 for CFWheels references: "All historical references... have been preserved for accuracy."

## Test plan

- [x] All 6 forward-looking references updated
- [x] All 5 historical references verified untouched
- [x] Symmetric edits to #2125 (3.0-vs-4.0 comparison) already landed in that branch

## Follow-up

- Repo-wide sweep covering ~30 other files (`docs/src/`, `CLAUDE.md`, `tests/README.md`, examples, `.ai/wheels/testing/`, etc.) using the same rubric — planned as a separate PR so reviewers can see the sweep as one cohesive rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)