### PR TITLE
docs: add Wheels 4.0 blog post skeletons

### DIFF
--- a/docs/releases/blog-skeletons/01-closing-the-maturity-gap.md
+++ b/docs/releases/blog-skeletons/01-closing-the-maturity-gap.md
@@ -1,0 +1,125 @@
+---
+status: skeleton
+slot: lead post (publish first)
+target_length: 1200–1600 words
+---
+
+# Wheels 4.0 — Closing the Maturity Gap
+
+**Subhead / dek:** *Fourteen weeks, 185 PRs, and the features that finally put Wheels shoulder-to-shoulder with Rails 8, Laravel 12, and Django 5.*
+
+**Target audience:**
+- Current Wheels users wondering whether 4.0 is "just a point release"
+- CFML developers evaluating whether to stay on the platform
+- Framework watchers outside CFML who last looked at CFWheels 2.x and moved on
+- Engineering leads deciding whether Wheels can be a safe default for new projects
+
+**Lead paragraph intent (3–4 sentences, NOT prose):**
+- Frame: for years, framework comparisons listed the same CFWheels gaps — no bulk ops, no polymorphic assocs, no advisory locks, no first-class middleware, no browser testing.
+- Pivot: those gaps were real, and they're now closed.
+- Scope: 185 PRs between 3.0.0 (Jan 10) and 4.0 (Apr 16) — roughly 14 weeks.
+- Promise of the post: a guided tour of *the gaps that closed*, organized by what users actually do with the framework.
+
+## Sections
+
+### 1. "The comparison table problem"
+- Every framework-comparison blog post from the last five years had the same CFWheels rows: *no*, *no*, *via plugin*, *manual*.
+- [`docs/wheels-vs-frameworks.md`](https://github.com/wheels-dev/wheels/blob/develop/docs/wheels-vs-frameworks.md) used to look a certain way. Here's what changed.
+- Hand-off to the next section: show the gaps, then show how they closed.
+
+### 2. Data layer — bulk ops, polymorphism, advisory locks
+- **Bulk insert / upsert** ([#2101](https://github.com/wheels-dev/wheels/pull/2101)) — per-adapter native UPSERT for MySQL, PostgreSQL, SQL Server, SQLite, H2, CockroachDB, Oracle.
+- **Polymorphic associations** ([#2104](https://github.com/wheels-dev/wheels/pull/2104)) — `belongsTo(polymorphic=true)` + `hasMany(as=)`.
+- **Advisory locks + pessimistic locking** ([#2103](https://github.com/wheels-dev/wheels/pull/2103)) — `withAdvisoryLock(name, callback)` and `.forUpdate()` on QueryBuilder.
+- **Chainable query builder, scopes, enums, batch processing** ([#1919](https://github.com/wheels-dev/wheels/pull/1919)–[#1922](https://github.com/wheels-dev/wheels/pull/1922)) — Rails-idiom parity.
+- **CockroachDB adapter** ([#1876](https://github.com/wheels-dev/wheels/pull/1876) + follow-ups) — seventh supported DB.
+
+### 3. Migrations — auto-diff from models
+- **Auto-migrations** ([#2102](https://github.com/wheels-dev/wheels/pull/2102)) + **rename detection** ([#2112](https://github.com/wheels-dev/wheels/pull/2112)) — Django's `makemigrations` energy with CLI + MCP surface.
+- Beats Rails and Laravel on this specific axis (both still require manual migrations).
+
+### 4. Routing and controllers — middleware + model binding
+- **First-class middleware pipeline** ([#1924](https://github.com/wheels-dev/wheels/pull/1924)).
+- **Route model binding** ([#1929](https://github.com/wheels-dev/wheels/pull/1929)).
+- **Typed route constraints + API versioning** ([#1891](https://github.com/wheels-dev/wheels/pull/1891)).
+
+### 5. Real-time and background work
+- **Background jobs without Redis** ([#1934](https://github.com/wheels-dev/wheels/pull/1934)) — tease post #4.
+- **SSE pub/sub channels** ([#1940](https://github.com/wheels-dev/wheels/pull/1940)).
+- **Multi-tenancy in-core** ([#1951](https://github.com/wheels-dev/wheels/pull/1951)) — tease post #7.
+
+### 6. Testing — the category that was most embarrassing, now most complete
+- **HTTP TestClient** ([#2099](https://github.com/wheels-dev/wheels/pull/2099)).
+- **Parallel test runner** ([#2100](https://github.com/wheels-dev/wheels/pull/2100)).
+- **Browser testing via Playwright Java** ([#2113](https://github.com/wheels-dev/wheels/pull/2113) + series).
+- Tease post #6.
+
+### 7. DI and core
+- **Expanded DI container** ([#1933](https://github.com/wheels-dev/wheels/pull/1933)) — request-scoped services, auto-wiring.
+- **Package system** ([#1995](https://github.com/wheels-dev/wheels/pull/1995) + [#2017](https://github.com/wheels-dev/wheels/pull/2017)).
+
+### 8. Security and developer experience (brief, tease post #3)
+- 40+ security-hardening PRs.
+- Deny-all CORS default, HSTS default-on in prod, CSRF key required in prod.
+
+### 9. Where Wheels still trails — be honest
+- **Ecosystem size** — smaller than Rails/Laravel/Django communities.
+- **Bidirectional WebSocket** — intentional non-goal; SSE is the cross-engine-uniform primitive.
+- **Asset-pipeline maturity** — Vite integration is newer than Rails' / Laravel's tooling. (Follow-on work underway.)
+
+### 10. What this means for your 3.x app
+- Point to post #2 ("Upgrading from Wheels 3.x") and the upgrade guide.
+- Mention the Legacy Compatibility Adapter ([#2015](https://github.com/wheels-dev/wheels/pull/2015)) for the soft landing.
+
+## Code / config snippets to include (pick 3)
+
+```cfm
+// Bulk upsert (adapter-native UPSERT syntax)
+model("Product").upsertAll(records, uniqueBy="sku");
+
+// Polymorphic association
+hasMany(name="comments", as="commentable", polymorphic=true);
+
+// Advisory lock
+application.wo.withAdvisoryLock("payroll-run", () => {
+    processPayroll();
+});
+```
+
+```cfm
+// Middleware pipeline + route-scoped rate limiting
+mapper()
+    .scope(path="/api", middleware=[
+        new wheels.middleware.RateLimiter(maxRequests=100, windowSeconds=60)
+    ])
+        .resources("users")
+    .end()
+.end();
+```
+
+```cfm
+// Auto-migration diff
+var am = CreateObject("component", "wheels.migrator.AutoMigrator");
+var d = am.diff("User", {renames: {"full_name": "fullName"}});
+am.writeMigration(d, "rename_name_field");
+```
+
+## Suggested visuals
+
+- **Hero:** radar/spider chart — Rails 8, Laravel 12, Django 5, Wheels 3.0, Wheels 4.0 across 8 axes (ORM, migrations, middleware, real-time, testing, DI, security, jobs). Show the Wheels 3.0 line as conspicuously smaller; Wheels 4.0 overlaps the others.
+- **Secondary:** the closed-gap table from [`wheels-3.0-vs-4.0.md`](https://github.com/wheels-dev/wheels/blob/develop/docs/releases/wheels-3.0-vs-4.0.md) — "Peer-framework context — where 4.0 closed gaps" — as a screenshot or re-rendered embed.
+
+## Outro / CTA (1 paragraph)
+
+- Thank contributors: @bpamiri, @zainforbjs, @chapmandu, @mlibbe.
+- Link to the upgrade guide.
+- Link to the full audit for the obsessive readers.
+- Subtle call for testers / feedback on the release candidate.
+
+## Citations (must link in final post)
+
+- [Feature audit](https://github.com/wheels-dev/wheels/blob/develop/docs/releases/wheels-4.0-audit.md)
+- [3.0 → 4.0 comparison](https://github.com/wheels-dev/wheels/blob/develop/docs/releases/wheels-3.0-vs-4.0.md)
+- [Wheels vs. frameworks](https://github.com/wheels-dev/wheels/blob/develop/docs/wheels-vs-frameworks.md)
+- [Upgrade guide](https://github.com/wheels-dev/wheels/blob/develop/docs/src/introduction/upgrading-to-4.0.md)
+- CHANGELOG entry for 4.0 (once tagged)

--- a/docs/releases/blog-skeletons/02-upgrading-from-3x.md
+++ b/docs/releases/blog-skeletons/02-upgrading-from-3x.md
@@ -1,0 +1,124 @@
+---
+status: skeleton
+slot: post 2 (existing-user focus; publish in week 1 alongside lead)
+target_length: 1400–1800 words
+---
+
+# Upgrading from Wheels 3.x
+
+**Subhead / dek:** *Ten breaking changes, one Legacy Compatibility Adapter, and an honest map of what you'll have to touch.*
+
+**Target audience:**
+- Existing Wheels 3.x users planning a 4.0 upgrade
+- Teams evaluating whether the upgrade fits a sprint or a quarter
+- Ops/SRE reviewers who want to know which defaults changed in production
+
+**Lead paragraph intent:**
+- Most 3.x apps will upgrade with minimal code changes.
+- But there are 10 specific places where behavior changed and you need to look.
+- This post walks each of them with detect / fix / opt-out guidance.
+- Links to the full upgrade guide for the complete reference.
+
+## Sections
+
+### 1. "The two-path upgrade"
+- **Path A — clean upgrade:** fix the 10 breaking items directly. Recommended for apps that want to stay on the golden path.
+- **Path B — Legacy Compatibility Adapter** ([#2015](https://github.com/wheels-dev/wheels/pull/2015)): enable it and most 3.x code continues to work while you migrate on your own schedule.
+- Frame the post around Path A with LCA callouts.
+
+### 2. The 10 breaking items (the heart of the post)
+
+Use a consistent 4-part micro-template per item: **What changed / How to detect / How to fix / Opt-out.**
+
+1. **CORS default: wildcard → deny-all** ([#2039](https://github.com/wheels-dev/wheels/pull/2039)).
+2. **HSTS default-on in production** ([#2081](https://github.com/wheels-dev/wheels/pull/2081)).
+3. **CSRF key required in production; JWT algorithm validation** ([#2079](https://github.com/wheels-dev/wheels/pull/2079)).
+4. **`allowEnvironmentSwitchViaUrl` default false in prod; reload password required** ([#2076](https://github.com/wheels-dev/wheels/pull/2076), [#2082](https://github.com/wheels-dev/wheels/pull/2082)).
+5. **`wheels snippets` → `wheels code`** ([#1852](https://github.com/wheels-dev/wheels/pull/1852)).
+6. **Test base class: `wheels.Test` → `wheels.WheelsTest`** ([#1889](https://github.com/wheels-dev/wheels/pull/1889)).
+7. **Tests directory rename: `tests/specs/functions/` → `tests/specs/functional/`** ([#1872](https://github.com/wheels-dev/wheels/pull/1872)).
+8. **Legacy RocketUnit removed from core** ([#1925](https://github.com/wheels-dev/wheels/pull/1925)) — existing RocketUnit specs still run; WheelsTest BDD mandatory for new.
+9. **RateLimiter `trustProxy` default false + proxy strategy `last`** ([#2024](https://github.com/wheels-dev/wheels/pull/2024), [#2088](https://github.com/wheels-dev/wheels/pull/2088)).
+10. **CFWheels → Wheels rebrand** ([#2064](https://github.com/wheels-dev/wheels/pull/2064)) — callers referencing old namespaces must update; most user code unaffected.
+
+### 3. The Legacy Compatibility Adapter
+- One-flag opt-in; documented surface; intended as a bridge, not a permanent layer.
+- When to use it (inherited monolith with unclear test coverage) vs when not (new code, small apps).
+- Link to LCA docs.
+
+### 4. Deprecations to address (not breakers, but don't sleep on them)
+- **Legacy `plugins/` folder** ([#1995](https://github.com/wheels-dev/wheels/pull/1995)) — still works, warns on load. Plan a migration to `packages/` → `vendor/`.
+- **Monolithic `paginationLinks()`** ([#1930](https://github.com/wheels-dev/wheels/pull/1930)) — retained for back-compat; new code should use `paginationNav()` or the composable helpers.
+- **`wheels.Test` extension** — retained; new specs extend `wheels.WheelsTest`.
+
+### 5. Recommended (not required) migrations
+- **Adopt the middleware pipeline** ([#1924](https://github.com/wheels-dev/wheels/pull/1924)) for cross-cutting concerns previously done with filters/plugins.
+- **Turn on route model binding** ([#1929](https://github.com/wheels-dev/wheels/pull/1929)) — cuts boilerplate `findByKey()` in every `show`/`edit`/`update`.
+- **Use the chainable QueryBuilder** for any place you were concatenating WHERE strings ([#1922](https://github.com/wheels-dev/wheels/pull/1922)).
+- **Adopt WheelsTest BDD** for new tests, even if old specs stay on RocketUnit/xUnit.
+- **Replace Redis-backed job queues with the built-in job worker** ([#1934](https://github.com/wheels-dev/wheels/pull/1934)) — tease post #4.
+
+### 6. Testing your upgrade
+- **Enable the test client** ([#2099](https://github.com/wheels-dev/wheels/pull/2099)) — write a smoke test that hits every top-level route and asserts 200/redirect.
+- **Run the parallel runner** ([#2100](https://github.com/wheels-dev/wheels/pull/2100)) — in 4.0 you should expect a noticeable speed-up regardless of upgrade path.
+- **Browser-test your critical-path flow** ([#2113](https://github.com/wheels-dev/wheels/pull/2113)) — login → do-the-thing → log out. 15 minutes of setup, lifetime of regression coverage.
+
+### 7. Production deploy checklist
+- Set `allowOrigins` explicitly (not `*`).
+- Set a non-empty CSRF encryption key.
+- Set a non-empty reload password.
+- If behind a proxy/load balancer, configure RateLimiter `trustProxy` + proxy strategy intentionally.
+- Confirm HSTS is what you want (max-age, includeSubDomains).
+- Run the framework's own test suite against your DB adapter if you've extended it.
+
+## Code / config snippets to include (pick 3)
+
+```cfm
+// Before 4.0: wildcard CORS, nothing to configure.
+// After 4.0: explicit allowOrigins required.
+set(middleware = [
+    new wheels.middleware.Cors(allowOrigins="https://myapp.com,https://admin.myapp.com")
+]);
+```
+
+```cfm
+// Before: legacy test base
+component extends="wheels.Test" { ... }
+
+// After: WheelsTest BDD
+component extends="wheels.WheelsTest" {
+    function run() {
+        describe("User", () => {
+            it("validates email", () => {
+                expect(model("User").new(email="bad").valid()).toBeFalse();
+            });
+        });
+    }
+}
+```
+
+```cfm
+// Opt-in soft landing: Legacy Compatibility Adapter
+// config/settings.cfm
+set(legacyCompatibilityAdapter=true);
+```
+
+## Suggested visuals
+
+- **Lead table:** compact 10-row before/after grid — one line per breaking item ("CORS: `*` → deny-all", "HSTS: off → on in prod", etc.). Screenshot-friendly; makes the scope tangible.
+- **Decision tree:** "Should you enable the LCA?" — 3 yes/no nodes, terminal recommendations. Two-color inline SVG.
+
+## Outro / CTA
+
+- "Most upgrades take an afternoon, not a sprint."
+- Point to the upgrade guide for the canonical reference.
+- Invite issues with the `upgrade` label for stuck teams.
+- Mention [#2131](https://github.com/wheels-dev/wheels/issues/2131) for GA tag status.
+
+## Citations (must link in final post)
+
+- [Upgrade guide](https://github.com/wheels-dev/wheels/blob/develop/docs/src/introduction/upgrading-to-4.0.md)
+- [3.0 → 4.0 comparison](https://github.com/wheels-dev/wheels/blob/develop/docs/releases/wheels-3.0-vs-4.0.md) (for the Breaking defaults hardened rows)
+- [Feature audit — Breaking changes section](https://github.com/wheels-dev/wheels/blob/develop/docs/releases/wheels-4.0-audit.md#breaking-changes)
+- Legacy Compatibility Adapter PR [#2015](https://github.com/wheels-dev/wheels/pull/2015)
+- All 10 Breaking PRs linked inline in section 2

--- a/docs/releases/blog-skeletons/03-security-hardening.md
+++ b/docs/releases/blog-skeletons/03-security-hardening.md
@@ -1,0 +1,141 @@
+---
+status: skeleton
+slot: post 3 (week 2; pairs with GA announce for security-minded audiences)
+target_length: 1600–2000 words
+---
+
+# Security Hardening in Wheels 4.0
+
+**Subhead / dek:** *Forty-plus PRs, one narrative: how 4.0 becomes a secure-by-default framework.*
+
+**Target audience:**
+- Security engineers auditing Wheels for enterprise adoption
+- Teams under compliance pressure (SOC2, HIPAA, PCI)
+- Existing Wheels users who want to know which defaults to trust
+- CFML community members who remember the era of "roll-your-own-CSRF"
+
+**Lead paragraph intent:**
+- 4.0 isn't a security release — it's a release that takes security seriously across 8 categories.
+- 40+ PRs, not a checkbox. Each category has a coherent posture now.
+- This post walks each attack surface: what 3.0 did, what attacker scenarios were in-scope, how 4.0 closes them.
+- Known-limitations honesty at the end.
+
+## Sections
+
+### 1. "What changed posture-wise"
+- 3.0 had per-issue security patches; 4.0 has secure-by-default opinions.
+- Not a CVE round-up — a *category-by-category* tightening.
+
+### 2. SQL injection — QueryBuilder + scope pipeline
+- **Category frame:** user-provided input reaching SQL generation.
+- **What hardened:**
+  - QueryBuilder property + operator validation ([#2025](https://github.com/wheels-dev/wheels/pull/2025)).
+  - ORDER BY clause ([#2026](https://github.com/wheels-dev/wheels/pull/2026)).
+  - `$quoteValue` single-quote escaping ([#2033](https://github.com/wheels-dev/wheels/pull/2033)).
+  - Scope handler argument sanitization ([#2043](https://github.com/wheels-dev/wheels/pull/2043), [#2045](https://github.com/wheels-dev/wheels/pull/2045), [#2056](https://github.com/wheels-dev/wheels/pull/2056), [#2061](https://github.com/wheels-dev/wheels/pull/2061), [#2070](https://github.com/wheels-dev/wheels/pull/2070), [#2090](https://github.com/wheels-dev/wheels/pull/2090)).
+  - Geography property detection ([#2044](https://github.com/wheels-dev/wheels/pull/2044)); WKT handling ([#2055](https://github.com/wheels-dev/wheels/pull/2055)).
+  - Index hints via `$indexHint` ([#2058](https://github.com/wheels-dev/wheels/pull/2058)).
+- **Takeaway:** scope handlers and QueryBuilder chains are safe to use with user-provided values — the framework validates structurally.
+
+### 3. Path traversal — multiple surfaces
+- Partial template rendering ([#2071](https://github.com/wheels-dev/wheels/pull/2071)).
+- `guideImage` endpoint ([#2037](https://github.com/wheels-dev/wheels/pull/2037)).
+- MCP documentation reader ([#2049](https://github.com/wheels-dev/wheels/pull/2049)).
+- Encoded-bypass attempts ([#2089](https://github.com/wheels-dev/wheels/pull/2089)).
+- **Takeaway:** every path-accepting surface was audited; canonicalization catches encoded variants.
+
+### 4. Session / CSRF / redirect integrity
+- **SameSite CSRF cookie** ([#2035](https://github.com/wheels-dev/wheels/pull/2035)).
+- **Auto-gen encryption key when empty** ([#2054](https://github.com/wheels-dev/wheels/pull/2054)).
+- **CSRF key required in production** ([#2079](https://github.com/wheels-dev/wheels/pull/2079)).
+- **Session fixation prevention on login** ([#2034](https://github.com/wheels-dev/wheels/pull/2034)).
+- **Open-redirect blocked in `redirectTo()`** ([#2038](https://github.com/wheels-dev/wheels/pull/2038)).
+
+### 5. CORS and security headers (the deny-by-default story)
+- **CORS:** wildcard → deny-all ([#2039](https://github.com/wheels-dev/wheels/pull/2039)); rejects wildcard + credentials ([#2053](https://github.com/wheels-dev/wheels/pull/2053)).
+- **SecurityHeaders middleware:** CSP, HSTS, Permissions-Policy ([#2036](https://github.com/wheels-dev/wheels/pull/2036)); HSTS default-on in prod ([#2081](https://github.com/wheels-dev/wheels/pull/2081)).
+- Frame: "deny-by-default" is the policy; apps opt in to the behavior they actually need.
+
+### 6. Rate limiter — hardening a hardening feature
+- **Initial addition** ([#1931](https://github.com/wheels-dev/wheels/pull/1931)) was the easy part; production-hardening it was the interesting work.
+- `trustProxy` default false ([#2024](https://github.com/wheels-dev/wheels/pull/2024)).
+- Memory exhaustion + IP spoofing mitigations ([#2041](https://github.com/wheels-dev/wheels/pull/2041)).
+- Per-key exhaustion ([#2048](https://github.com/wheels-dev/wheels/pull/2048)).
+- Fail-closed on lock timeout ([#2069](https://github.com/wheels-dev/wheels/pull/2069)).
+- Cleanup throttle + key length limit ([#2080](https://github.com/wheels-dev/wheels/pull/2080)).
+- Proxy strategy default = `last` ([#2088](https://github.com/wheels-dev/wheels/pull/2088)).
+
+### 7. JWT and console / reload — auth and dev surfaces
+- **JWT algorithm claim validated** + constant-time signature ([#2079](https://github.com/wheels-dev/wheels/pull/2079), [#2086](https://github.com/wheels-dev/wheels/pull/2086)).
+- **`consoleeval` hardened:** POST-only, robust IPv6, Content-Type checks ([#2059](https://github.com/wheels-dev/wheels/pull/2059)); constant-time + rate-limited reload ([#2077](https://github.com/wheels-dev/wheels/pull/2077)); hash-based reload password ([#2022](https://github.com/wheels-dev/wheels/pull/2022)).
+- **`allowEnvironmentSwitchViaUrl`** default false in prod ([#2076](https://github.com/wheels-dev/wheels/pull/2076)); non-empty reload password required ([#2082](https://github.com/wheels-dev/wheels/pull/2082)).
+
+### 8. CLI and MCP — AI-era attack surface
+- **CLI shell sanitization:** deploy commands ([#2068](https://github.com/wheels-dev/wheels/pull/2068), [#2073](https://github.com/wheels-dev/wheels/pull/2073)); db shell injection ([#2040](https://github.com/wheels-dev/wheels/pull/2040)).
+- **MCP hardening:** path traversal ([#2049](https://github.com/wheels-dev/wheels/pull/2049), [#2062](https://github.com/wheels-dev/wheels/pull/2062)); auth gate + input validation ([#2050](https://github.com/wheels-dev/wheels/pull/2050)); error suppression ([#2072](https://github.com/wheels-dev/wheels/pull/2072)); port validation ([#2075](https://github.com/wheels-dev/wheels/pull/2075)); structural allowlist ([#2083](https://github.com/wheels-dev/wheels/pull/2083)); CSRNG session tokens ([#2087](https://github.com/wheels-dev/wheels/pull/2087)).
+- Frame: the MCP endpoint is the new untrusted-input boundary in an AI-integrated dev workflow. Treat it like a public API, because it is.
+
+### 9. XSS and view helpers
+- **Formalized `h()`, `hAttr()`, `stripTags()`, `stripLinks()`** ([#2097](https://github.com/wheels-dev/wheels/pull/2097)).
+- **Pagination XSS hardening** ([#2042](https://github.com/wheels-dev/wheels/pull/2042), [#2057](https://github.com/wheels-dev/wheels/pull/2057), [#2060](https://github.com/wheels-dev/wheels/pull/2060)) — `prependToPage`, `anchorDivider`, `appendToPage` sanitized; HTML-entity bypass closed.
+- **SSE newline injection** closed ([#2051](https://github.com/wheels-dev/wheels/pull/2051)).
+
+### 10. Known limitations — honesty section
+- Link to [#2078](https://github.com/wheels-dev/wheels/pull/2078) (documented limitations).
+- Be explicit about what the framework does NOT claim to solve: app-level authorization, tenant-isolation decisions, post-auth IDOR.
+- Point at OWASP checklist mapping (aspirational — call it out as a follow-on if not shipped by publish date).
+
+## Code / config snippets to include (pick 3)
+
+```cfm
+// Deny-by-default CORS — opt in to the origins you want
+set(middleware = [
+    new wheels.middleware.Cors(
+        allowOrigins="https://app.example.com",
+        allowMethods="GET,POST",
+        allowCredentials=true
+    )
+]);
+```
+
+```cfm
+// Rate limiter — production-ready defaults
+new wheels.middleware.RateLimiter(
+    maxRequests=100,
+    windowSeconds=60,
+    strategy="slidingWindow",
+    storage="database",
+    trustProxy=true,           // must be set intentionally when behind LB
+    proxyStrategy="last"        // last proxy in chain is authoritative
+)
+```
+
+```cfm
+// SecurityHeaders — CSP + HSTS + Permissions-Policy
+new wheels.middleware.SecurityHeaders(
+    contentSecurityPolicy="default-src 'self'; script-src 'self' 'unsafe-inline'",
+    hstsMaxAge=31536000,
+    hstsIncludeSubDomains=true,
+    permissionsPolicy="geolocation=(), microphone=()"
+)
+```
+
+## Suggested visuals
+
+- **Category tally bar chart:** 8 categories (SQL, path, session, CORS, rate-limiter, console, MCP, XSS) with PR counts. Shows the breadth.
+- **Before / after defaults table:** 6 rows — CORS, HSTS, CSRF key, env-switch URL, reload password, RateLimiter `trustProxy` — showing 3.0 default vs 4.0 default. Screenshot-friendly.
+
+## Outro / CTA
+
+- "Secure-by-default is a posture, not a feature."
+- Link to the known-limitations doc.
+- Invite responsible disclosure per SECURITY.md.
+- Tease post #4 (jobs) — because `RateLimiter` storage=database shares infrastructure with the job queue.
+
+## Citations (must link in final post)
+
+- All PRs linked inline (section 2–9).
+- [Feature audit § Security hardening](https://github.com/wheels-dev/wheels/blob/develop/docs/releases/wheels-4.0-audit.md#19-security-hardening-cross-cutting)
+- [3.0 → 4.0 comparison § Security posture](https://github.com/wheels-dev/wheels/blob/develop/docs/releases/wheels-3.0-vs-4.0.md#security-posture--40-hardening-prs-in-40)
+- Known limitations doc ([#2078](https://github.com/wheels-dev/wheels/pull/2078))
+- `docs/src/working-with-wheels/security.md` (if extant)

--- a/docs/releases/blog-skeletons/04-background-jobs.md
+++ b/docs/releases/blog-skeletons/04-background-jobs.md
@@ -1,0 +1,123 @@
+---
+status: skeleton
+slot: post 4 (week 2; pairs with ecosystem comparison story)
+target_length: 1200–1500 words
+---
+
+# Background Jobs Without Redis
+
+**Subhead / dek:** *A production-ready job queue that needs only your database — with a CLI daemon, live monitoring, and tenant awareness built in.*
+
+**Target audience:**
+- Rails developers tired of the Redis + Sidekiq + Sidekiq Pro layer cake
+- Laravel developers who've priced out Horizon + Redis
+- Django developers running Celery + RabbitMQ + Redis for simple email sending
+- Wheels teams who've been running cron-driven scripts as a "queue"
+
+**Lead paragraph intent:**
+- Every mainstream framework ships a job queue story — and every one of them assumes Redis.
+- Wheels 4.0 ships a job queue that assumes only your existing database.
+- Optimistic locking, exponential backoff, timeout recovery, CLI daemon, live dashboard.
+- And because it's DB-backed, it inherits multi-tenancy for free.
+
+## Sections
+
+### 1. "The Redis tax on small-to-medium apps"
+- Redis is a reasonable dependency. It's also a reasonable *extra* dependency — separate process, separate RAM budget, separate failure mode, separate ops doc.
+- For a 10k-user SaaS or an internal tool, a queue that lives in the DB you already have is often the right engineering trade.
+- Precedent: `delayed_job` (Ruby), `database_cleaner`-style queues, Laravel's database driver. Wheels picks this lane and makes it first-class.
+
+### 2. The Job CFC surface
+- Define a job: extend `wheels.Job`, set `this.queue` and `this.maxRetries` in `config()`, put work in `perform(struct data)`.
+- Enqueue: `job.enqueue(data={...})`, `job.enqueueIn(seconds=300, data={...})`, `job.enqueueAt(runAt=date, data={...})`.
+- Retries: configurable exponential backoff — `this.baseDelay = 2` and `this.maxDelay = 3600`. Formula: `Min(baseDelay * 2^attempt, maxDelay)`.
+
+### 3. The CLI daemon
+- `wheels jobs work` — pick up jobs, process, exit on SIGTERM.
+- `wheels jobs work --queue=mailers --interval=3` — target a queue, poll every 3s.
+- `wheels jobs status` — per-queue breakdown (`pending / processing / completed / failed / total`).
+- `wheels jobs retry --queue=mailers` — retry failures.
+- `wheels jobs purge --completed --older-than=30` — housekeeping.
+- `wheels jobs monitor` — live dashboard.
+
+### 4. What makes the DB-backed implementation work
+- **Optimistic locking** so two workers never claim the same job.
+- **Timeout recovery** — stuck jobs get requeued.
+- **Configurable backoff** — per-job, not framework-wide.
+- **Single table (`wheels_jobs`)** — auto-created via migration; inspect with SQL you already know.
+
+### 5. Multi-tenancy for free
+- Because tenant switching ([#1951](https://github.com/wheels-dev/wheels/pull/1951)) happens at the datasource layer, jobs enqueued in tenant A land in tenant A's queue.
+- No "tenant ID in payload" dance. The worker picks up the job with the tenant context already resolved.
+- Tease post #7 (multi-tenancy).
+
+### 6. When to pick Redis anyway
+- **Throughput ceiling:** hundreds of thousands of jobs/minute — Redis-based queues (Sidekiq, Oban) will outpace a DB-backed one.
+- **Pub/sub fanout:** you want real-time push to N workers with no polling cost.
+- **Latency:** sub-50ms pickup matters.
+- For most SaaS apps, you're nowhere near those limits.
+
+### 7. Operating the worker in production
+- Run under systemd/supervisord; rely on `wheels jobs work` exit codes.
+- Log ingestion: stdout is structured; pipe to your log stack.
+- Scale horizontally — run multiple workers against the same DB; the optimistic lock handles contention.
+- Monitoring: `wheels jobs status --format=json` for your metrics pipeline.
+
+### 8. The SSE channel adjacency (brief)
+- While you're wiring background work, know that 4.0 also shipped **pub/sub SSE channels** ([#1940](https://github.com/wheels-dev/wheels/pull/1940)). Jobs complete → publish to an SSE channel → user's browser updates. No websockets required.
+
+## Code / config snippets to include (pick 3)
+
+```cfm
+// app/jobs/SendWelcomeEmailJob.cfc
+component extends="wheels.Job" {
+    function config() {
+        super.config();
+        this.queue = "mailers";
+        this.maxRetries = 5;
+        this.baseDelay = 2;
+        this.maxDelay = 3600;
+    }
+    public void function perform(struct data = {}) {
+        sendEmail(to=data.email, subject="Welcome!", from="app@example.com");
+    }
+}
+```
+
+```cfm
+// Enqueue three ways
+job = new app.jobs.SendWelcomeEmailJob();
+job.enqueue(data={email: user.email});                     // immediate
+job.enqueueIn(seconds=300, data={email: user.email});       // 5 min delay
+job.enqueueAt(runAt=reminderDate, data={email: user.email}); // exact time
+```
+
+```bash
+# Operating the worker
+wheels jobs work --queue=mailers --interval=3   # foreground daemon
+wheels jobs status                              # quick health check
+wheels jobs status --format=json                # for metrics
+wheels jobs retry --queue=mailers               # retry failures
+wheels jobs purge --completed --older-than=30   # housekeeping
+wheels jobs monitor                             # live dashboard
+```
+
+## Suggested visuals
+
+- **Architecture diagram:** two stacks side-by-side. Left: "Rails + Sidekiq" with Redis box, Sidekiq worker, scheduler, web. Right: "Wheels 4.0" with the same DB, `wheels jobs work` daemon, web. Visually emphasize the removed Redis box.
+- **Screenshot:** `wheels jobs monitor` live dashboard showing a queue working. Even a simulated screenshot tells the story.
+- **Simple timeline:** job enqueued → picked up → failed → retry 1 (backoff 2s) → retry 2 (4s) → retry 3 (8s) → exhausted. Teaches the backoff formula visually.
+
+## Outro / CTA
+
+- "Check your production dependency list. If Redis is there only for the job queue, consider the one-less-service version."
+- Link to jobs docs in `docs/src/`.
+- Tease post #7 (multi-tenancy).
+
+## Citations (must link in final post)
+
+- [Job worker daemon PR #1934](https://github.com/wheels-dev/wheels/pull/1934)
+- [Multi-tenancy PR #1951](https://github.com/wheels-dev/wheels/pull/1951)
+- [SSE pub/sub channels PR #1940](https://github.com/wheels-dev/wheels/pull/1940)
+- [Feature audit § Background jobs](https://github.com/wheels-dev/wheels/blob/develop/docs/releases/wheels-4.0-audit.md#7-background-jobs)
+- CLAUDE.md "Background Jobs Quick Reference" section as the canonical API reference

--- a/docs/releases/blog-skeletons/05-lucli-zero-docker.md
+++ b/docs/releases/blog-skeletons/05-lucli-zero-docker.md
@@ -1,0 +1,129 @@
+---
+status: skeleton
+slot: post 5 (week 2–3; paired with contributor-focused outreach)
+target_length: 1100–1400 words
+---
+
+# LuCLI and the Zero-Docker Dev Experience
+
+**Subhead / dek:** *Sixty-second test runs, one native binary, and a multi-phase migration that quietly transformed how Wheels is built.*
+
+**Target audience:**
+- CFML developers who gave up on `box test` → Docker matrix runs taking 20+ minutes
+- Contributors bounced off the project by Docker setup friction
+- Internal team tracking the LuCLI-as-strategic-direction arc
+- Framework authors curious about the Ortus-independence strategy
+
+**Lead paragraph intent:**
+- For a decade, running the Wheels test suite meant Docker, a CommandBox server, and patience.
+- Today, it means one shell script, SQLite, and 60 seconds.
+- This is the LuCLI story — what it is, how the migration went, and what it unlocks.
+
+## Sections
+
+### 1. "Why Docker was the wrong default for the inner loop"
+- Docker was the right answer for cross-engine CI (Lucee 5/6/7 × Adobe 2018/2021/2023/2025 × 7 databases).
+- Docker is the wrong answer for the inner dev loop. A failing test shouldn't take 90 seconds to confirm.
+- The 2024/2025 CFML landscape shifted: Lucee 7 + LuCLI (Lucee-as-a-CLI) became mature enough to support a pure-Java, zero-Docker inner loop.
+
+### 2. What LuCLI is
+- A single binary (`lucli`) that runs Lucee directly without CommandBox/Ortus infrastructure.
+- Starts a CFML-capable server, runs a script, or drops into a REPL.
+- Brew-installable on macOS; direct-download tarballs for Linux/Windows.
+- Frame: "Node.js for CFML" — single binary, fast startup, scriptable.
+
+### 3. The migration arc — Phase 1 through Phase 4
+- **Phase 1** (pre-4.0) — LuCLI matures to production-readiness ([project_lucli_phase1.md](https://github.com/wheels-dev/wheels/blob/develop/)).
+- **Phase 2** ([#2063](https://github.com/wheels-dev/wheels/pull/2063)) — local testing without Docker. `tools/test-local.sh` ships.
+- **Phase 2 service layer + MCP annotations** ([#1941](https://github.com/wheels-dev/wheels/pull/1941)).
+- **LuCLI-native CI** ([#2032](https://github.com/wheels-dev/wheels/pull/2032)) — Lucee 7 + SQLite in CI for every PR.
+- **Phase 3-4** ([#2065](https://github.com/wheels-dev/wheels/pull/2065)) — in-process service invocation; scaffold + seed as library calls, not shell-outs.
+- **Tier 1 commands ported to LuCLI** ([#2092](https://github.com/wheels-dev/wheels/pull/2092)) + **LuCLI module distribution** ([#2018](https://github.com/wheels-dev/wheels/pull/2018)).
+
+### 4. What it feels like now
+- `brew install lucli` (one time).
+- `bash tools/test-local.sh` — full core suite, ~60s on a developer laptop.
+- `bash tools/test-local.sh security` — subset, ~5s.
+- REPL: `lucli server run --port=8080`, then `curl` or a browser.
+- CI runs the same pipeline. Local == CI.
+
+### 5. Why the frameworks team made this a strategic choice
+- **Reduced Ortus dependency** — Wheels controls its own testing and tooling story end-to-end.
+- **Optimized for AI-augmented dev** — fast feedback loops matter more in an era where iteration rate is the constraint.
+- **Lower barrier to contribution** — "install Docker, install CommandBox, docker compose up -d lucee6, wait..." becomes "install lucli, run the script."
+- Not a rejection of Ortus tools — CommandBox, TestBox-era specs, and the rest continue to work. This is a complementary path.
+
+### 6. Cross-engine testing still matters
+- LuCLI inner loop = Lucee 7 + SQLite. That covers ~95% of real bugs.
+- The other 5% (Adobe CF quirks, database-specific SQL) still run in Docker-based CI on a schedule.
+- Best practice: push early, push often; let Docker CI catch the cross-engine edge cases.
+
+### 7. What ships with the Wheels CLI in 4.0
+- `wheels new` — scaffold app.
+- `wheels g model/controller/scaffold` — generators.
+- `wheels test run` — LuCLI-native.
+- `wheels dbmigrate latest / up / down / info / diff` — migrations including auto-diff.
+- `wheels db:seed` — convention-based seeding.
+- `wheels jobs work/status/retry/purge/monitor` — background jobs.
+- `wheels browser:install` — Playwright JARs + Chromium.
+- `wheels server start/stop/status` — dev server wrapper.
+
+### 8. What's still coming
+- Full command-set parity with CommandBox-era `wheels`.
+- More in-process service invocation (fewer process fork boundaries).
+- Per-OS packaging polish.
+
+## Code / config snippets to include
+
+```bash
+# First-time setup (one-time)
+brew install lucli                # or download from GitHub releases
+brew install openjdk@21           # Java 21 required
+
+# Inner loop — the 60s test run
+cd /path/to/wheels
+bash tools/test-local.sh          # all core tests
+bash tools/test-local.sh model    # model tests only
+bash tools/test-local.sh security # security tests only
+```
+
+```bash
+# Manual server mode (for ad-hoc curl / browser testing)
+sqlite3 wheelstestdb.db "SELECT 1;"
+sqlite3 wheelstestdb_tenant_b.db "SELECT 1;"
+lucli server run --port=8080
+
+# In another terminal
+curl -s "http://localhost:8080/?reload=true&password=wheels"
+curl -sf "http://localhost:8080/wheels/core/tests?db=sqlite&format=json" | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); print(f'{d[\"totalPass\"]} pass, {d[\"totalFail\"]} fail')"
+```
+
+```bash
+# CI runs the same commands the developer does
+# .github/workflows/pr.yml (simplified)
+- run: bash tools/test-local.sh
+```
+
+## Suggested visuals
+
+- **Timeline:** Phase 1 → Phase 2 → Phase 3-4, with dates and PR numbers. Shows the 14-week transformation.
+- **Before/after bar:** "Time to first test result." Docker-first vs LuCLI-first. Aim for a 20x or 30x gap — honest and striking.
+- **Screenshot:** `bash tools/test-local.sh` terminal output showing 2667 tests pass in 60s.
+
+## Outro / CTA
+
+- "Clone, install lucli, run the test script. You'll know you're onboarded in under a minute."
+- Link to the contributing guide.
+- Plug the `wheels-cli-lucli` repo.
+- Note that the Phase 2 validation (2667 tests passing) confirms the migration is production-ready.
+
+## Citations (must link in final post)
+
+- [Phase 2 PR #2063](https://github.com/wheels-dev/wheels/pull/2063)
+- [LuCLI CI PR #2032](https://github.com/wheels-dev/wheels/pull/2032)
+- [Phase 3-4 PR #2065](https://github.com/wheels-dev/wheels/pull/2065)
+- [LuCLI module distribution PR #2018](https://github.com/wheels-dev/wheels/pull/2018)
+- [Tier 1 commands PR #2092](https://github.com/wheels-dev/wheels/pull/2092)
+- [LuCLI repo](https://github.com/bpamiri/LuCLI)
+- CLAUDE.md "Running Tests Locally (LuCLI — Recommended)" section

--- a/docs/releases/blog-skeletons/06-testing.md
+++ b/docs/releases/blog-skeletons/06-testing.md
@@ -1,0 +1,154 @@
+---
+status: skeleton
+slot: post 6 (week 2–3; pairs with LuCLI post)
+target_length: 1400–1700 words
+---
+
+# Testing in Wheels 4.0
+
+**Subhead / dek:** *HTTP integration tests, parallel runners, and full-browser Playwright — the category that was most embarrassing in 3.0 is the most complete in 4.0.*
+
+**Target audience:**
+- QA engineers evaluating CFML frameworks
+- Developers who've been writing integration tests with curl + bash
+- Teams considering Cypress/Playwright but wanting a unified CFML testing story
+- Existing Wheels teams wondering whether BDD-only is worth the migration
+
+**Lead paragraph intent:**
+- In 3.0, Wheels testing was RocketUnit specs and custom harnesses.
+- In 4.0, Wheels testing is a full pyramid: unit (WheelsTest BDD) + integration (HTTP TestClient) + end-to-end (Playwright-backed BrowserTest) — run in parallel.
+- This post walks each layer with a concrete example, then discusses the BDD-only stance.
+
+## Sections
+
+### 1. "The test pyramid, finally complete"
+- Unit tests exist in every framework; that's table stakes.
+- Integration and E2E were the gaps. Both land in 4.0 — natively, not via third-party bridges.
+- Running them fast: parallel by default.
+
+### 2. Unit tests — WheelsTest BDD
+- `wheels.WheelsTest` replaces `wheels.Test` as the canonical base class ([#1889](https://github.com/wheels-dev/wheels/pull/1889)).
+- `describe()` / `it()` / `expect()` — familiar BDD syntax.
+- RocketUnit retained for legacy specs but deprecated for new work ([#1925](https://github.com/wheels-dev/wheels/pull/1925)).
+- Tests directory renamed to `tests/specs/functional/` ([#1872](https://github.com/wheels-dev/wheels/pull/1872)).
+
+### 3. Integration — HTTP TestClient
+- `TestClient.visit("/users").assertOk().assertSee("John")` — fluent, familiar from Laravel/Rails test clients.
+- Assertions: status codes, body content (`assertSee`, `assertDontSee`, `assertSeeInOrder`), JSON responses (`assertJson`, `assertJsonPath` with dot notation), redirects, headers, cookies.
+- Cookies tracked across requests → session support.
+- PR: [#2099](https://github.com/wheels-dev/wheels/pull/2099).
+- Use case: test a full request/response cycle without a browser.
+
+### 4. End-to-end — BrowserTest (Playwright Java)
+- Extend `wheels.wheelstest.BrowserTest`; get `this.browser` as a fluent DSL wrapping Playwright Java.
+- Install once: `wheels browser:install` — ~370MB (JARs + Chromium).
+- ~60 DSL methods: navigation, interaction (`click`, `fill`, `select`, `attach`, `dragAndDrop`), keyboard, waiting (`waitFor`, `waitForText`, `waitForUrl`), scoping (`within`), cookies, auth (`loginAs`, `logout`), dialogs (Lucee-only), viewport (`resize`, `resizeToMobile`), script, screenshots, full assertion suite.
+- Shipped across [#2113](https://github.com/wheels-dev/wheels/pull/2113), [#2115](https://github.com/wheels-dev/wheels/pull/2115), [#2116](https://github.com/wheels-dev/wheels/pull/2116), [#2121](https://github.com/wheels-dev/wheels/pull/2121), [#2122](https://github.com/wheels-dev/wheels/pull/2122).
+- CI runs browser specs in `pr.yml` and `snapshot.yml` with Playwright JARs + Chromium cached.
+- Caveat: dialogs use `createDynamicProxy` which is Lucee-specific; specs skip gracefully on other engines.
+
+### 5. Parallel — ParallelRunner
+- PR: [#2100](https://github.com/wheels-dev/wheels/pull/2100).
+- Discovers bundles, round-robin partitions them across N workers, fires parallel HTTP requests via `cfthread`, aggregates JSON results.
+- Configurable worker count and timeout.
+- Cuts suite time on multi-core CI runners.
+
+### 6. "Why BDD-only for new tests?"
+- Signals intent clearly: `describe("User.valid()", () => { it("requires email", ...) })` reads top-to-bottom.
+- Consolidates on one style — dual-stack testing confused contributors.
+- Legacy RocketUnit specs continue to run; nobody has to migrate. New specs should follow the BDD pattern.
+
+### 7. A critical-path test, end-to-end in 50 lines
+- Skeleton example: login → create a record → verify it appears in the list → delete it → verify it's gone.
+- Show the BrowserTest equivalent using `loginAs()`, `fill()`, `click()`, `assertSee()`.
+- 15-minute setup, lifetime of regression coverage. Call out that this replaces manual QA for the 5-10 critical journeys in most apps.
+
+### 8. Hard-won gotchas (short list)
+- **`##` in selectors** — CFML requires `##` to emit literal `#`. `"##email"` → `"#email"` at runtime.
+- **`client` is a Lucee reserved scope.** Use `var c = ...` or `var bc = ...` instead of `var client`.
+- **`this.browserTestSkipped`** — when Playwright JARs aren't installed, `beforeAll` sets this flag; all `it`s should short-circuit to stay green.
+- **Data URLs work for most tests** — no fixture server needed for ~95% of DSL coverage.
+- Reference: [`.ai/wheels/testing/browser-testing.md`](https://github.com/wheels-dev/wheels/blob/develop/.ai/wheels/testing/browser-testing.md).
+
+### 9. Test data, fixtures, and populate.cfm
+- `tests/populate.cfm` remains the DROP + CREATE + seed harness.
+- Test models live in `tests/_assets/models/`.
+- LuCLI + SQLite for local runs; full matrix DBs for CI.
+
+## Code / config snippets to include (pick 3)
+
+```cfm
+// Unit — WheelsTest BDD
+component extends="wheels.WheelsTest" {
+    function run() {
+        describe("User", () => {
+            it("validates presence of email", () => {
+                var u = model("User").new();
+                expect(u.valid()).toBeFalse();
+            });
+        });
+    }
+}
+```
+
+```cfm
+// Integration — HTTP TestClient
+component extends="wheels.WheelsTest" {
+    function run() {
+        describe("GET /users", () => {
+            it("lists users", () => {
+                TestClient.visit("/users")
+                    .assertOk()
+                    .assertSee("John")
+                    .assertJsonPath("data[0].email", "john@example.com");
+            });
+        });
+    }
+}
+```
+
+```cfm
+// End-to-end — BrowserTest with loginAs + critical-path assertion
+component extends="wheels.wheelstest.BrowserTest" {
+    this.browserEngine = "chromium";
+
+    function run() {
+        browserDescribe("Create a user via the admin UI", () => {
+            it("creates and lists a user", () => {
+                if (this.browserTestSkipped) return;
+                this.browser
+                    .loginAs({email: "admin@example.com"})
+                    .visit("/admin/users/new")
+                    .fill("##name", "Alice")
+                    .fill("##email", "alice@example.com")
+                    .click("button[type=submit]")
+                    .assertUrlContains("/admin/users")
+                    .assertSee("Alice");
+            });
+        });
+    }
+}
+```
+
+## Suggested visuals
+
+- **Test pyramid:** classic triangle — unit (wide base: WheelsTest BDD) / integration (middle: TestClient) / E2E (tip: BrowserTest). Label each layer with the Wheels-specific API.
+- **Screenshot:** parallel runner output showing workers claiming bundles, final aggregate summary.
+- **Before/after (3.0 vs 4.0):** checklist matrix — unit / integration / E2E / parallel / BDD syntax. 3.0 column mostly empty; 4.0 column mostly checked.
+
+## Outro / CTA
+
+- "You can reach your first green browser test in under half an hour."
+- Link to `docs/src/working-with-wheels/testing-your-application.md`.
+- Link to `.ai/wheels/testing/browser-testing.md` for the deep reference.
+- Note BrowserTest is Chromium-only at 4.0 launch; Firefox/WebKit are roadmap.
+
+## Citations (must link in final post)
+
+- [TestClient PR #2099](https://github.com/wheels-dev/wheels/pull/2099)
+- [ParallelRunner PR #2100](https://github.com/wheels-dev/wheels/pull/2100)
+- [BrowserTest PRs #2113, #2115, #2116, #2121, #2122](https://github.com/wheels-dev/wheels/pull/2113)
+- [WheelsTest namespace #1889](https://github.com/wheels-dev/wheels/pull/1889)
+- [RocketUnit deprecation #1925](https://github.com/wheels-dev/wheels/pull/1925)
+- `docs/src/working-with-wheels/testing-your-application.md`
+- `.ai/wheels/testing/browser-testing.md`

--- a/docs/releases/blog-skeletons/07-multi-tenancy.md
+++ b/docs/releases/blog-skeletons/07-multi-tenancy.md
@@ -1,0 +1,116 @@
+---
+status: skeleton
+slot: post 7 (week 3; SaaS-audience focus)
+target_length: 900–1200 words
+---
+
+# Multi-Tenancy Built In
+
+**Subhead / dek:** *Per-request datasource switching in core — no gem, no package, no plugin. And tenant-aware background jobs come along for the ride.*
+
+**Target audience:**
+- SaaS founders and architects evaluating CFML frameworks for a multi-tenant product
+- Existing Wheels teams who've been rolling their own tenant switching via `application.wheels.dataSourceName = ...`
+- Rails/Laravel/Django devs curious what "built-in multi-tenancy" actually looks like
+
+**Lead paragraph intent:**
+- Multi-tenancy in Rails is `apartment` gem. In Laravel it's `stancl/tenancy`. In Django it's `django-tenants`. In Wheels 4.0 it's *the framework*.
+- That sounds boastful — but the practical difference is real: tenant resolution, datasource switching, and tenant-aware job queues are one coherent system, not three plugins duct-taped together.
+- PR [#1951](https://github.com/wheels-dev/wheels/pull/1951) landed the core. This post walks a realistic SaaS scenario to show why that matters.
+
+## Sections
+
+### 1. "The seam you need to cut cleanly"
+- Multi-tenancy is a seam problem, not a feature problem. You need *one* seam that catches every query, every job, every background task.
+- Plugin-based multi-tenancy catches 80% — then a stray `cfquery` or a job that forgot to resolve tenant context leaks data across tenants. That's a "write the incident report on Sunday" bug.
+- Framework-level tenancy catches 100% because every data path goes through the datasource resolver.
+
+### 2. Three models, one framework
+- **Separate database per tenant** — cleanest isolation, per-customer backup/restore. Wheels 4.0 supports it via datasource switching.
+- **Shared database, separate schema** — supported via datasource naming that points to the same DB but different schema.
+- **Shared database, row-level** — scoped queries. Less cleanly isolated but fine for many products. (Note: this model requires discipline regardless of framework.)
+
+### 3. Tenant resolution — from request to datasource
+- Typical sources: subdomain (`acme.myapp.com`), path prefix (`/t/acme`), header (`X-Tenant: acme`), auth claim (JWT `tid`).
+- Resolution happens early — as middleware — and stores the tenant context on the request.
+- Models pick up the datasource automatically for the rest of the request lifecycle.
+
+### 4. Tenant-aware background jobs
+- Enqueue from tenant A's request context → job lands in tenant A's queue.
+- Worker picks up job → tenant context restored → `model("Order").findAll()` queries tenant A's DB.
+- No "tenant ID as payload field" ceremony. No `with_tenant(tenant) { ... }` wrapper at the top of every job's `perform`.
+- Tease post #4 (jobs).
+
+### 5. When NOT to use framework-level multi-tenancy
+- Admin / ops console that needs cross-tenant queries. Plan for it deliberately — exit the tenant context explicitly, or use a "system" datasource for admin reads.
+- Cross-tenant reports. Same rule — these are a deliberate exception, not a framework fight.
+
+### 6. Compared to the alternatives
+- **Rails + apartment** — similar model; requires gem + config. Framework-level in Wheels.
+- **Laravel + stancl/tenancy** — rich feature set but adds middleware and per-request initialization overhead from a plugin. Wheels inlines this.
+- **Django + django-tenants** — solid but schema-only by default. Wheels supports separate DB out of the box.
+
+### 7. Migration and seeding per tenant
+- Each tenant DB gets the same migration set run against it.
+- `wheels dbmigrate latest` can target per-tenant datasources.
+- Seeding via `wheels db:seed` respects the active tenant context.
+- (Short section — deep multi-tenant migration tactics is a follow-on post.)
+
+### 8. Operational story
+- Adding a tenant = creating a datasource + running migrations + optional seed.
+- Removing a tenant = destroying the datasource. Clean delete, no row-leak risk.
+- Backup/restore is per-datasource — operationally clean.
+- Rate limiter database storage lives on the *app* DB, not per-tenant — one less thing to provision.
+
+## Code / config snippets to include (pick 2)
+
+```cfm
+// config/settings.cfm — tenant resolution via middleware
+set(middleware = [
+    new app.middleware.TenantResolver()     // sets request-scoped tenant ctx
+]);
+
+// app/middleware/TenantResolver.cfc
+component implements="wheels.middleware.MiddlewareInterface" {
+    public any function handle(required struct request, required any next) {
+        var subdomain = ListFirst(arguments.request.cgi.server_name, ".");
+        arguments.request.tenant = subdomain;
+        // Framework datasource switching hook — exact API in docs
+        $setTenantDatasource(arguments.request.tenant);
+        return arguments.next(arguments.request);
+    }
+}
+```
+
+```cfm
+// Job that implicitly runs in tenant context
+component extends="wheels.Job" {
+    function config() {
+        super.config();
+        this.queue = "reports";
+    }
+    public void function perform(struct data = {}) {
+        var orders = model("Order").findAll();   // tenant A's orders, automatically
+        generateMonthlyReport(orders);
+    }
+}
+```
+
+## Suggested visuals
+
+- **Architecture diagram:** request arrives → TenantResolver middleware → datasource resolved → controller/model → (on enqueue) job stored with tenant context → worker picks up → tenant context restored → model queries land on correct DB. Highlight that "tenant context" is one concept threaded through.
+- **Comparison table:** Wheels 4.0 vs Rails+apartment vs Laravel+stancl vs Django-tenants — axis: framework-native? separate-DB model? tenant-aware jobs? schema model? Row-level model?
+
+## Outro / CTA
+
+- "If you've been thinking 'we'll deal with multi-tenancy later,' 4.0 makes 'now' a lot cheaper than 'later.'"
+- Link to multi-tenancy docs once they land in `docs/src/`.
+- Invite feedback on real SaaS patterns — this is a feature the team wants to harden based on production use.
+
+## Citations (must link in final post)
+
+- [Multi-tenancy PR #1951](https://github.com/wheels-dev/wheels/pull/1951)
+- [Job worker daemon PR #1934](https://github.com/wheels-dev/wheels/pull/1934) (for the jobs-are-tenant-aware claim)
+- [Middleware pipeline PR #1924](https://github.com/wheels-dev/wheels/pull/1924) (for the resolver pattern)
+- [Feature audit § Multi-tenancy](https://github.com/wheels-dev/wheels/blob/develop/docs/releases/wheels-4.0-audit.md#9-multi-tenancy)
+- Multi-tenancy docs page (to be confirmed / written if absent)

--- a/docs/releases/blog-skeletons/08-wirebox-to-wheelsdi.md
+++ b/docs/releases/blog-skeletons/08-wirebox-to-wheelsdi.md
@@ -1,0 +1,117 @@
+---
+status: skeleton
+slot: post 8 (week 3–4; contributor / framework-internals audience)
+target_length: 1000–1300 words
+---
+
+# From WireBox to wheelsdi — The Framework Gets Leaner
+
+**Subhead / dek:** *An internal modernization that nobody asked for, that changed how Wheels feels to extend and to ship.*
+
+**Target audience:**
+- Contributors who've tried to debug Wheels' boot sequence
+- CFML devs who know WireBox/TestBox/CommandBox and want the story behind Wheels stepping off that stack
+- Framework authors curious about decomposition strategies
+- Tech leads who have to justify "we're not using the standard CFML DI container" in a review
+
+**Lead paragraph intent:**
+- Most of 4.0 is about what users do. This post is about what *we* changed under the hood — why `application.wirebox` became `application.wheelsdi`, why TestBox was replaced with WheelsTest, why the init sequence was decomposed.
+- None of this is user-visible. All of it is how future features are going to land faster and with less ceremony.
+- This is the "rim modernization" story.
+
+## Sections
+
+### 1. "The accidental coupling problem"
+- Over a decade, CFWheels (and later Wheels) accreted hard dependencies on Ortus infrastructure — WireBox for DI, TestBox for testing, CommandBox for CLI.
+- Each dependency was a reasonable choice in its moment. Collectively, they constrained velocity: upgrading Lucee or Adobe CF meant first confirming WireBox, TestBox, and CommandBox all worked in the new environment.
+- The release pace Wheels 4.0 needed (185 PRs in 14 weeks) was not compatible with that coupling.
+
+### 2. What "rim modernization" means
+- The "rim" — the outer layer where Wheels meets the CFML engine — got decomposed into engine-specific adapter modules ([#2016](https://github.com/wheels-dev/wheels/pull/2016)).
+- Adapter modules isolate: struct member function idioms (Lucee vs Adobe CF), scope handling (Adobe CF's different `application` scope semantics), closure semantics, CFML version quirks.
+- Downstream: tests exercise the engine-neutral core against each adapter, not the core against the engine directly.
+
+### 3. WireBox → wheelsdi (#1883, #1888)
+- `application.wirebox` renamed to `application.wheelsdi` ([#1888](https://github.com/wheels-dev/wheels/pull/1888)).
+- Same surface — `map()`, `bind()`, resolution behavior — but the implementation is in-house and smaller.
+- Explicit scopes: transient (default), singleton, request-scoped.
+- Expanded DI features landed on this base: request-scoped services, `service()` global helper, declarative `inject()` in controller `config()`, interface binding, auto-wiring of `init()` arguments ([#1933](https://github.com/wheels-dev/wheels/pull/1933)).
+- Why in-house: DI container behavior is central to how Wheels extends; keeping it in-tree means fixes ship with the framework, not on a third-party release cadence.
+
+### 4. TestBox → WheelsTest
+- WheelsTest is a BDD test runner that lives inside the framework ([#1889](https://github.com/wheels-dev/wheels/pull/1889)).
+- Provides `describe()`, `it()`, `expect()` — idiomatic BDD.
+- Compatible with the test infrastructure pattern that Wheels specs were already using under TestBox.
+- RocketUnit legacy specs continue to work ([#1925](https://github.com/wheels-dev/wheels/pull/1925)).
+
+### 5. Decomposed init
+- Historically, Wheels' `onApplicationStart` was a monolithic sequence: engine detection → DI wiring → model/controller loading → route compilation → plugin loading → environment setup.
+- 4.0 decomposed this into discrete phases, each testable in isolation.
+- Package loading became a phase with per-package error isolation ([#1995](https://github.com/wheels-dev/wheels/pull/1995)) — a broken package logs and skips, the app continues.
+
+### 6. The package system — philosophical shift from plugins
+- Legacy `plugins/` folder worked via mixin merging into global scope by default.
+- New `packages/` (staging) → `vendor/` (activation) model requires *explicit opt-in* for what the package mixes into (`controller`, `view`, `model`, `global`, `none`). Default `none`.
+- Dependency graph via topological sort; `requires` / `replaces` / `suggests` ([#2017](https://github.com/wheels-dev/wheels/pull/2017)).
+- Per-package error isolation — the kind of operational posture that makes enabling third-party code a lower-risk decision.
+
+### 7. CommandBox → LuCLI direction (brief; tease post #5)
+- CLI story parallels the DI and testing stories: dependency → in-house alternative that's cheaper to evolve.
+- Not a CommandBox rejection — CommandBox continues to work. LuCLI is the fast path for the inner loop and CI.
+
+### 8. What this means for contributors
+- **Shorter boot time during dev** — decomposed init + package lazy-loading = less startup friction.
+- **Smaller surface to learn** — wheelsdi's API is narrower than WireBox's; new contributors don't need to read Ortus docs to wire a service.
+- **Testing that explains itself** — BDD specs read like documentation; RocketUnit specs mostly don't.
+
+### 9. What this doesn't mean
+- Not a rejection of Ortus tooling. CommandBox, WireBox, TestBox remain excellent products; many Wheels users will keep using them in their own apps.
+- Not a "silver bullet." The decomposition shipped with its own set of cross-engine gotchas that had to be solved ([#2028](https://github.com/wheels-dev/wheels/pull/2028), [#2030](https://github.com/wheels-dev/wheels/pull/2030), [#2031](https://github.com/wheels-dev/wheels/pull/2031)).
+
+## Code / config snippets to include (pick 2)
+
+```cfm
+// config/services.cfm — in-house DI, same familiar surface
+var di = injector();
+di.map("emailService").to("app.lib.EmailService").asSingleton();
+di.map("currentUser").to("app.lib.CurrentUserResolver").asRequestScoped();
+di.bind("INotifier").to("app.lib.SlackNotifier").asSingleton();
+```
+
+```cfm
+// Declarative injection in a controller — ergonomics of the new DI
+component extends="Controller" {
+    function config() {
+        inject("emailService, currentUser");
+    }
+
+    function create() {
+        this.emailService.send(
+            to=this.currentUser.email(),
+            subject="Welcome"
+        );
+    }
+}
+```
+
+## Suggested visuals
+
+- **Dependency diagram:** two stacks. Left: "Wheels 3.0" with WireBox, TestBox, CommandBox boxes wrapped around the core. Right: "Wheels 4.0" with wheelsdi, WheelsTest, LuCLI as *part of* the core. Visual distinction: the 4.0 diagram has fewer external boxes.
+- **Init timeline (optional):** horizontal phases of the decomposed init sequence — engine detect / DI / models / controllers / routes / packages / environment. Caption: "each phase is testable in isolation."
+
+## Outro / CTA
+
+- "The most important 4.0 feature is the one nobody feels directly — the one that lets future features ship faster."
+- Link to the package system docs.
+- Point to the contributing guide and invite DI container / adapter module contributions.
+
+## Citations (must link in final post)
+
+- [Rim modernization PR #1883](https://github.com/wheels-dev/wheels/pull/1883)
+- [WireBox → wheelsdi PR #1888](https://github.com/wheels-dev/wheels/pull/1888)
+- [Expanded DI PR #1933](https://github.com/wheels-dev/wheels/pull/1933)
+- [WheelsTest namespace PR #1889](https://github.com/wheels-dev/wheels/pull/1889)
+- [Package system PR #1995](https://github.com/wheels-dev/wheels/pull/1995)
+- [Module system + dependency graph PR #2017](https://github.com/wheels-dev/wheels/pull/2017)
+- [Engine adapter modules PR #2016](https://github.com/wheels-dev/wheels/pull/2016)
+- [Feature audit § Internal refactors](https://github.com/wheels-dev/wheels/blob/develop/docs/releases/wheels-4.0-audit.md#20-internal-refactors--infrastructure)

--- a/docs/releases/blog-skeletons/README.md
+++ b/docs/releases/blog-skeletons/README.md
@@ -1,0 +1,43 @@
+# Wheels 4.0 — Blog Post Skeletons
+
+Skeletons (outlines, not publication-ready prose) for the Wheels 4.0 launch blog series. Each file is a hand-off brief for a writer or a follow-on AI pass to expand into a full post.
+
+**Status:** skeletons only. Headlines, section outlines, target audiences, lead paragraph intent, example code to include, suggested visuals, and citations. No finished prose.
+
+**Scope:** marketing / release-comms artifact. Lives outside the published doc site (`docs/src/`) — GitBook does not index this folder.
+
+## The series (priority order)
+
+1. **[Wheels 4.0 — Closing the Maturity Gap](01-closing-the-maturity-gap.md)** (lead post). Frames 4.0 as the release where Wheels caught up with Rails 8 / Laravel 12 / Django 5 on framework-comparison gaps.
+2. **[Upgrading from Wheels 3.x](02-upgrading-from-3x.md)**. Practical migration guide around the 10 breaking changes, with the Legacy Compatibility Adapter as the soft-landing story.
+3. **[Security Hardening in 4.0](03-security-hardening.md)**. 40+ security PRs told as one narrative — SQL injection, path traversal, CSRF/CORS/HSTS, MCP hardening, rate limiter.
+4. **[Background Jobs Without Redis](04-background-jobs.md)**. DB-backed job worker daemon + CLI + multi-tenancy. Genuinely differentiated vs Rails/Laravel/Django equivalents.
+5. **[LuCLI and the Zero-Docker Dev Experience](05-lucli-zero-docker.md)**. 60s test runs, the Phase 1 → Phase 4 arc, CI migration story.
+6. **[Testing in Wheels 4.0](06-testing.md)**. HTTP TestClient + parallel runner + browser testing (Playwright Java) + WheelsTest BDD-only posture.
+7. **[Multi-Tenancy Built In](07-multi-tenancy.md)**. Per-request datasource switching in-core; tenant-aware background jobs.
+8. **[From WireBox to wheelsdi](08-wirebox-to-wheelsdi.md)**. The rim-modernization arc — decomposed init, in-house DI, engine adapter modules, leaner core.
+
+## Source material
+
+Each skeleton cites specific PRs and cross-links back to the three canonical sources:
+
+- [Feature audit](../wheels-4.0-audit.md) — 185 merged PRs, ~70 distinct features, the source of truth.
+- [3.0 → 4.0 ground-made-up](../wheels-3.0-vs-4.0.md) — row-by-row before/after.
+- [Upgrade guide](../../src/introduction/upgrading-to-4.0.md) — Breaking items + Legacy Compatibility Adapter.
+- [Wheels vs. peer frameworks](../../wheels-vs-frameworks.md) — current 4.0 parity comparison, including "Where Wheels Trails."
+
+## Writing-pass instructions
+
+When a writer (human or AI) expands a skeleton:
+
+1. Keep the headline as-is unless there's a compelling reason to change it.
+2. The subhead / dek is a hard one-sentence limit.
+3. Lead with a scenario or a specific before/after — not a feature list.
+4. Every PR cited in the skeleton should be linked in the final post (absolute `https://github.com/wheels-dev/wheels/pull/N` URLs).
+5. Where a skeleton links to a doc in `docs/releases/` (audit, comparison), those files are NOT published on GitBook — link to the GitHub blob URL (`https://github.com/wheels-dev/wheels/blob/develop/docs/releases/...`).
+6. Where a skeleton links to `docs/src/` (upgrade guide, wheels-vs-frameworks), those ARE on GitBook — use the canonical docs URL once known.
+
+## Out of scope for these skeletons
+
+- Final tag / release-date language. Use placeholders like "Wheels 4.0" without dates; the GA date is tracked in [#2131](https://github.com/wheels-dev/wheels/issues/2131).
+- Diagrams / charts. Skeletons describe the *intent* of a visual (radar chart, timeline, architecture box diagram); actual visuals are produced during the writing pass.


### PR DESCRIPTION
## Summary

- Adds eight blog post skeletons under `docs/releases/blog-skeletons/` covering the priority themes from the [4.0 feature audit](https://github.com/wheels-dev/wheels/blob/develop/docs/releases/wheels-4.0-audit.md).
- Each skeleton is an outline (target headline, audience, sections, code examples, visuals, PR citations) — a hand-off brief for a writer or follow-on AI pass. Not publication-ready prose.
- `README.md` indexes the series and documents the writing-pass contract (absolute GitHub URLs for `docs/releases/` files since GitBook doesn't index that folder).

Eight themes, priority order:

1. Wheels 4.0 — closing the maturity gap (lead)
2. Upgrading from Wheels 3.x
3. Security hardening
4. Background jobs without Redis
5. LuCLI and the zero-Docker dev experience
6. Testing in Wheels 4.0
7. Multi-tenancy built in
8. From WireBox to wheelsdi

Lives outside `docs/src/` — marketing/release-comms artifact, not a published doc page.

## Test plan

- [ ] `docs/releases/blog-skeletons/README.md` renders correctly on GitHub
- [ ] Each of the 8 skeleton files has a clear headline, section outline, code snippets, suggested visuals, and PR citations
- [ ] Absolute GitHub URLs are used for cross-links to `docs/releases/` files (since GitBook doesn't index that folder)
- [ ] PR numbers referenced match the audit / comparison docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)