### PR TITLE
docs: rename TestBox to WheelsTest in CLI roadmap + tweet example

### DIFF
--- a/cli/WHEELS-CLI-ROADMAP.md
+++ b/cli/WHEELS-CLI-ROADMAP.md
@@ -2,6 +2,8 @@
 
 This document outlines the CLI commands that a modern Wheels framework should implement, inspired by Rails, Laravel, and leveraging CommandBox's native capabilities and the ForgeBox ecosystem.
 
+> **Note:** The testing-strategy sections below predate the WheelsTest fork decision. They recommend integrating the external `commandbox-testbox-cli` module. The actual direction taken in Wheels 4.0 was to fork TestBox in-house as WheelsTest and provide `wheels test run` / `wheels browser:test` natively via the Wheels CLI. Those sections are preserved for historical context but should be revised in a follow-up editorial pass.
+
 ## Philosophy: Embrace the Ecosystem
 
 Rather than building everything from scratch, we should leverage existing CommandBox modules from ForgeBox where possible, focusing our development efforts on Wheels-specific functionality.

--- a/examples/tweet/.claude/commands/wheels_execute.md
+++ b/examples/tweet/.claude/commands/wheels_execute.md
@@ -924,7 +924,7 @@ hasMany(name="comments", dependent="delete");  // ✅ Continue
 #startFormTag(...)##authenticityToken()#  // ✅ Continue
 ```
 
-### Phase 4: TestBox BDD Test Suite Creation (10-20 minutes)
+### Phase 4: WheelsTest BDD Test Suite Creation (10-20 minutes)
 - **⏰ TIMING**: Tests are written AFTER implementation is complete (not before - this is not TDD)
 - **✅ REQUIREMENT**: Tests MUST be written BEFORE marking feature complete
 - **🧹 CLEANUP**: All tests must include proper `beforeEach()` and `afterEach()` for isolation
@@ -1367,7 +1367,7 @@ A feature is only considered complete when ALL of the following are true:
 - [ ] ✅ **MCP server connection validated before starting**
 - [ ] ✅ All relevant `.ai` documentation was consulted
 - [ ] ✅ No anti-patterns detected in generated code
-- [ ] ✅ **Comprehensive TestBox BDD test suite written and passing**
+- [ ] ✅ **Comprehensive WheelsTest BDD test suite written and passing**
 - [ ] ✅ **All model BDD specs pass (validations, associations, methods)**
 - [ ] ✅ **All controller BDD specs pass (actions, filters, security)**
 - [ ] ✅ **All integration BDD specs pass (user workflows, CRUD)**
@@ -1432,7 +1432,7 @@ The workflow automatically tests:
 Code will be automatically rejected if:
 - Any mixed argument styles are detected
 - Any `ArrayLen()` calls on model associations exist
-- **Any TestBox BDD spec fails**
+- **Any WheelsTest BDD spec fails**
 - **Test coverage is below 90%**
 - **Missing BDD specs for any component**
 - Any browser test fails
@@ -1454,11 +1454,11 @@ Code will be automatically rejected if:
 - Input validation must be implemented
 - SQL injection prevention must be verified
 
-## TestBox BDD Testing Requirements
+## WheelsTest BDD Testing Requirements
 
 ### Mandatory BDD Test Structure
 
-Every component MUST have comprehensive TestBox BDD specs using the following structure:
+Every component MUST have comprehensive WheelsTest BDD specs using the following structure:
 
 #### Model Specs (`/tests/specs/models/`)
 ```cfm
@@ -1466,7 +1466,7 @@ component extends="wheels.WheelsTest" {
 
     function beforeAll() {
         // Setup database and test environment
-        application.testbox = new testbox.system.TestBox();
+        application.wheelstest = new wheels.wheelstest.system.TestBox();
     }
 
     function afterAll() {
@@ -1562,7 +1562,7 @@ component extends="wheels.WheelsTest" {
 component extends="wheels.WheelsTest" {
 
     function beforeAll() {
-        application.testbox = new testbox.system.TestBox();
+        application.wheelstest = new wheels.wheelstest.system.TestBox();
     }
 
     function run() {
@@ -1763,7 +1763,7 @@ wheels test all --reporter=json
 - **Overall**: Minimum 90% total coverage across all components
 
 #### Test Data Management
-- Use TestBox's `beforeEach()` and `afterEach()` for test isolation
+- Use WheelsTest's `beforeEach()` and `afterEach()` for test isolation
 - Create test fixtures for complex scenarios
 - Always clean up test data to prevent test pollution
 - Use database transactions for faster test execution
@@ -1807,7 +1807,7 @@ Error: MCP server not responding
 → Fallback: Document why MCP unavailable, use CLI tools as last resort
 ```
 
-#### TestBox BDD Test Failure Recovery
+#### WheelsTest BDD Test Failure Recovery
 ```
 Error: BDD specs failing or missing
 → Load: .ai/wheels/testing/ documentation
@@ -1864,7 +1864,7 @@ Based on application type detected:
 - **Flexibility**: Claude Code can adapt the workflow dynamically
 - **Error Handling**: Better error recovery and human-readable feedback
 - **Documentation Integration**: Direct access to `.ai` folder without MCP resource limitations
-- **Comprehensive Testing**: TestBox BDD specs + Browser testing + Integration testing
+- **Comprehensive Testing**: WheelsTest BDD specs + Browser testing + Integration testing
 - **Test Coverage**: Mandatory 90%+ coverage with detailed analysis
 - **Quality Assurance**: No feature complete without passing test suite
 - **Reporting**: Rich, detailed reporting with screenshots, test results, and coverage analysis

--- a/examples/tweet/.opencode/command/wheels_execute.md
+++ b/examples/tweet/.opencode/command/wheels_execute.md
@@ -24,7 +24,7 @@ The `/wheels_execute` command implements a comprehensive 7-phase development wor
 1. **Pre-Flight Documentation Loading** - Systematically load relevant patterns from `.ai` folder
 2. **Intelligent Analysis & Planning** - Parse requirements and create detailed implementation plan
 3. **Template-Driven Implementation** - Generate code using established patterns with error recovery
-4. **TestBox BDD Test Suite Creation** - Write comprehensive BDD tests before marking complete
+4. **WheelsTest BDD Test Suite Creation** - Write comprehensive BDD tests before marking complete
 5. **Multi-Level Testing Execution** - Run unit tests, integration tests, and validation
 6. **Comprehensive Browser Testing** - Test every button, form, and link automatically
 7. **Quality Assurance & Reporting** - Anti-pattern detection and final validation
@@ -51,7 +51,7 @@ The `/wheels_execute` command implements a comprehensive 7-phase development wor
 - **Consistency Enforcement**: Ensure patterns match existing codebase
 - **Security Integration**: Add CSRF protection, validation, authentication
 
-### Phase 4: TestBox BDD Test Suite Creation (10-20 minutes)
+### Phase 4: WheelsTest BDD Test Suite Creation (10-20 minutes)
 - **Model Tests**: Write BDD specs for all model functionality, validations, and associations
 - **Controller Tests**: Write BDD specs for all controller actions and security filters
 - **Integration Tests**: Write BDD specs for complete user workflows and CRUD operations
@@ -124,7 +124,7 @@ model("Post").findByKey(params.key);
 A feature is only considered complete when ALL of the following are true:
 - [ ] ✅ All relevant `.ai` documentation was consulted
 - [ ] ✅ No anti-patterns detected in generated code
-- [ ] ✅ **Comprehensive TestBox BDD test suite written and passing**
+- [ ] ✅ **Comprehensive WheelsTest BDD test suite written and passing**
 - [ ] ✅ **All model BDD specs pass (validations, associations, methods)**
 - [ ] ✅ **All controller BDD specs pass (actions, filters, security)**
 - [ ] ✅ **All integration BDD specs pass (user workflows, CRUD)**
@@ -189,7 +189,7 @@ The workflow automatically tests:
 Code will be automatically rejected if:
 - Any mixed argument styles are detected
 - Any `ArrayLen()` calls on model associations exist
-- **Any TestBox BDD spec fails**
+- **Any WheelsTest BDD spec fails**
 - **Test coverage is below 90%**
 - **Missing BDD specs for any component**
 - Any browser test fails
@@ -210,11 +210,11 @@ Code will be automatically rejected if:
 - Input validation must be implemented
 - SQL injection prevention must be verified
 
-## TestBox BDD Testing Requirements
+## WheelsTest BDD Testing Requirements
 
 ### Mandatory BDD Test Structure
 
-Every component MUST have comprehensive TestBox BDD specs using the following structure:
+Every component MUST have comprehensive WheelsTest BDD specs using the following structure:
 
 #### Model Specs (`/tests/specs/models/`)
 ```cfm
@@ -222,7 +222,7 @@ component extends="wheels.WheelsTest" {
 
     function beforeAll() {
         // Setup database and test environment
-        application.testbox = new testbox.system.TestBox();
+        application.wheelstest = new wheels.wheelstest.system.TestBox();
     }
 
     function afterAll() {
@@ -318,7 +318,7 @@ component extends="wheels.WheelsTest" {
 component extends="wheels.WheelsTest" {
 
     function beforeAll() {
-        application.testbox = new testbox.system.TestBox();
+        application.wheelstest = new wheels.wheelstest.system.TestBox();
     }
 
     function run() {
@@ -503,7 +503,7 @@ wheels test all --coverage --reporter=json
 - **Overall**: Minimum 90% total coverage across all components
 
 #### Test Data Management
-- Use TestBox's `beforeEach()` and `afterEach()` for test isolation
+- Use WheelsTest's `beforeEach()` and `afterEach()` for test isolation
 - Create test fixtures for complex scenarios
 - Always clean up test data to prevent test pollution
 - Use database transactions for faster test execution
@@ -538,7 +538,7 @@ Error: ArrayLen() on query object detected
 → Validate: Browser test confirms functionality
 ```
 
-#### TestBox BDD Test Failure Recovery
+#### WheelsTest BDD Test Failure Recovery
 ```
 Error: BDD specs failing or missing
 → Load: .ai/wheels/testing/ documentation
@@ -595,7 +595,7 @@ Based on application type detected:
 - **Flexibility**: Claude Code can adapt the workflow dynamically
 - **Error Handling**: Better error recovery and human-readable feedback
 - **Documentation Integration**: Direct access to `.ai` folder without MCP resource limitations
-- **Comprehensive Testing**: TestBox BDD specs + Browser testing + Integration testing
+- **Comprehensive Testing**: WheelsTest BDD specs + Browser testing + Integration testing
 - **Test Coverage**: Mandatory 90%+ coverage with detailed analysis
 - **Quality Assurance**: No feature complete without passing test suite
 - **Reporting**: Rich, detailed reporting with screenshots, test results, and coverage analysis


### PR DESCRIPTION
## Summary

Editorial follow-up PR to #2127 (20-file sweep) and #2128 (testing-your-application.md). Covers the last three files deferred from the sweep:

- `cli/WHEELS-CLI-ROADMAP.md` (15 refs)
- `examples/tweet/.claude/commands/wheels_execute.md` (10 refs)
- `examples/tweet/.opencode/command/wheels_execute.md` (11 refs)

## Changes

### `cli/WHEELS-CLI-ROADMAP.md` — status banner added

The roadmap's testing-strategy sections predate the WheelsTest fork decision. They originally proposed integrating the external `commandbox-testbox-cli` module; the actual direction taken in Wheels 4.0 was to fork TestBox in-house as WheelsTest and ship `wheels test run` / `wheels browser:test` natively.

Rather than rewriting those strategy sections (which would be beyond a rename-sweep scope), I added a **banner at the top** flagging the drift:

```markdown
> **Note:** The testing-strategy sections below predate the WheelsTest fork decision.
> They recommend integrating the external `commandbox-testbox-cli` module. The actual
> direction taken in Wheels 4.0 was to fork TestBox in-house as WheelsTest and provide
> `wheels test run` / `wheels browser:test` natively via the Wheels CLI. Those sections
> are preserved for historical context but should be revised in a follow-up editorial pass.
```

References deliberately preserved (within the banner's coverage):
- Section 4 "Advanced Testing (via TestBox CLI Module)"
- "Leverage Existing Modules" item 1
- Phase 1 Module Integration steps
- CommandBox Integration Points section
- `box.json` dependency listing for `commandbox-testbox-cli`
- Recommended Module Installation section

This preserves the historical record of the earlier strategy while making it clear it's been superseded. Reviewers who want to rewrite those sections can do so in a separate editorial PR.

### `examples/tweet/.claude/commands/wheels_execute.md` — rename sweep

- `TestBox BDD` → `WheelsTest BDD` (descriptive references)
- `testbox.system.TestBox` → `wheels.wheelstest.system.TestBox` (code paths)
- `application.testbox` → `application.wheelstest` (CFML scope)
- `"Use TestBox's beforeEach/afterEach"` → `"Use WheelsTest's …"`

### `examples/tweet/.opencode/command/wheels_execute.md` — same pattern

Mirror opencode variant of the Claude command file. Same treatment.

## Legitimate retentions

**In the roadmap** (covered by banner): all the external `commandbox-testbox-cli` module references, preserved as historical strategy record.

**In the tweet files**: just the code references `wheels.wheelstest.system.TestBox` — which are correct class paths, not outdated references.

## Test plan

- [x] Roadmap banner makes the superseded-strategy context clear before readers hit the affected sections
- [x] All tweet-file code paths updated to match the canonical `wheels.wheelstest.system.*` namespace (per `tests/runner.cfm`)
- [x] No CommandBox package identifiers (`commandbox-testbox-cli`) incorrectly renamed — those are specific third-party package names
- [ ] Optional follow-up PR: rewrite the roadmap's testing sections to reflect WheelsTest direction, remove the commandbox-testbox-cli dependencies, and update example commands

## Closes the rename initiative

With this PR, every forward-looking documentation file referencing `TestBox` has been updated per the three-bucket rubric. Remaining references across the repo are:
- Upstream URL labels to `testbox.ortusbooks.com`
- Historical/event descriptions (rename events, replacement events, 3.0.0 CHANGELOG section)
- Historical planning artifacts in `docs/superpowers/plans/**` and `docs/superpowers/specs/**` (out of scope per earlier agreement)
- The preserved strategy sections in this roadmap, covered by the new banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)