### PR TITLE
docs: rename TestBox to WheelsTest across forward-looking docs

### DIFF
--- a/.ai/wheels/controllers/testing.md
+++ b/.ai/wheels/controllers/testing.md
@@ -1,11 +1,11 @@
 # Controller Testing
 
 ## Description
-Comprehensive guide to testing Wheels controllers using TestBox 5 with modern BDD (Behavior Driven Development) syntax. Wheels 3.0 uses TestBox integration for testing controllers with `describe()`, `it()`, and `expect()` patterns.
+Comprehensive guide to testing Wheels controllers using WheelsTest with modern BDD (Behavior Driven Development) syntax. Wheels uses WheelsTest for testing controllers with `describe()`, `it()`, and `expect()` patterns.
 
-## TestBox BDD Testing Structure
+## WheelsTest BDD Testing Structure
 
-### Modern Test Structure (TestBox 5)
+### Modern Test Structure (WheelsTest)
 ```cfm
 // tests/specs/controllers/ProductsControllerSpec.cfc
 component extends="wheels.WheelsTest" {
@@ -862,7 +862,7 @@ function setupTestData() {
 }
 ```
 
-## TestBox BDD Best Practices
+## WheelsTest BDD Best Practices
 
 ### 1. Write Focused, Descriptive Tests
 ```cfm
@@ -964,13 +964,13 @@ describe("Email Integration", () => {
 });
 ```
 
-## Modern TestBox Resources
+## BDD Reference — Upstream TestBox Docs
 
-For comprehensive TestBox 5 documentation:
-- [TestBox BDD Documentation](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer)
-- [TestBox Expectations](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer/expectations)
-- [MockBox Documentation](https://testbox.ortusbooks.com/v6.x/mocking/mockbox)
-- [TestBox Life-cycle Methods](https://testbox.ortusbooks.com/v6.x/digging-deeper/life-cycle-methods)
+WheelsTest inherits the BDD syntax from upstream Ortus TestBox. For comprehensive BDD, expectation, and lifecycle reference:
+- [BDD Primer](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer)
+- [Expectations](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer/expectations)
+- [MockBox](https://testbox.ortusbooks.com/v6.x/mocking/mockbox)
+- [Life-cycle Methods](https://testbox.ortusbooks.com/v6.x/digging-deeper/life-cycle-methods)
 
 ## Related Documentation
 - [Controller Architecture](./architecture.md)

--- a/.ai/wheels/models/testing.md
+++ b/.ai/wheels/models/testing.md
@@ -1,11 +1,11 @@
 # Model Testing
 
 ## Description
-Comprehensive guide to testing Wheels models using TestBox 5 with modern BDD (Behavior Driven Development) syntax. This guide covers validation testing, association testing, business logic testing, and callback testing using `describe()`, `it()`, and `expect()` patterns.
+Comprehensive guide to testing Wheels models using WheelsTest with modern BDD (Behavior Driven Development) syntax. This guide covers validation testing, association testing, business logic testing, and callback testing using `describe()`, `it()`, and `expect()` patterns.
 
-## TestBox BDD Model Test Structure
+## WheelsTest BDD Model Test Structure
 
-### Modern Test Template (TestBox 5)
+### Modern Test Template (WheelsTest)
 ```cfm
 /**
  * UserModelSpec - Test User model functionality using BDD
@@ -38,7 +38,7 @@ component extends="wheels.WheelsTest" {
 }
 ```
 
-### TestBox BDD Test Organization
+### WheelsTest BDD Test Organization
 ```
 tests/
 ├── specs/
@@ -637,7 +637,7 @@ function test_account_locking_after_failed_attempts() {
 }
 ```
 
-## TestBox BDD Test Utilities and Helpers
+## WheelsTest BDD Test Utilities and Helpers
 
 ### BDD Test Data Factory
 ```cfm
@@ -746,7 +746,7 @@ function test_eager_loading_performance() {
 }
 ```
 
-## TestBox BDD Test Organization Best Practices
+## WheelsTest BDD Test Organization Best Practices
 
 ### 1. Use Descriptive BDD Structure
 ```cfm
@@ -802,13 +802,13 @@ beforeEach(() => {
 - Use clear, readable expectations
 - Group related functionality with nested describe blocks
 
-## Modern TestBox Resources
+## BDD Reference — Upstream TestBox Docs
 
-For comprehensive TestBox 5 documentation:
-- [TestBox BDD Documentation](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer)
-- [TestBox Expectations](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer/expectations)
-- [MockBox Documentation](https://testbox.ortusbooks.com/v6.x/mocking/mockbox)
-- [TestBox Life-cycle Methods](https://testbox.ortusbooks.com/v6.x/digging-deeper/life-cycle-methods)
+WheelsTest inherits the BDD syntax from upstream Ortus TestBox. For comprehensive BDD, expectation, and lifecycle reference:
+- [BDD Primer](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer)
+- [Expectations](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer/expectations)
+- [MockBox](https://testbox.ortusbooks.com/v6.x/mocking/mockbox)
+- [Life-cycle Methods](https://testbox.ortusbooks.com/v6.x/digging-deeper/life-cycle-methods)
 
 ## Related Documentation
 - [Model Architecture](./architecture.md)

--- a/.ai/wheels/testing/browser-testing.md
+++ b/.ai/wheels/testing/browser-testing.md
@@ -33,7 +33,7 @@ Three CFCs under `vendor/wheels/wheelstest/`:
 
 1. **`BrowserLauncher.cfc`** — process-level owner of the Playwright instance. Reads `vendor/wheels/browser-manifest.json`, walks the `classpath[]` array to compute JAR paths, loads them into a `URLClassLoader` with `PlatformClassLoader` as parent (critical — see Gotchas below), acquires one `Browser` per engine, caches it. State machine: `uninitialized → ready → shut-down`.
 2. **`BrowserClient.cfc`** — the DSL. Takes a `Page`, a `BrowserContext`, and a base URL; wraps Playwright's locator/page APIs with the ~40 chainable methods enumerated below.
-3. **`BrowserTest.cfc`** — TestBox BDD base class. `beforeAll` lazy-initializes an application-scoped launcher so all spec CFCs in a test run share one Chromium startup (~1.7 s). Provides `browserDescribe(title, body)` which wraps `describe()` with per-`it` beforeEach/afterEach that create a fresh `BrowserContext` and inject it as `this.browser`.
+3. **`BrowserTest.cfc`** — WheelsTest BDD base class. `beforeAll` lazy-initializes an application-scoped launcher so all spec CFCs in a test run share one Chromium startup (~1.7 s). Provides `browserDescribe(title, body)` which wraps `describe()` with per-`it` beforeEach/afterEach that create a fresh `BrowserContext` and inject it as `this.browser`.
 
 ## Spec structure
 
@@ -60,7 +60,7 @@ component extends="wheels.wheelstest.BrowserTest" {
 
 ### Why `browserDescribe` instead of `beforeEach` on the class
 
-TestBox BDD treats `beforeAll`/`afterAll` as class-level lifecycle hooks but `beforeEach`/`afterEach` as *registration* functions that must be called from inside a `describe` body. So the natural "add a method named `beforeEach` to the parent class and let inheritance do its thing" pattern doesn't work. `browserDescribe` sidesteps this by calling `describe(...)` internally and registering the hooks from within the suite body.
+WheelsTest BDD treats `beforeAll`/`afterAll` as class-level lifecycle hooks but `beforeEach`/`afterEach` as *registration* functions that must be called from inside a `describe` body. So the natural "add a method named `beforeEach` to the parent class and let inheritance do its thing" pattern doesn't work. `browserDescribe` sidesteps this by calling `describe(...)` internally and registering the hooks from within the suite body.
 
 ## CI / skip logic
 
@@ -314,7 +314,7 @@ Dialog handling requires implementing Playwright's `Consumer<Dialog>` Java inter
 
 The `/_browser/*` fixture routes (login-as, logout, login form, protected page) are mounted by the framework in test mode. They must come before `.wildcard()` in `config/routes.cfm` or the wildcard catches them first. The framework handles this automatically, but custom route files that override the default order should be aware.
 
-### Fat arrow closures in TestBox suites
+### Fat arrow closures in WheelsTest suites
 
 CFML fat arrow syntax (`() => { ... }`) works in most contexts, but closure semantics can differ from `function() { ... }` in edge cases related to `this` binding and component scope. In browser test specs, fat arrows work well for `describe`/`it` callbacks because `this` refers to the spec CFC instance. If you encounter scope issues, switch to explicit `function()` syntax.
 

--- a/.ai/wheels/testing/unit-testing.md
+++ b/.ai/wheels/testing/unit-testing.md
@@ -2,9 +2,9 @@
 
 ## Two Test Frameworks
 
-Wheels has two test frameworks. **All new tests must use TestBox.**
+Wheels has two test frameworks. **All new tests must use WheelsTest.**
 
-| | TestBox (current) | RocketUnit (legacy) |
+| | WheelsTest (current) | RocketUnit (legacy) |
 |---|---|---|
 | **Syntax** | `describe`/`it`/`expect` (BDD) | `test_methodName()` + `assert()` |
 | **Base class** | `wheels.WheelsTest` | `wheels.Test` |
@@ -12,7 +12,7 @@ Wheels has two test frameworks. **All new tests must use TestBox.**
 | **Runner URL** | `/wheels/app/tests` | `/wheels/tests/core` |
 | **Status** | Active, all new tests | Legacy, backwards-compat only |
 
-## TestBox Test Structure
+## WheelsTest Test Structure
 
 ### File Layout
 
@@ -30,7 +30,7 @@ tests/
     controllers/     <- Controller specs
     functional/      <- End-to-end specs
   populate.cfm       <- Creates/seeds test tables (runs before every test suite)
-  runner.cfm         <- TestBox runner (web entry point)
+  runner.cfm         <- WheelsTest runner (web entry point)
 ```
 
 ### Writing a Spec
@@ -59,7 +59,7 @@ component extends="wheels.WheelsTest" {
 ### Key Points
 
 - **Extend `wheels.WheelsTest`** — this injects all `application.wo` methods (like `model()`) into the test scope automatically.
-- **Use `function run()`** — TestBox calls this to discover specs. Not `init()`, not `config()`.
+- **Use `function run()`** — WheelsTest calls this to discover specs. Not `init()`, not `config()`.
 - **Arrow functions work** — `() => {}` is fine for `describe`/`it`/`beforeEach`.
 
 ## Test Models
@@ -144,7 +144,7 @@ for (const b of j.bundleStats) {
 "
 ```
 
-**Why node instead of jq?** The Wheels TestBox JSON response contains unquoted `true`/`false` booleans that break strict JSON parsers. Node's `JSON.parse` handles them.
+**Why node instead of jq?** The WheelsTest JSON response contains unquoted `true`/`false` booleans that break strict JSON parsers. Node's `JSON.parse` handles them.
 
 ## Common Gotchas
 
@@ -197,4 +197,4 @@ DROP TABLE IF EXISTS c_o_r_e_authors <!--- parent --->
 
 ### 5. Pre-existing Test Failures
 
-The `vendor/wheels/rocketunit_tests/` legacy RocketUnit suite has some pre-existing failures (e.g., in `model.errors`). Don't chase these — they're known issues in the legacy suite. The RocketUnit test files have been removed; only infrastructure (Test.cfc, populate.cfm, _assets/) remains for backwards compatibility. Focus on making your TestBox specs green.
+The `vendor/wheels/rocketunit_tests/` legacy RocketUnit suite has some pre-existing failures (e.g., in `model.errors`). Don't chase these — they're known issues in the legacy suite. The RocketUnit test files have been removed; only infrastructure (Test.cfc, populate.cfm, _assets/) remains for backwards compatibility. Focus on making your WheelsTest specs green.

--- a/.ai/wheels/views/testing.md
+++ b/.ai/wheels/views/testing.md
@@ -1,6 +1,6 @@
-# Testing Views with TestBox BDD
+# Testing Views with WheelsTest BDD
 
-## Modern View Testing with TestBox 5
+## Modern View Testing with WheelsTest
 
 ### BDD View Testing Structure
 
@@ -339,7 +339,7 @@ component extends="wheels.WheelsTest" {
 }
 ```
 
-## TestBox BDD Best Practices for View Testing
+## WheelsTest BDD Best Practices for View Testing
 
 ### 1. Test Isolation with BDD Lifecycle
 
@@ -558,13 +558,13 @@ curl -s http://localhost:8080/posts | grep -c '<article' && echo "posts displaye
 
 **Without content verification, this error goes undetected!**
 
-## Modern TestBox Resources
+## BDD Reference — Upstream TestBox Docs
 
-For comprehensive TestBox 5 documentation:
-- [TestBox BDD Documentation](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer)
-- [TestBox Expectations](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer/expectations)
-- [MockBox Documentation](https://testbox.ortusbooks.com/v6.x/mocking/mockbox)
-- [TestBox Life-cycle Methods](https://testbox.ortusbooks.com/v6.x/digging-deeper/life-cycle-methods)
+WheelsTest inherits the BDD syntax from upstream Ortus TestBox. For comprehensive BDD, expectation, and lifecycle reference:
+- [BDD Primer](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer)
+- [Expectations](https://testbox.ortusbooks.com/v6.x/getting-started/testbox-bdd-primer/expectations)
+- [MockBox](https://testbox.ortusbooks.com/v6.x/mocking/mockbox)
+- [Life-cycle Methods](https://testbox.ortusbooks.com/v6.x/digging-deeper/life-cycle-methods)
 
 ## Related Documentation
 - [View Architecture](./architecture.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -457,7 +457,7 @@ Disabled links render as `<span class="disabled">` by default. All helpers accep
 
 ## Testing Quick Reference
 
-**All new tests use TestBox BDD syntax.** RocketUnit (`test_` prefix, `assert()`) is legacy only — never use it for new tests.
+**All new tests use WheelsTest BDD syntax.** RocketUnit (`test_` prefix, `assert()`) is legacy only — never use it for new tests.
 
 ### Two test suites
 - **App tests**: `/wheels/app/tests` — project-specific tests in `tests/specs/`. Uses `tests/populate.cfm` for test data and `tests/TestRunner.cfc` for setup.
@@ -774,7 +774,7 @@ component extends="wheels.wheelstest.BrowserTest" {
 
     function run() {
         // browserDescribe() wraps describe() with beforeEach/afterEach that
-        // create a fresh Page per `it`. TestBox's BDD lifecycle only treats
+        // create a fresh Page per `it`. WheelsTest's BDD lifecycle only treats
         // beforeAll/afterAll as class-level, so we register per-it hooks
         // from inside the suite body via this helper.
         browserDescribe("Login flow", () => {
@@ -838,7 +838,7 @@ Deeper documentation lives in `.ai/` — Claude will search it automatically whe
 - `.ai/wheels/views/` — layouts, partials, form helpers (including HTML5), link helpers
 - `.ai/wheels/database/` — migrations, queries, seeding, advanced operations
 - `.ai/wheels/cli/` — generators (including admin generator)
-- `.ai/wheels/testing/` — unit testing with TestBox, test infrastructure, common gotchas
+- `.ai/wheels/testing/` — unit testing with WheelsTest, test infrastructure, common gotchas
 - `.ai/wheels/configuration/` — routing, environments, settings, DI container
 
 ## Commit Message Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ If you're making a **breaking change** or working on **core functionality**, it'
 
 **Writing Tests:**
 
-* Use TestBox for new test cases
+* Use WheelsTest for new test cases
 * Place tests in the appropriate `/tests` directory
 * Follow existing test patterns and naming conventions
 * Include both positive and negative test cases
@@ -187,7 +187,7 @@ Understanding the monorepo structure will help you navigate contributions:
 * `/docs/` — API documentation and guides
 * `/examples/` — Sample applications
 * `/templates/` — Scaffolding templates for new apps
-* `/tests/` — TestBox test suites
+* `/tests/` — WheelsTest test suites
 * `/tools/` — Build scripts, Docker configs, utilities
 
 **Important Files:**
@@ -204,8 +204,8 @@ Understanding the monorepo structure will help you navigate contributions:
 **Dependencies:**
 Wheels 3.0 includes these core dependencies (automatically managed):
 
-* **WireBox** — Dependency injection and object management
-* **TestBox** — Testing framework
+* **wheelsdi** — Dependency injection and object management (in-house; formerly WireBox)
+* **WheelsTest** — Testing framework (in-house; formerly TestBox)
 
 **Database Support:**
 
@@ -241,6 +241,6 @@ When asking for help:
 
 ---
 
-💡 **New to Wheels 3.0?** The framework now uses a monorepo architecture with WireBox and TestBox as core dependencies. The directory structure has been modernized with `/app`, `/public`, and `/vendor` directories. Take time to explore these changes.
+💡 **New to Wheels 3.0?** The framework now uses a monorepo architecture with wheelsdi and WheelsTest as core components. The directory structure has been modernized with `/app`, `/public`, and `/vendor` directories. Take time to explore these changes.
 
 **Thank you for contributing to Wheels!**

--- a/docs/src/command-line-tools/cli-guides/testing.md
+++ b/docs/src/command-line-tools/cli-guides/testing.md
@@ -4,7 +4,7 @@ Comprehensive guide to testing in Wheels applications using the CLI.
 
 ## Overview
 
-Wheels CLI provides robust testing capabilities through TestBox integration, offering:
+Wheels CLI provides robust testing capabilities through WheelsTest integration, offering:
 - Unit and integration testing
 - BDD-style test writing
 - Watch mode for continuous testing
@@ -403,7 +403,7 @@ component {
     };
     this.datasource = "test";
 
-    // TestBox settings
+    // WheelsTest settings (preserves the Application.cfc `this.testbox` convention for back-compat)
     this.testbox = {
         bundles: ["tests"],
         recurse: true,
@@ -753,4 +753,4 @@ wheels test run --db=oracle
 
 - [wheels test run](../commands/test/test-run.md) - Test execution command
 - [wheels test advanced](../commands/test/test-advanced.md) - Advanced test options
-- [TestBox Documentation](https://testbox.ortusbooks.com/) - Complete TestBox guide
+- [BDD syntax reference (upstream TestBox docs)](https://testbox.ortusbooks.com/) — WheelsTest inherits the BDD syntax from upstream Ortus TestBox

--- a/docs/src/working-with-wheels/browser-testing.md
+++ b/docs/src/working-with-wheels/browser-testing.md
@@ -231,7 +231,7 @@ wheels browser:test --verbose
 |---|---|---|
 | Language | CFML (`.cfc` files) | TypeScript/JavaScript (`.spec.ts`) |
 | Setup | `wheels browser:install` | `npm install && npx playwright install` |
-| Test runner | TestBox (runs in Wheels) | Playwright Test (runs in Node.js) |
+| Test runner | WheelsTest (runs in Wheels) | Playwright Test (runs in Node.js) |
 | Best for | Framework tests, CFML-centric teams | Frontend-heavy apps, JS-centric teams |
 | Browser support | Chromium only | Chromium, Firefox, WebKit |
 
@@ -239,7 +239,7 @@ Both approaches are valid. Use native CFML if you want tests alongside your mode
 
 ## See Also
 
-- [Testing Your Application](testing-your-application.md) — Unit and integration testing with TestBox
+- [Testing Your Application](testing-your-application.md) — Unit and integration testing with WheelsTest
 - [End-to-End Testing](end-to-end-testing.md) — Node.js/TypeScript Playwright approach
 - [`wheels browser:install`](../command-line-tools/commands/browser/browser-install.md) — CLI command reference
 - [`wheels browser:test`](../command-line-tools/commands/browser/browser-test.md) — CLI command reference

--- a/docs/src/working-with-wheels/directory-structure.md
+++ b/docs/src/working-with-wheels/directory-structure.md
@@ -46,7 +46,7 @@ public/
   Application.cfc
   index.cfm
 tests/
-  TestBox/
+  specs/
 vendor
 ```
 
@@ -141,7 +141,7 @@ compose.yml
 
 **test-artifacts/** - Files generated during test suite execution, typically excluded from version control.
 
-**tests/** - Complete TestBox test suite for framework validation and regression testing.
+**tests/** - Complete WheelsTest test suite for framework validation and regression testing.
 
 **tools/** - Build scripts, Docker configurations, and development utilities for maintaining the framework.
 

--- a/docs/src/working-with-wheels/end-to-end-testing.md
+++ b/docs/src/working-with-wheels/end-to-end-testing.md
@@ -7,7 +7,7 @@ description: A comprehensive guide to end-to-end testing your Wheels application
 This guide covers how to install, configure, and run Playwright end-to-end (E2E) tests for your Wheels application. Playwright enables you to test your application from a user's perspective, simulating real browser interactions across multiple browsers.
 
 {% hint style="info" %}
-This guide covers the **Node.js/TypeScript Playwright** approach. For native CFML browser testing that runs inside TestBox, see [Browser Testing](browser-testing.md).
+This guide covers the **Node.js/TypeScript Playwright** approach. For native CFML browser testing that runs inside WheelsTest, see [Browser Testing](browser-testing.md).
 {% endhint %}
 
 ## Overview
@@ -490,6 +490,6 @@ Verify the server is listening on the correct interface:
 
 ## Related Documentation
 
-- [Testing Your Application](testing-your-application.md) - Unit and integration testing with TestBox
+- [Testing Your Application](testing-your-application.md) - Unit and integration testing with WheelsTest
 - [Using the Test Environment](using-the-test-environment.md) - Docker-based test environment for framework testing
 - [Request Handling](handling-requests-with-controllers/request-handling.md) - Understanding Wheels request lifecycle

--- a/docs/wheels-vs-frameworks.md
+++ b/docs/wheels-vs-frameworks.md
@@ -213,7 +213,7 @@ Only Wheels and Laravel have full DI containers. Wheels uses explicit `map/bind`
 
 | Capability | Wheels | Rails | Laravel | Django |
 |---|---|---|---|---|
-| Test framework | TestBox (BDD) | Minitest/RSpec | PHPUnit/Pest | pytest/unittest |
+| Test framework | WheelsTest (BDD) | Minitest/RSpec | PHPUnit/Pest | pytest/unittest |
 | BDD syntax | `describe/it/expect` | RSpec `describe/it/expect` | Pest `describe/it/expect` | pytest style |
 | Fixtures/Factories | Test models + populate.cfm | Fixtures + FactoryBot | Factories (Eloquent) | Fixtures + factory_boy |
 | HTTP/integration testing | Built-in `TestClient` (`visit/get/post`, `assertOk/assertSee/assertJson/...`) | Integration tests + Capybara | HTTP tests + Dusk | Client + Selenium |

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ A complete, production-ready starter application that showcases best practices f
 - **Modern Architecture**: Clean separation of concerns with MVC pattern
 - **Database Integration**: Complete model setup with migrations
 - **RESTful API**: Example endpoints following REST conventions
-- **Testing Suite**: Comprehensive test coverage with TestBox
+- **Testing Suite**: Comprehensive test coverage with WheelsTest
 - **Deployment Ready**: Docker configuration and deployment scripts
 
 ## Installation

--- a/examples/starter-app/README.md
+++ b/examples/starter-app/README.md
@@ -125,7 +125,7 @@ plugins/            # Third-party plugins
 - **3.1.0-snapshot** - MVC Framework
 - **Lucee 5,6,7, Adobe 2018-2025, Boxlang** - CFML Engine
 - **Database** - MySQL, PostgreSQL, Microsoft SQL Server, Oracle, SQLite, H2
-- **TestBox** - Testing framework (vendored with Wheels)
+- **WheelsTest** - Testing framework (vendored with Wheels)
 
 ### Frontend
 
@@ -293,10 +293,10 @@ tests/
 
 ```bash
 # Run all tests
-box testbox run
+wheels test run
 
 # Run specific test suite
-box testbox run --directory tests/requests/
+wheels test run --directory tests/requests/
 ```
 
 ## Support & Resources

--- a/examples/tweet/.claude/skills/README.md
+++ b/examples/tweet/.claude/skills/README.md
@@ -108,7 +108,7 @@ Generate database-agnostic Wheels migrations for schema changes.
 **Auto-fixes all detected issues before writing files!**
 
 #### 6. [wheels-test-generator](wheels-test-generator/SKILL.md)
-Generate TestBox BDD test specs for models, controllers, and integrations.
+Generate WheelsTest BDD test specs for models, controllers, and integrations.
 
 **Activates when:**
 - Creating tests/specs

--- a/examples/tweet/.claude/skills/SKILLS-QUICK-START.md
+++ b/examples/tweet/.claude/skills/SKILLS-QUICK-START.md
@@ -65,7 +65,7 @@ Result: Complete blog in 3 minutes!
 3. **wheels-view-generator** - Views with proper query handling
 4. **wheels-migration-generator** - Database-agnostic migrations
 5. **wheels-anti-pattern-detector** - Automatic code validation (ALWAYS ON)
-6. **wheels-test-generator** - TestBox BDD specs
+6. **wheels-test-generator** - WheelsTest BDD specs
 7. **wheels-debugging** - Error troubleshooting
 8. **wheels-refactoring** - Performance optimization
 9. **wheels-api-generator** - RESTful JSON APIs

--- a/examples/tweet/AGENTS.md
+++ b/examples/tweet/AGENTS.md
@@ -274,7 +274,7 @@ Wheels follows the Model-View-Controller (MVC) architectural pattern:
 - **Configuration** (`/config/`): Application settings, routes, environment configurations
 - **Database** (`/app/migrator/migrations/`): Version-controlled schema changes
 - **Assets** (`/public/`): Static files, CSS, JavaScript, images
-- **Tests** (`/tests/`): TestBox unit and integration tests
+- **Tests** (`/tests/`): WheelsTest unit and integration tests
 
 ### Directory Structure
 ```

--- a/packages/legacyadapter/README.md
+++ b/packages/legacyadapter/README.md
@@ -79,7 +79,7 @@ The scanner detects these patterns and provides guidance:
 | `renderPageToString()` | Critical | All files | Must be replaced |
 | `this.version =` | Warning | `plugins/` only | Plugin version — move to package.json |
 | `this.dependency =` | Warning | `plugins/` only | Plugin deps — move to package.json |
-| `extends="wheels.Test"` | Warning | All files | Use `wheels.WheelsTest` for TestBox |
+| `extends="wheels.Test"` | Warning | All files | Use `wheels.WheelsTest` (BDD) |
 | `application.wheels.*` access | Info | All files | Consider DI container |
 | `extends="Model"` (short) | Info | All files | Future-proof to full path |
 | `extends="Controller"` (short) | Info | All files | Future-proof to full path |

--- a/packages/sentry/CLAUDE.md
+++ b/packages/sentry/CLAUDE.md
@@ -26,7 +26,7 @@ packages/sentry/
 ├── box.json               # CommandBox package metadata
 ├── README.md              # User-facing documentation
 └── tests/
-    └── SentrySpec.cfc     # TestBox BDD specs
+    └── SentrySpec.cfc     # WheelsTest BDD specs
 ```
 
 ## Configuration

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Wheels Testing Quick Start
 
-This directory contains the test suite for your Wheels application using TestBox.
+This directory contains the test suite for your Wheels application using WheelsTest.
 
 ## Quick Start
 
@@ -21,13 +21,13 @@ wheels generate test api v1.users
 
 ```bash
 # Run all tests
-box testbox run
+wheels test run
 
 # Run specific directory
-box testbox run --directory=tests/specs/unit
+wheels test run --directory=tests/specs/unit
 
 # Watch mode for TDD
-box testbox watch
+wheels test watch
 ```
 
 Or visit: `http://localhost/tests/runner.cfm`
@@ -136,6 +136,5 @@ wheels test migrate tests --recursive
 ## Documentation
 
 For comprehensive documentation, see:
-- [Testing with TestBox Guide](/docs/testing-with-testbox.md)
-- [TestBox Documentation](https://testbox.ortusbooks.com/)
 - [Wheels Testing Guide](https://wheels.dev/3.1.0/guides/working-with-wheels/testing-your-application)
+- [BDD syntax reference (upstream TestBox docs)](https://testbox.ortusbooks.com/) — WheelsTest inherits the same BDD syntax as upstream Ortus TestBox


### PR DESCRIPTION
## Summary

Repo-wide sweep applying the three-bucket rename rubric to **20 forward-looking documentation files**. Companion to #2125 (3.0 → 4.0 comparison) and #2126 (audit + CHANGELOG follow-up). Closes the bulk of the `TestBox` → `WheelsTest` rename work across the documentation surface.

**Rubric applied (from #2126):**

| Bucket | Treatment |
|---|---|
| Current framework identity | Rename → `WheelsTest` |
| BDD style/pattern name | Drop qualifier → `BDD syntax` |
| Historical / rename-event / upstream-project references | **Preserved** |

## Files touched (20 total, 75 insertions / 74 deletions)

**User-facing docs:**
- `docs/wheels-vs-frameworks.md` (parity comparison)
- `docs/src/working-with-wheels/{directory-structure,end-to-end-testing,browser-testing}.md`
- `docs/src/command-line-tools/cli-guides/testing.md`
- `tests/README.md`

**Developer-facing:**
- `CLAUDE.md`, `CONTRIBUTING.md`

**Claude reference docs (`.ai/wheels/`):**
- `testing/{browser-testing,unit-testing}.md`
- `{views,controllers,models}/testing.md`

**Examples:**
- `examples/{README,starter-app/README,tweet/AGENTS}.md`
- `examples/tweet/.claude/skills/{README,SKILLS-QUICK-START}.md`

**Packages:**
- `packages/{legacyadapter/README,sentry/CLAUDE}.md`

## Legitimate retentions (per bucket 3)

These references deliberately kept:

| What | Where | Why |
|---|---|---|
| "formerly TestBox" | `CONTRIBUTING.md:207-208` | Historical provenance |
| `testbox.ortusbooks.com` URLs with "upstream TestBox docs" labels | Several | Genuine upstream-project references for BDD syntax |
| `this.testbox = {...}` Application.cfc property | `cli-guides/testing.md:407` | CFML back-compat convention that WheelsTest preserves |
| `/tmp/testbox_results.json` temp filenames | `.ai/wheels/testing/unit-testing.md:131-132` | Example shell-command temp file, cosmetic only |

## Bonus correctness fixes caught during sweep

- **Stale directory tree** in `docs/src/working-with-wheels/directory-structure.md:48-49` — listed `tests/TestBox/` which doesn't exist in the actual filesystem. Changed to `tests/specs/` to match reality.
- **CLI command modernization** in `tests/README.md` and `examples/starter-app/README.md` — `box testbox run` → `wheels test run`, matching the canonical Wheels CLI form documented in CLAUDE.md's Testing Quick Reference.
- **`.ai/wheels/{views,controllers,models}/testing.md`** — "Modern TestBox Resources" sections retitled to "BDD Reference — Upstream TestBox Docs" with explicit clarification that WheelsTest inherits the BDD syntax from upstream Ortus TestBox. Link text stripped of `TestBox` prefix since the section heading already establishes provenance.

## Deferred to editorial follow-up PRs

These files have complex mixes of stale code snippets, CommandBox CLI commands, external URLs, and prose that need per-line editorial judgment beyond mechanical rename:

- `docs/src/working-with-wheels/testing-your-application.md` (39 refs) — has outdated `testbox.system.TestBox(...)` code paths that need functional update to `wheels.wheelstest.system.TestBox(...)` per the actual `tests/runner.cfm`
- `cli/WHEELS-CLI-ROADMAP.md` (15 refs) — roadmap doc, needs forward-looking vs historical classification
- `examples/tweet/.claude/commands/wheels_execute.md` (10 refs) + `.opencode/command/wheels_execute.md` (11 refs) — tweet example commands that need verification they still work

## Out of scope

- `docs/superpowers/plans/**` and `docs/superpowers/specs/**` — historical planning artifacts. Per bucket 3, these describe what was planned at the time with the names that existed then. Retroactively rewriting them would erase provenance of contemporaneous decision-making.

## Test plan

- [x] All 20 modified files: grep confirms remaining TestBox refs are in bucket-3 retention category
- [x] `replace_all` on "TestBox BDD" was applied to 3 `.ai/` files; link-text collisions fixed by rewriting the Upstream BDD Reference section wholesale
- [x] Cross-checked against actual `tests/runner.cfm` to pick the correct namespace (`wheels.wheelstest.system.*`) before deciding what's current vs stale
- [ ] Manual reviewer scan of the diff for any retention-vs-rename judgment that should flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)