### PR TITLE
feat(view): transitive modulepreload and css resolution for vite pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 - Composable pagination view helpers: `paginationInfo()`, `previousPageLink()`, `nextPageLink()`, `firstPageLink()`, `lastPageLink()`, `pageNumberLinks()`, and `paginationNav()` for building custom pagination UIs (#1930)
 - XSS helpers formalized: `h()`, `hAttr()`, `stripTags()`, `stripLinks()` (#2097)
 - Redesigned v4.0 congratulations page for scaffolded apps (#2098)
+- `vitePreloadTag()` view helper emits `<link rel="modulepreload">` for a Vite entrypoint and its transitive chunk imports, suitable for Turbo Drive hover-preload patterns
+- `viteScriptTag()` and `viteStyleTag()` now resolve transitive chunk imports from the Vite manifest: modulepreload links for JS chunks are emitted into `<head>`, and CSS from transitive chunks is included in the stylesheet tags (brings parity with Rails/Laravel Vite integrations)
+- `viteStrictManifest` setting (default `true`) — missing manifest entries now throw `Wheels.ViteAssetNotFound` in production. Set to `false` to restore 3.x silent behavior.
 
 **Background jobs & real-time**
 - Job worker daemon with CLI commands (`wheels jobs work/status/retry/purge/monitor`) for persistent background job processing with optimistic locking, timeout recovery, and live monitoring (#1934)

--- a/docs/src/introduction/upgrading-to-4.0.md
+++ b/docs/src/introduction/upgrading-to-4.0.md
@@ -31,6 +31,7 @@ If every row in this table looks fine for your app, your upgrade is probably str
 | 8 | Test base `wheels.Test` → `wheels.WheelsTest` | Required for new tests only; old base still works for existing tests |
 | 9 | `tests/specs/functions/` → `tests/specs/functional/` (framework) | Apps that mirrored the old layout can rename for consistency |
 | 10 | `application.wirebox` → `application.wheelsdi` | Prefer the `service()` global helper instead of direct scope access |
+| 11 | Vite `viteStrictManifest=true` default — missing manifest entries throw | Run `vite build`, or `set(viteStrictManifest=false)` |
 
 ## Breaking changes — detailed
 
@@ -364,6 +365,25 @@ var emailer = application.wheelsdi.getInstance("EmailService");
 **Opt-out**
 
 None — this is a straight rename. Apps rarely touch this directly in practice; the `service()` helper (available since 4.0) is the idiomatic replacement.
+
+### 11. Vite asset pipeline — strict manifest default
+
+**What changed.** Missing Vite manifest entries now throw `Wheels.ViteAssetNotFound` in production, controlled by the new `viteStrictManifest` setting (default `true`). In 3.x, a missing entry silently returned the raw entrypoint path or an empty string when `showErrorInformation=false`. This turned a deploy-time misconfiguration into a runtime 404 mystery — links to `/build/src/main.js` loaded as 404s with no useful error.
+
+**How to detect.** If your production deploy has previously tolerated a missing Vite entry (because `vite build` wasn't run, or the manifest file moved), the error surfaces immediately on the first request that calls `viteAsset()`, `viteScriptTag()`, `viteStyleTag()`, or `vitePreloadTag()`.
+
+**How to fix.** Run your Vite build to (re)generate `manifest.json` at the configured `viteBuildPath`, or correct the `viteManifestFile` setting. This is the recommended fix — the strict default is deliberately loud so deploys surface the bug instead of 404-ing end users.
+
+**Opt out.** Apps that genuinely want the 3.x silent behavior can:
+
+```cfm
+// config/settings.cfm
+set(viteStrictManifest=false);
+```
+
+With strict off, missing entries throw only when `showErrorInformation=true` (development), matching 3.x behavior.
+
+**Bonus.** 4.0 also adds transitive-imports resolution to `viteScriptTag()` and `viteStyleTag()` (automatic `<link rel="modulepreload">` and chunk-CSS injection) and a new `vitePreloadTag()` view helper for Turbo Drive hover-preload patterns. No action required — these are additive and on by default.
 
 ### Security-hardening defaults — quick reference
 

--- a/docs/superpowers/plans/2026-04-16-vite-pipeline-maturity.md
+++ b/docs/superpowers/plans/2026-04-16-vite-pipeline-maturity.md
@@ -1,0 +1,124 @@
+# Implementation Plan — Vite Pipeline Maturity (Approach D)
+
+**Date:** 2026-04-16
+**Spec:** [2026-04-16-vite-pipeline-maturity-design.md](../specs/2026-04-16-vite-pipeline-maturity-design.md)
+**Branch:** `peter/vite-pipeline-maturity`
+**Commit prefix:** `feat(view):` (for the main change) and `test(view):` / `docs:` as appropriate.
+
+## Approach
+
+Test-Driven Development throughout. Write a failing test first, implement the minimum change to pass, refactor if needed. Run the full `view` test subset after each step; run the full core suite before pushing.
+
+## Files touched
+
+1. `vendor/wheels/view/vite.cfc` — main implementation: add `$viteResolveAssets`, `$viteMissingEntry`, `$viteHtmlHead`, `vitePreloadTag`; update `viteScriptTag`, `viteStyleTag`, `viteAsset` to call the resolver and respect strict mode.
+2. `vendor/wheels/events/init/views.cfm` — register `viteStrictManifest = true` default.
+3. `vendor/wheels/tests/specs/view/viteSpec.cfc` — new describe blocks for `$viteResolveAssets`, `vitePreloadTag`, strict mode; additive assertions for `viteScriptTag`/`viteStyleTag`.
+4. `CHANGELOG.md` — Added + Changed entries under `[Unreleased]`.
+5. `docs/src/introduction/upgrading-to-4.0.md` — short callout about the strict-manifest default and how to opt out.
+
+## Steps
+
+### Step 1 — Register the `viteStrictManifest` setting
+
+**Why first:** other code will read this via `$get("viteStrictManifest")`; having it registered from the start avoids false failures.
+
+- Edit `vendor/wheels/events/init/views.cfm`: add `application.$wheels.viteStrictManifest = true;` in the Vite block.
+- Edit `vendor/wheels/tests/specs/view/viteSpec.cfc` `beforeAll`: add `viteStrictManifest = true` to the defaults struct.
+- No new tests yet — this is scaffolding.
+
+### Step 2 — TDD `$viteMissingEntry`
+
+- Add a failing test: `viteAsset` throws `Wheels.ViteAssetNotFound` when entry missing AND `viteStrictManifest=true` AND `showErrorInformation=false` (this is the 3.x quiet case that's now loud).
+- Implement `$viteMissingEntry(entrypoint)` that reads both flags and throws when `strict OR showErr`.
+- Refactor `viteAsset`, `viteScriptTag`, `viteStyleTag` to call `$viteMissingEntry` instead of inlining the `showErrorInformation` check. All three currently have the same 5-line block; DRY it up in this step.
+- Add a test for non-strict silent behavior: `viteAsset` with `viteStrictManifest=false` and `showErrorInformation=false` returns the entrypoint string unchanged.
+
+### Step 3 — TDD `$viteResolveAssets` — leaf entry
+
+- Add a failing test: resolver returns `{scripts: [entry.file], styles: [entry.css...], preloads: []}` for an entry with no imports.
+- Implement the happy path: read the entry, seed `scripts`/`styles`, return with `preloads=[]`.
+- Note: this is the "leaf" case; no tree walking yet.
+
+### Step 4 — TDD `$viteResolveAssets` — transitive imports
+
+- Add a failing test with the three-level fixture from the spec: `main.js` → `_chunk-SHARED` → `_chunk-VENDOR`. Expect preloads `["assets/chunk-SHARED.js", "assets/chunk-VENDOR.js"]` (order: depth-first) and styles including all three CSS files.
+- Implement the recursive walker with a visited set. Use a `local.visited` struct keyed by chunk key.
+- Add a diamond-dependency test: two chunks both import the same third chunk. Verify no duplicate in `preloads`.
+- Add a cycle test: A → B → A. Verify termination and both chunks appear exactly once.
+
+### Step 5 — TDD `$viteResolveAssets` — missing-entry gate
+
+- Add a failing test: `$viteResolveAssets("src/missing.js")` throws under strict mode.
+- Add a test: under non-strict mode, returns `{scripts: [], styles: [], preloads: []}`.
+- The resolver's first line calls `$viteMissingEntry(entrypoint)`; non-strict path returns the empty shape.
+
+### Step 6 — Refactor `viteScriptTag` to use the resolver
+
+- Add a failing test: `viteScriptTag` output includes `<link rel="modulepreload">` for each transitive chunk.
+- Add the `$viteHtmlHead(text)` pass-through helper and a test-stubbable capture (for tests, check the output via a test-only buffer or a stubbed function).
+- Refactor `viteScriptTag`:
+  - In prod mode, call `$viteResolveAssets()`.
+  - Emit each `styles[]` as `<link rel="stylesheet">` — this already gains transitive CSS.
+  - Emit `scripts[0]` as `<script type="module">`.
+  - Emit each `preloads[]` as `<link rel="modulepreload">` via `$viteHtmlHead()` (always to `<head>`, regardless of the `head` arg).
+- Verify existing tests still pass.
+
+### Step 7 — Refactor `viteStyleTag` to use the resolver
+
+- Add a failing test: `viteStyleTag` emits stylesheet links for transitive chunk CSS.
+- Refactor: call `$viteResolveAssets()`, emit one `<link rel="stylesheet">` per entry in `styles[]`.
+- Existing "single entry CSS" test should still pass since the resolver's `styles[]` starts with the entry's own `file`.
+
+### Step 8 — Add `vitePreloadTag`
+
+- Add failing tests:
+  - Returns empty string in dev mode.
+  - With `head=false`, returns `<link rel="modulepreload">` for entry.file AND each preload.
+  - With `head=true` (default), emits via `$viteHtmlHead()` and returns empty.
+  - Throws under strict mode when entry missing.
+- Implement `vitePreloadTag(entrypoint, head=true)`:
+  - Dev mode: return "".
+  - Prod mode: call `$viteResolveAssets()`. Build markup with the entry's file first, then each preload. Emit via `$viteHtmlHead()` if `head`, else return.
+
+### Step 9 — Docstrings and CHANGELOG
+
+- Ensure every new/changed public function has a CFDoc comment following the existing `[section: View Helpers]` / `[category: Asset Functions]` convention.
+- Update `CHANGELOG.md` `[Unreleased]`:
+  - **Added:** `vitePreloadTag()` view helper for emitting `<link rel="modulepreload">` tags, useful for Turbo Drive hover-preload patterns. Transitive modulepreload and CSS resolution in `viteScriptTag()` and `viteStyleTag()` via a new internal `$viteResolveAssets()` resolver.
+  - **Added:** `viteStrictManifest` setting (default `true`) — missing manifest entries now throw `Wheels.ViteAssetNotFound` in production. Set to `false` to restore 3.x silent behavior.
+- Add a short callout to `docs/src/introduction/upgrading-to-4.0.md` under a "Vite asset pipeline" heading: strict-manifest default, with the opt-out.
+
+### Step 10 — Local verification
+
+- `bash tools/test-local.sh view` — all view tests green on Lucee 7 + SQLite.
+- `bash tools/test-local.sh` — full core suite green.
+- Spot-check under Lucee 6 via Docker (see CLAUDE.md "Running Tests Locally (Docker — Legacy)").
+- Spot-check under Adobe CF 2025 via Docker.
+
+### Step 11 — Commit & PR
+
+- Commit structure:
+  - `feat(view): add $viteResolveAssets resolver and strict manifest default` (step 1 + 2 + 3-5 + 7 core)
+  - `feat(view): add vitePreloadTag helper and modulepreload in viteScriptTag` (step 6 + 8)
+  - `test(view): cover transitive imports tree and strict manifest` (step 4 diamond/cycle test if not bundled above)
+  - `docs: document vite strict manifest and preload helper` (step 9 doc parts)
+
+  In practice, bundling into 1–2 commits is fine if the test-per-feature discipline is preserved in the work itself — reviewers care about the implementation being correct, not the commit count. Target 2 commits: one `feat(view)` with the full implementation + tests, one `docs:` with CHANGELOG + upgrade-guide callout.
+
+- PR: base `develop`, title `feat(view): transitive modulepreload and css resolution for vite pipeline`.
+- PR body links the spec and the plan, summarizes the three user-visible changes (transitive modulepreload, transitive CSS, strict manifest default, new helper), and calls out the opt-out path.
+
+## Risk / blast radius
+
+- **Behavior change for apps with a missing manifest entry in prod.** Previously silent; now throws under default strict mode. Mitigated by the explicit upgrade-guide callout and the `viteStrictManifest=false` opt-out.
+- **Additional `<link rel="modulepreload">` tags in `<head>`.** Browsers that don't support modulepreload ignore the rel; no backward-compat risk. Byte overhead is small (one link tag per chunk).
+- **`$htmlhead` calls inside `viteScriptTag` regardless of the `head` arg.** This is a new side effect — `viteScriptTag("main.js", head=false)` used to emit only inline markup; now it also emits modulepreload links via `$htmlhead`. This is correct behavior (preloads must be in `<head>`), and the modulepreload links are the only side effect. Call out in the CHANGELOG.
+
+## Rollback
+
+The change is contained to one CFC, one init file, and one test spec. Revert commit, redeploy — fully reversible.
+
+## Unresolved questions
+
+- Should `viteScriptTag(head=false)` still push modulepreload into `<head>` unconditionally? (Spec says yes; preloads in `<body>` are useless.) Confirmed yes during design — document prominently.

--- a/docs/superpowers/specs/2026-04-16-vite-pipeline-maturity-design.md
+++ b/docs/superpowers/specs/2026-04-16-vite-pipeline-maturity-design.md
@@ -1,0 +1,269 @@
+# Vite Pipeline Maturity — Approach D Design
+
+**Date:** 2026-04-16
+**Status:** Approved (Approach D decided in prior brainstorming session; this document captures the design for implementation.)
+**Author:** Peter Amiri + Claude
+
+## Problem
+
+`docs/wheels-vs-frameworks.md` lists asset-pipeline maturity as the last remaining gap after Wheels 4.0 closes most parity rows against Rails 8 / Laravel 12 / Django 5. Specifically:
+
+1. **No transitive modulepreload.** `viteScriptTag()` emits only the entry's own script. Vite's build output lists transitive chunk imports in `manifest.imports`, and Rails/Laravel's Vite integrations emit `<link rel="modulepreload">` for each. Missing this is a real production-perf miss — the browser can't start fetching shared chunks until the entry script parses.
+2. **No transitive CSS.** `viteScriptTag()` and `viteStyleTag()` emit CSS only from the entry's own `css` array. If a shared chunk contributes CSS (common with CSS-in-JS or shared stylesheets in component libraries), that CSS is dropped from the document.
+3. **Silent failure in production.** When `showErrorInformation=false` (typical prod), a missing manifest entry returns the raw entrypoint string or empty string. This turns a deploy-time misconfiguration into a runtime mystery — links to `/build/src/main.js` load 404s with no useful error.
+4. **No explicit preload helper.** Turbo Drive (shipped in Wheels 4.0 via the Hotwire package) uses hover-preload — on `mouseenter`, fetch the next page and its assets. Without a dedicated `vitePreloadTag(entrypoint)`, views can't declare "I know we'll navigate here soon — start fetching its JS now."
+
+Post-4.0 asset-pipeline maturity is a stated goal in the 4.0 audit's follow-ups list (`docs/releases/wheels-4.0-audit.md`, "Vite pipeline maturity").
+
+## Solution (Approach D — "C lite")
+
+Extract a private `$viteResolveAssets(entrypoint)` function inside `vendor/wheels/view/vite.cfc` that walks the manifest once and returns a resolved asset set. Existing helpers become thin callers; a new `vitePreloadTag()` reuses the same seam. Keep everything in `vite.cfc` — no separate CFC.
+
+**Why not full Approach C (dedicated CFC):** the resolver is ~40 lines of logic; a separate CFC adds component-file ceremony, mixin wiring, and test-scaffolding burden for a private surface. Leaving the helper in `vite.cfc` gives us the internal seam without any user-visible structural change.
+
+**Why not Approach A (inline in each helper):** duplication. The transitive-imports walker is the same in `viteScriptTag()`, `viteStyleTag()`, and `vitePreloadTag()`. Inlining it three times invites drift.
+
+**Why not Approach B (CFC per entry type — scripts/styles/preloads):** over-engineered. Vite's manifest is one data structure; one resolver walks it.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Public API shape | Add `vitePreloadTag(entrypoint)`; `viteScriptTag()` and `viteStyleTag()` remain with additive behavior | Backward-compatible; new helper is opt-in |
+| Resolver location | Private `$viteResolveAssets()` inside `vite.cfc` | Minimal structural change; fits the existing `$vite*` helper convention |
+| Resolver return shape | `{scripts: [...], styles: [...], preloads: [...]}` | Mirrors Rails' `ViteRails::Manifest::Entry` expanded output; each caller picks what it needs |
+| Transitive walk | Recursive with visited-set for cycle safety | Manifests can have circular imports in rare dev-time states; defensive programming for prod |
+| `preloads` semantics | Transitive `imports` chain from the manifest (chunk keys) — the entry itself is NOT in this list | Matches Rails' modulepreload behavior; `viteScriptTag()` emits the entry as `<script>`, preloads as `<link>` |
+| Modulepreload emission | Via `$htmlhead()` so preloads land in `<head>` regardless of where `viteScriptTag()` was called from | Preloads in `<body>` are effectively useless — the parser has already found the entry script |
+| Strict mode default | New setting `viteStrictManifest` defaults to `true` | Consistent with Wheels 4.0's deny-by-default security posture. Missing entries are deployment bugs, not runtime fallbacks |
+| Strict mode opt-out | `set(viteStrictManifest=false)` restores 3.x silent behavior | Legacy apps and Legacy Compatibility Adapter users have an escape hatch |
+| Dev-mode behavior | `$viteResolveAssets()` is called only in prod (non-dev) mode | Dev mode has no manifest; Vite handles chunk resolution |
+| Cycle handling | Visited-set + recursive walk; revisit skipped | Simple, covers the rare self-referential case that can appear in source-map-enabled dev builds |
+| Test fixture strategy | Fixture manifests inline in `viteSpec.cfc` beforeEach blocks, simulating `imports` trees up to 3 levels deep | No file-system fixtures; keeps tests hermetic and fast |
+
+## Architecture
+
+### Current helper graph (3.x / early 4.0)
+
+```
+viteAsset()     → reads manifest, returns file URL
+viteScriptTag() → reads manifest, emits entry CSS links + entry <script>
+viteStyleTag()  → reads manifest, emits one <link rel=stylesheet>
+```
+
+Each helper walks the manifest independently; each handles the missing-entry case independently. CSS and preloads from transitive imports are dropped.
+
+### Target helper graph (Approach D)
+
+```
+$viteResolveAssets(entrypoint)
+    └── walks manifest.imports transitively, dedup via visited set
+    └── returns {scripts, styles, preloads}
+
+viteAsset()         → (unchanged semantics; adds strict-mode path)
+viteScriptTag()     → calls $viteResolveAssets()
+                      → emits styles as <link rel=stylesheet>
+                      → emits entry as <script type=module>
+                      → emits preloads as <link rel=modulepreload> via $htmlhead()
+viteStyleTag()      → calls $viteResolveAssets()
+                      → emits every style as <link rel=stylesheet>
+                      → (ignores scripts/preloads)
+vitePreloadTag()    → calls $viteResolveAssets()
+                      → emits entry + preloads as <link rel=modulepreload>
+                      → (no scripts, no styles)
+```
+
+### Resolver algorithm
+
+```
+$viteResolveAssets(entrypoint):
+    manifest = $viteManifest()
+    if entrypoint not in manifest:
+        $viteMissingEntry(entrypoint)        # strict-mode gate
+        return {scripts: [], styles: [], preloads: []}
+
+    entry = manifest[entrypoint]
+    scripts = [entry.file]                    # always first
+    styles  = list copy of entry.css (or empty)
+    preloads = []
+    visited = {entrypoint}
+
+    walk(importKeys = entry.imports or []):
+        for key in importKeys:
+            if key in visited: continue
+            visited.add(key)
+            if key not in manifest: continue  # defensive; shouldn't happen
+            chunk = manifest[key]
+            preloads.append(chunk.file)        # for modulepreload
+            for css in (chunk.css or []):
+                styles.append(css)             # transitive CSS
+            walk(chunk.imports or [])          # recurse
+
+    return {scripts, styles, preloads}
+```
+
+### Missing-entry gate
+
+```
+$viteMissingEntry(entrypoint):
+    strict = $get("viteStrictManifest") default true
+    showErr = $get("showErrorInformation")
+    if strict or showErr:
+        Throw(type="Wheels.ViteAssetNotFound", ...)
+    # non-strict + non-showErr: silent (3.x behavior)
+```
+
+### Setting registration
+
+Add to `vendor/wheels/events/init/views.cfm`:
+```cfm
+application.$wheels.viteStrictManifest = true;
+```
+
+No environment-specific default — the whole point is "deploy bugs should be visible." Apps that need 3.x behavior set `viteStrictManifest=false` explicitly.
+
+## Public API additions
+
+### `vitePreloadTag(entrypoint, [head=true])`
+
+```cfm
+/**
+ * Returns <link rel="modulepreload"> tags for a Vite entrypoint and its
+ * transitive chunk imports. Useful for Turbo Drive hover-preload patterns
+ * or for explicit warming of assets a subsequent navigation will need.
+ *
+ * In development mode, returns an empty string — Vite handles module
+ * resolution dynamically and modulepreload is unnecessary.
+ *
+ * [section: View Helpers]
+ * [category: Asset Functions]
+ *
+ * @entrypoint The source entrypoint path (e.g. "src/main.js").
+ * @head Set to `false` to return the markup for inline placement;
+ *       default true emits via `$htmlhead()` so tags land in <head>.
+ */
+public string function vitePreloadTag(
+    required string entrypoint,
+    boolean head = true
+)
+```
+
+Behavior:
+- Dev mode: returns empty string.
+- Prod mode, strict-miss: throws `Wheels.ViteAssetNotFound`.
+- Prod mode, non-strict miss: returns empty string.
+- Prod mode, hit: emits `<link rel="modulepreload" href="...entry.file" />` for the entry, then one for each transitive chunk in `preloads`. By default (`head=true`), emits via `$htmlhead()` and returns empty string.
+
+### `viteScriptTag(entrypoint, [head=false])` — new behavior
+
+Additive, backward-compatible:
+1. Still emits CSS links (now from `styles`, which is entry CSS + transitive CSS).
+2. Still emits the entry `<script type="module">`.
+3. **Newly emits** `<link rel="modulepreload">` for each transitive chunk in `preloads`, always via `$htmlhead()` (regardless of the `head` argument), so preloads always land in `<head>` where they're useful.
+
+### `viteStyleTag(entrypoint, [head=false])` — new behavior
+
+Additive:
+1. Still emits a `<link rel="stylesheet">` for the entrypoint's own file.
+2. **Newly emits** additional `<link rel="stylesheet">` tags for every CSS in transitive chunks.
+
+### Strict manifest — new setting
+
+`viteStrictManifest` (boolean, default `true`):
+- `true`: missing entry throws `Wheels.ViteAssetNotFound` regardless of `showErrorInformation`.
+- `false`: restores 3.x silent behavior (only throws when `showErrorInformation=true`).
+
+## Test plan
+
+Tests extend `vendor/wheels/tests/specs/view/viteSpec.cfc`. Fixtures are inline manifest structs with three-level import trees.
+
+### Fixture — transitive imports manifest
+
+```cfm
+{
+  "src/main.js": {
+    file: "assets/main-ABC.js",
+    isEntry: true,
+    imports: ["_chunk-SHARED-XYZ.js"],
+    css: ["assets/main-MAIN.css"]
+  },
+  "_chunk-SHARED-XYZ.js": {
+    file: "assets/chunk-SHARED-XYZ.js",
+    imports: ["_chunk-VENDOR-DEF.js"],
+    css: ["assets/chunk-SHARED.css"]
+  },
+  "_chunk-VENDOR-DEF.js": {
+    file: "assets/chunk-VENDOR-DEF.js",
+    imports: [],
+    css: ["assets/chunk-VENDOR.css"]
+  }
+}
+```
+
+### New tests
+
+**`$viteResolveAssets` (new describe block):**
+1. Returns scripts=[entry.file], styles=[entry.css], preloads=[] for a leaf entry.
+2. Returns preloads with all transitive chunks for a nested imports tree.
+3. Dedupes when two chunks import the same third chunk (diamond dependency).
+4. Does not infinite-loop on a cyclic imports graph.
+5. Aggregates CSS from entry + all transitive chunks.
+6. Honors strict mode: throws `Wheels.ViteAssetNotFound` when entry missing and `viteStrictManifest=true`.
+7. Non-strict mode returns empty resolved set when entry missing and `showErrorInformation=false`.
+
+**`viteScriptTag` additive:**
+8. Emits `<link rel="modulepreload">` for each transitive chunk (verify via `$htmlhead`-captured output; Lucee/Adobe need a test shim since `cfhtmlhead` is not easy to inspect — alternative: verify by checking the helper's side effect through a test-only capture).
+9. Emits stylesheet links for transitive chunk CSS (verify inline output contains each chunk CSS file).
+
+**`viteStyleTag` additive:**
+10. Emits stylesheet links for transitive chunk CSS.
+
+**`vitePreloadTag` (new describe block):**
+11. Returns empty string in dev mode.
+12. Emits modulepreload for entry.file in prod mode with `head=false`.
+13. Emits modulepreload for each transitive chunk in addition to entry.
+14. With `head=true` (default), emits via `$htmlhead()` and returns empty.
+15. Throws on missing entry under strict mode.
+
+**Strict-mode behavior (existing helpers):**
+16. `viteAsset` throws on missing entry when `viteStrictManifest=true`, regardless of `showErrorInformation`.
+17. `viteAsset` returns entrypoint silently when `viteStrictManifest=false` and `showErrorInformation=false` (3.x behavior).
+
+### `$htmlhead` testing shim
+
+`$htmlhead()` is CFML's mechanism for injecting HTML into `<head>`. Testing it across engines is awkward. Two options:
+
+- **Option A (preferred):** add a test-scope `$viteHtmlHead(text)` pass-through that `viteScriptTag`/`vitePreloadTag` call. Tests can stub this via a shared struct. No shim in production behavior; just an extraction for testability.
+- **Option B:** inspect side-effects through a Lucee/Adobe engine-specific mechanism. Fragile, engine-coupled.
+
+Go with A.
+
+### Cross-engine verification
+
+Run the full spec file under:
+- Lucee 7 + SQLite (local, via `bash tools/test-local.sh view`)
+- Lucee 6 + SQLite (Docker: `docker compose up -d lucee6 && curl ...`)
+- Adobe CF 2025 + SQLite (Docker: `docker compose up -d adobe2025 && curl ...`)
+
+Spot-check on BoxLang if CI catches it. No new engine-specific code is introduced, so the risk surface is low.
+
+## Out of scope (deliberately deferred)
+
+- **SRI (Subresource Integrity) hashes.** Not shipped in Vite's default manifest; requires a build plugin or post-build hash computation. Approach D leaves a seam (`$viteResolveAssets()`) where a future `integrity` field on each resolved asset can plug in.
+- **CSP nonce integration.** Similar — leave the seam; separate spec.
+- **Legacy-bundle fallback (`viteLegacyScriptTag`).** Adds another helper; not required for modern browsers which are the Wheels 4.x baseline.
+- **Vue/React-specific refresh helpers (`viteReactRefresh`).** Framework-specific; lives in per-framework wheels packages if needed.
+
+## Rollout
+
+1. Land changes on `develop` behind the new `viteStrictManifest=true` default.
+2. Upgrade guide (`docs/src/introduction/upgrading-to-4.0.md`) adds a note: "If a previously-silent missing Vite entrypoint now throws, either fix the missing entry (recommended) or `set(viteStrictManifest=false)`."
+3. CHANGELOG entry under `[Unreleased]`:
+   - **Added:** `vitePreloadTag()` helper; transitive modulepreload and CSS resolution in `viteScriptTag()`/`viteStyleTag()`; `viteStrictManifest` setting.
+   - **Changed:** `viteStrictManifest` default `true` — missing manifest entries now throw `Wheels.ViteAssetNotFound` in production.
+4. `wheels-vs-frameworks.md` "Where Wheels Trails" update: asset-pipeline maturity row loses the "trailing" asterisk.
+
+## Unresolved questions
+
+- **`viteHmrPreload()` / hover-preload integration.** Worth shipping a view helper that emits `<link data-turbo-track="reload" rel="preload" as="fetch">`? — deferred to Turbo integration PR.
+- **Manifest fingerprint for cache-busting.** Consider reading manifest mtime as an application-scope cache key so reloads after a new `vite build` auto-clear the cache. — low priority; `?reload=true` already covers it.

--- a/vendor/wheels/events/init/views.cfm
+++ b/vendor/wheels/events/init/views.cfm
@@ -27,6 +27,7 @@
 		application.$wheels.viteBuildPath = "build";
 		application.$wheels.viteManifestFile = ".vite/manifest.json";
 		application.$wheels.viteDevMode = (application.$wheels.environment == "development");
+		application.$wheels.viteStrictManifest = true;
 
 		// Test framework settings.
 		application.$wheels.validateTestPackageMetaData = true;

--- a/vendor/wheels/tests/specs/view/viteSpec.cfc
+++ b/vendor/wheels/tests/specs/view/viteSpec.cfc
@@ -9,7 +9,8 @@ component extends="wheels.WheelsTest" {
 			viteDevMode = false,
 			viteDevServerUrl = "http://localhost:5173",
 			viteBuildPath = "build",
-			viteManifestFile = ".vite/manifest.json"
+			viteManifestFile = ".vite/manifest.json",
+			viteStrictManifest = true
 		};
 		for (var key in defaults) {
 			if (!StructKeyExists(application[appKey], key)) {
@@ -31,6 +32,8 @@ component extends="wheels.WheelsTest" {
 				_origDevUrl = application.wheels.viteDevServerUrl
 				_origBuildPath = application.wheels.viteBuildPath
 				_origManifestFile = application.wheels.viteManifestFile
+				_origStrict = application.wheels.viteStrictManifest
+				_origShowErr = application.wheels.showErrorInformation
 			})
 
 			afterEach(() => {
@@ -39,6 +42,8 @@ component extends="wheels.WheelsTest" {
 				application.wheels.viteDevServerUrl = _origDevUrl
 				application.wheels.viteBuildPath = _origBuildPath
 				application.wheels.viteManifestFile = _origManifestFile
+				application.wheels.viteStrictManifest = _origStrict
+				application.wheels.showErrorInformation = _origShowErr
 				// Clear manifest cache from the active application scope
 				var appKey = application.wo.$appKey()
 				StructDelete(application[appKey], "viteManifestCache")
@@ -93,6 +98,28 @@ component extends="wheels.WheelsTest" {
 				expect(function() {
 					_controller.viteAsset("src/missing.js")
 				}).toThrow("Wheels.ViteAssetNotFound")
+			})
+
+			it("throws under strict mode even when showErrorInformation is false", () => {
+				application.wheels.viteDevMode = false
+				application.wheels.viteStrictManifest = true
+				application.wheels.showErrorInformation = false
+				application.wheels.viteManifestCache = {}
+
+				expect(function() {
+					_controller.viteAsset("src/missing.js")
+				}).toThrow("Wheels.ViteAssetNotFound")
+			})
+
+			it("returns entrypoint silently when strict=false and showErrorInformation=false", () => {
+				application.wheels.viteDevMode = false
+				application.wheels.viteStrictManifest = false
+				application.wheels.showErrorInformation = false
+				application.wheels.viteManifestCache = {}
+
+				e = _controller.viteAsset("src/missing.js")
+
+				expect(e).toBe("src/missing.js")
 			})
 		})
 
@@ -158,6 +185,56 @@ component extends="wheels.WheelsTest" {
 				expect(e).toInclude("assets/main-BRBhM4rY.js")
 			})
 
+			it("emits stylesheet links for transitive chunk CSS", () => {
+				application.wheels.viteDevMode = false
+				application.wheels.viteManifestCache = {
+					"src/main.js": {
+						file: "assets/main-ABC.js",
+						isEntry: true,
+						imports: ["_chunk-SHARED.js"],
+						css: ["assets/main-MAIN.css"]
+					},
+					"_chunk-SHARED.js": {
+						file: "assets/chunk-SHARED.js",
+						imports: [],
+						css: ["assets/chunk-SHARED.css"]
+					}
+				}
+
+				e = _controller.viteScriptTag("src/main.js")
+
+				expect(e).toInclude("assets/main-MAIN.css")
+				expect(e).toInclude("assets/chunk-SHARED.css")
+			})
+
+			it("emits modulepreload links for transitive chunks via $viteHtmlHead", () => {
+				application.wheels.viteDevMode = false
+				application.wheels.viteManifestCache = {
+					"src/main.js": {
+						file: "assets/main-ABC.js",
+						isEntry: true,
+						imports: ["_chunk-SHARED.js"]
+					},
+					"_chunk-SHARED.js": {
+						file: "assets/chunk-SHARED.js",
+						imports: ["_chunk-VENDOR.js"]
+					},
+					"_chunk-VENDOR.js": {
+						file: "assets/chunk-VENDOR.js",
+						imports: []
+					}
+				}
+				request.$viteHeadCapture = []
+
+				_controller.viteScriptTag("src/main.js")
+
+				var captured = ArrayToList(request.$viteHeadCapture, Chr(10))
+				expect(captured).toInclude('rel="modulepreload"')
+				expect(captured).toInclude("assets/chunk-SHARED.js")
+				expect(captured).toInclude("assets/chunk-VENDOR.js")
+				StructDelete(request, "$viteHeadCapture")
+			})
+
 			it("throws when entrypoint not in manifest", () => {
 				application.wheels.viteDevMode = false
 				application.wheels.viteManifestCache = {}
@@ -206,12 +283,112 @@ component extends="wheels.WheelsTest" {
 				expect(e).toInclude('rel="stylesheet"')
 			})
 
+			it("emits stylesheet links for transitive chunk CSS", () => {
+				application.wheels.viteDevMode = false
+				application.wheels.viteManifestCache = {
+					"src/main.css": {
+						file: "assets/main-MAIN.css",
+						imports: ["_chunk-SHARED.js"],
+						css: []
+					},
+					"_chunk-SHARED.js": {
+						file: "assets/chunk-SHARED.js",
+						imports: [],
+						css: ["assets/chunk-SHARED.css"]
+					}
+				}
+
+				e = _controller.viteStyleTag("src/main.css")
+
+				expect(e).toInclude("assets/main-MAIN.css")
+				expect(e).toInclude("assets/chunk-SHARED.css")
+			})
+
 			it("throws when entrypoint not in manifest", () => {
 				application.wheels.viteDevMode = false
 				application.wheels.viteManifestCache = {}
 
 				expect(function() {
 					_controller.viteStyleTag("src/missing.css")
+				}).toThrow("Wheels.ViteAssetNotFound")
+			})
+		})
+
+		describe("Tests that vitePreloadTag", () => {
+
+			beforeEach(() => {
+				_controller = g.controller(name="dummy")
+				_origDevMode = application.wheels.viteDevMode
+				_origBuildPath = application.wheels.viteBuildPath
+				_origStrict = application.wheels.viteStrictManifest
+			})
+
+			afterEach(() => {
+				application.wheels.viteDevMode = _origDevMode
+				application.wheels.viteBuildPath = _origBuildPath
+				application.wheels.viteStrictManifest = _origStrict
+				var appKey = application.wo.$appKey()
+				StructDelete(application[appKey], "viteManifestCache")
+				if (StructKeyExists(request, "$viteHeadCapture")) {
+					StructDelete(request, "$viteHeadCapture")
+				}
+			})
+
+			it("returns empty string in dev mode", () => {
+				application.wheels.viteDevMode = true
+
+				e = _controller.vitePreloadTag("src/main.js")
+
+				expect(e).toBe("")
+			})
+
+			it("returns modulepreload for entry and each transitive chunk with head=false", () => {
+				application.wheels.viteDevMode = false
+				application.wheels.viteManifestCache = {
+					"src/main.js": {
+						file: "assets/main-ABC.js",
+						isEntry: true,
+						imports: ["_chunk-SHARED.js"]
+					},
+					"_chunk-SHARED.js": {
+						file: "assets/chunk-SHARED.js",
+						imports: []
+					}
+				}
+
+				e = _controller.vitePreloadTag(entrypoint="src/main.js", head=false)
+
+				expect(e).toInclude('rel="modulepreload"')
+				expect(e).toInclude("assets/main-ABC.js")
+				expect(e).toInclude("assets/chunk-SHARED.js")
+			})
+
+			it("emits via $viteHtmlHead and returns empty with default head=true", () => {
+				application.wheels.viteDevMode = false
+				application.wheels.viteManifestCache = {
+					"src/main.js": {
+						file: "assets/main-ABC.js",
+						isEntry: true,
+						imports: []
+					}
+				}
+				request.$viteHeadCapture = []
+
+				e = _controller.vitePreloadTag("src/main.js")
+
+				expect(e).toBe("")
+				var captured = ArrayToList(request.$viteHeadCapture, Chr(10))
+				expect(captured).toInclude('rel="modulepreload"')
+				expect(captured).toInclude("assets/main-ABC.js")
+			})
+
+			it("throws under strict mode when entry missing", () => {
+				application.wheels.viteDevMode = false
+				application.wheels.viteStrictManifest = true
+				application.wheels.viteManifestCache = {}
+
+				expect(function() {
+					_controller.vitePreloadTag("src/missing.js")
 				}).toThrow("Wheels.ViteAssetNotFound")
 			})
 		})
@@ -265,6 +442,172 @@ component extends="wheels.WheelsTest" {
 				e = _controller.$viteDevUrl("/src/main.js")
 
 				expect(e).toBe("http://localhost:5173/src/main.js")
+			})
+		})
+
+		describe("Tests that $viteResolveAssets", () => {
+
+			beforeEach(() => {
+				_controller = g.controller(name="dummy")
+				_origDevMode = application.wheels.viteDevMode
+				_origBuildPath = application.wheels.viteBuildPath
+				_origStrict = application.wheels.viteStrictManifest
+				_origShowErr = application.wheels.showErrorInformation
+				application.wheels.viteDevMode = false
+				application.wheels.viteStrictManifest = true
+			})
+
+			afterEach(() => {
+				application.wheels.viteDevMode = _origDevMode
+				application.wheels.viteBuildPath = _origBuildPath
+				application.wheels.viteStrictManifest = _origStrict
+				application.wheels.showErrorInformation = _origShowErr
+				var appKey = application.wo.$appKey()
+				StructDelete(application[appKey], "viteManifestCache")
+			})
+
+			it("returns scripts=[entry.file] and empty preloads for leaf entry", () => {
+				application.wheels.viteManifestCache = {
+					"src/main.js": {
+						file: "assets/main-LEAF.js",
+						isEntry: true
+					}
+				}
+
+				e = _controller.$viteResolveAssets("src/main.js")
+
+				expect(e).toBeTypeOf("struct")
+				expect(e.scripts).toBeTypeOf("array")
+				expect(ArrayLen(e.scripts)).toBe(1)
+				expect(e.scripts[1]).toBe("assets/main-LEAF.js")
+				expect(e.styles).toBeTypeOf("array")
+				expect(ArrayLen(e.styles)).toBe(0)
+				expect(e.preloads).toBeTypeOf("array")
+				expect(ArrayLen(e.preloads)).toBe(0)
+			})
+
+			it("includes entry CSS in styles array", () => {
+				application.wheels.viteManifestCache = {
+					"src/main.js": {
+						file: "assets/main.js",
+						isEntry: true,
+						css: ["assets/main-MAIN.css"]
+					}
+				}
+
+				e = _controller.$viteResolveAssets("src/main.js")
+
+				expect(ArrayLen(e.styles)).toBe(1)
+				expect(e.styles[1]).toBe("assets/main-MAIN.css")
+			})
+
+			it("walks transitive imports and collects preloads + chunk CSS", () => {
+				application.wheels.viteManifestCache = {
+					"src/main.js": {
+						file: "assets/main-ABC.js",
+						isEntry: true,
+						imports: ["_chunk-SHARED.js"],
+						css: ["assets/main-MAIN.css"]
+					},
+					"_chunk-SHARED.js": {
+						file: "assets/chunk-SHARED.js",
+						imports: ["_chunk-VENDOR.js"],
+						css: ["assets/chunk-SHARED.css"]
+					},
+					"_chunk-VENDOR.js": {
+						file: "assets/chunk-VENDOR.js",
+						imports: [],
+						css: ["assets/chunk-VENDOR.css"]
+					}
+				}
+
+				e = _controller.$viteResolveAssets("src/main.js")
+
+				expect(ArrayLen(e.scripts)).toBe(1)
+				expect(e.scripts[1]).toBe("assets/main-ABC.js")
+				expect(ArrayLen(e.preloads)).toBe(2)
+				expect(ArrayContains(e.preloads, "assets/chunk-SHARED.js")).toBeTrue()
+				expect(ArrayContains(e.preloads, "assets/chunk-VENDOR.js")).toBeTrue()
+				expect(ArrayLen(e.styles)).toBe(3)
+				expect(ArrayContains(e.styles, "assets/main-MAIN.css")).toBeTrue()
+				expect(ArrayContains(e.styles, "assets/chunk-SHARED.css")).toBeTrue()
+				expect(ArrayContains(e.styles, "assets/chunk-VENDOR.css")).toBeTrue()
+			})
+
+			it("dedupes diamond-dependency imports (two chunks sharing a third)", () => {
+				application.wheels.viteManifestCache = {
+					"src/main.js": {
+						file: "assets/main.js",
+						isEntry: true,
+						imports: ["_chunk-A.js", "_chunk-B.js"]
+					},
+					"_chunk-A.js": {
+						file: "assets/chunk-A.js",
+						imports: ["_chunk-SHARED.js"]
+					},
+					"_chunk-B.js": {
+						file: "assets/chunk-B.js",
+						imports: ["_chunk-SHARED.js"]
+					},
+					"_chunk-SHARED.js": {
+						file: "assets/chunk-SHARED.js",
+						imports: []
+					}
+				}
+
+				e = _controller.$viteResolveAssets("src/main.js")
+
+				expect(ArrayLen(e.preloads)).toBe(3)
+				// Each chunk exactly once
+				var sharedCount = 0
+				for (var p in e.preloads) {
+					if (p == "assets/chunk-SHARED.js") { sharedCount++ }
+				}
+				expect(sharedCount).toBe(1)
+			})
+
+			it("terminates on cyclic imports graph", () => {
+				application.wheels.viteManifestCache = {
+					"src/main.js": {
+						file: "assets/main.js",
+						isEntry: true,
+						imports: ["_chunk-A.js"]
+					},
+					"_chunk-A.js": {
+						file: "assets/chunk-A.js",
+						imports: ["_chunk-B.js"]
+					},
+					"_chunk-B.js": {
+						file: "assets/chunk-B.js",
+						imports: ["_chunk-A.js"]
+					}
+				}
+
+				e = _controller.$viteResolveAssets("src/main.js")
+
+				expect(ArrayLen(e.preloads)).toBe(2)
+			})
+
+			it("throws under strict mode when entry missing regardless of showErrorInformation", () => {
+				application.wheels.viteStrictManifest = true
+				application.wheels.showErrorInformation = false
+				application.wheels.viteManifestCache = {}
+
+				expect(function() {
+					_controller.$viteResolveAssets("src/missing.js")
+				}).toThrow("Wheels.ViteAssetNotFound")
+			})
+
+			it("returns empty resolved set under non-strict mode when entry missing and showErrorInformation=false", () => {
+				application.wheels.viteStrictManifest = false
+				application.wheels.showErrorInformation = false
+				application.wheels.viteManifestCache = {}
+
+				e = _controller.$viteResolveAssets("src/missing.js")
+
+				expect(ArrayLen(e.scripts)).toBe(0)
+				expect(ArrayLen(e.styles)).toBe(0)
+				expect(ArrayLen(e.preloads)).toBe(0)
 			})
 		})
 

--- a/vendor/wheels/view/vite.cfc
+++ b/vendor/wheels/view/vite.cfc
@@ -15,13 +15,7 @@ component {
 		}
 		local.manifest = $viteManifest();
 		if (!StructKeyExists(local.manifest, arguments.entrypoint)) {
-			if ($get("showErrorInformation")) {
-				Throw(
-					type="Wheels.ViteAssetNotFound",
-					message="Vite entrypoint '#arguments.entrypoint#' not found in manifest.",
-					extendedInfo="Available entrypoints: #StructKeyList(local.manifest)#. Run your Vite build to generate the manifest."
-				);
-			}
+			$viteMissingEntry(arguments.entrypoint, local.manifest);
 			return arguments.entrypoint;
 		}
 		return $get("webPath") & $get("viteBuildPath") & "/" & local.manifest[arguments.entrypoint].file;
@@ -46,32 +40,27 @@ component {
 			local.rv = '<script type="module" src="#local.devUrl#/@vite/client"></script>' & Chr(10);
 			local.rv &= '<script type="module" src="#$viteDevUrl(arguments.entrypoint)#"></script>' & Chr(10);
 		} else {
-			local.manifest = $viteManifest();
-			if (!StructKeyExists(local.manifest, arguments.entrypoint)) {
-				if ($get("showErrorInformation")) {
-					Throw(
-						type="Wheels.ViteAssetNotFound",
-						message="Vite entrypoint '#arguments.entrypoint#' not found in manifest.",
-						extendedInfo="Available entrypoints: #StructKeyList(local.manifest)#. Run your Vite build to generate the manifest."
-					);
-				}
+			local.resolved = $viteResolveAssets(arguments.entrypoint);
+			if (!ArrayLen(local.resolved.scripts)) {
 				return "";
 			}
-			local.entry = local.manifest[arguments.entrypoint];
 			local.buildPath = $get("webPath") & $get("viteBuildPath");
 
-			// Emit <link> tags for associated CSS files
-			if (StructKeyExists(local.entry, "css") && IsArray(local.entry.css)) {
-				for (local.cssFile in local.entry.css) {
-					local.rv &= '<link rel="stylesheet" href="#local.buildPath#/#local.cssFile#" />' & Chr(10);
-				}
+			for (local.cssFile in local.resolved.styles) {
+				local.rv &= '<link rel="stylesheet" href="#local.buildPath#/#local.cssFile#" />' & Chr(10);
 			}
 
-			local.rv &= '<script type="module" src="#local.buildPath#/#local.entry.file#"></script>' & Chr(10);
+			local.rv &= '<script type="module" src="#local.buildPath#/#local.resolved.scripts[1]#"></script>' & Chr(10);
+
+			// Modulepreload for transitive import chunks — always emitted into <head>
+			// regardless of the `head` arg, since preloads placed in <body> are useless.
+			for (local.chunkFile in local.resolved.preloads) {
+				$viteHtmlHead(text='<link rel="modulepreload" href="#local.buildPath#/#local.chunkFile#" />' & Chr(10));
+			}
 		}
 
 		if (arguments.head) {
-			$htmlhead(text=local.rv);
+			$viteHtmlHead(text=local.rv);
 			return "";
 		}
 		return local.rv;
@@ -93,24 +82,56 @@ component {
 			return "";
 		}
 
-		local.manifest = $viteManifest();
-		if (!StructKeyExists(local.manifest, arguments.entrypoint)) {
-			if ($get("showErrorInformation")) {
-				Throw(
-					type="Wheels.ViteAssetNotFound",
-					message="Vite entrypoint '#arguments.entrypoint#' not found in manifest.",
-					extendedInfo="Available entrypoints: #StructKeyList(local.manifest)#. Run your Vite build to generate the manifest."
-				);
-			}
+		local.resolved = $viteResolveAssets(arguments.entrypoint);
+		if (!ArrayLen(local.resolved.scripts)) {
+			return "";
+		}
+		local.buildPath = $get("webPath") & $get("viteBuildPath");
+		local.rv = '<link rel="stylesheet" href="#local.buildPath#/#local.resolved.scripts[1]#" />' & Chr(10);
+		for (local.cssFile in local.resolved.styles) {
+			local.rv &= '<link rel="stylesheet" href="#local.buildPath#/#local.cssFile#" />' & Chr(10);
+		}
+
+		if (arguments.head) {
+			$viteHtmlHead(text=local.rv);
+			return "";
+		}
+		return local.rv;
+	}
+
+	/**
+	 * Returns `<link rel="modulepreload">` tags for a Vite entrypoint and its transitive
+	 * chunk imports. Useful for Turbo Drive hover-preload patterns or for explicitly warming
+	 * assets a subsequent navigation will need.
+	 *
+	 * In development mode, returns an empty string — Vite handles module resolution
+	 * dynamically and modulepreload is unnecessary.
+	 *
+	 * [section: View Helpers]
+	 * [category: Asset Functions]
+	 *
+	 * @entrypoint The source entrypoint path (e.g. "src/main.js").
+	 * @head Set to `false` to return the markup for inline placement; default `true`
+	 *       emits via `$viteHtmlHead()` so tags land in `<head>`.
+	 */
+	public string function vitePreloadTag(required string entrypoint, boolean head = true) {
+		if ($viteDevMode()) {
 			return "";
 		}
 
-		local.entry = local.manifest[arguments.entrypoint];
+		local.resolved = $viteResolveAssets(arguments.entrypoint);
+		if (!ArrayLen(local.resolved.scripts)) {
+			return "";
+		}
+
 		local.buildPath = $get("webPath") & $get("viteBuildPath");
-		local.rv = '<link rel="stylesheet" href="#local.buildPath#/#local.entry.file#" />' & Chr(10);
+		local.rv = '<link rel="modulepreload" href="#local.buildPath#/#local.resolved.scripts[1]#" />' & Chr(10);
+		for (local.chunkFile in local.resolved.preloads) {
+			local.rv &= '<link rel="modulepreload" href="#local.buildPath#/#local.chunkFile#" />' & Chr(10);
+		}
 
 		if (arguments.head) {
-			$htmlhead(text=local.rv);
+			$viteHtmlHead(text=local.rv);
 			return "";
 		}
 		return local.rv;
@@ -165,6 +186,120 @@ component {
 	 */
 	public boolean function $viteDevMode() {
 		return $get("viteDevMode");
+	}
+
+	/**
+	 * Walks the Vite manifest for a single entrypoint and returns its resolved
+	 * script, styles, and modulepreload chunks. Follows transitive imports
+	 * depth-first, dedupes visited chunks, and terminates on cycles.
+	 *
+	 * Returns a struct with three array keys:
+	 *   - scripts:  [entry.file]            (the main JS file)
+	 *   - styles:   [entry.css..., chunk.css...]  (entry CSS + all transitive chunk CSS)
+	 *   - preloads: [chunk.file, ...]        (each transitive import chunk)
+	 *
+	 * Behavior on missing entry is delegated to `$viteMissingEntry` (strict-mode
+	 * gate). Returns an empty resolved set in non-strict mode.
+	 */
+	public struct function $viteResolveAssets(required string entrypoint) {
+		local.manifest = $viteManifest();
+		local.rv = {scripts: [], styles: [], preloads: []};
+
+		if (!StructKeyExists(local.manifest, arguments.entrypoint)) {
+			$viteMissingEntry(arguments.entrypoint, local.manifest);
+			return local.rv;
+		}
+
+		local.entry = local.manifest[arguments.entrypoint];
+		ArrayAppend(local.rv.scripts, local.entry.file);
+		if (StructKeyExists(local.entry, "css") && IsArray(local.entry.css)) {
+			for (local.cssFile in local.entry.css) {
+				ArrayAppend(local.rv.styles, local.cssFile);
+			}
+		}
+
+		local.visited = {};
+		local.visited[arguments.entrypoint] = true;
+		if (StructKeyExists(local.entry, "imports") && IsArray(local.entry.imports)) {
+			$viteWalkImports(
+				importKeys=local.entry.imports,
+				manifest=local.manifest,
+				visited=local.visited,
+				preloads=local.rv.preloads,
+				styles=local.rv.styles
+			);
+		}
+
+		return local.rv;
+	}
+
+	/**
+	 * Depth-first walks a list of chunk import keys, mutating the passed-in
+	 * preloads and styles arrays as it visits each chunk. The visited struct
+	 * prevents cycles and dedupes diamond dependencies.
+	 */
+	public void function $viteWalkImports(
+		required array importKeys,
+		required struct manifest,
+		required struct visited,
+		required array preloads,
+		required array styles
+	) {
+		for (local.key in arguments.importKeys) {
+			if (StructKeyExists(arguments.visited, local.key)) {
+				continue;
+			}
+			arguments.visited[local.key] = true;
+			if (!StructKeyExists(arguments.manifest, local.key)) {
+				continue;
+			}
+			local.chunk = arguments.manifest[local.key];
+			ArrayAppend(arguments.preloads, local.chunk.file);
+			if (StructKeyExists(local.chunk, "css") && IsArray(local.chunk.css)) {
+				for (local.cssFile in local.chunk.css) {
+					ArrayAppend(arguments.styles, local.cssFile);
+				}
+			}
+			if (StructKeyExists(local.chunk, "imports") && IsArray(local.chunk.imports)) {
+				$viteWalkImports(
+					importKeys=local.chunk.imports,
+					manifest=arguments.manifest,
+					visited=arguments.visited,
+					preloads=arguments.preloads,
+					styles=arguments.styles
+				);
+			}
+		}
+	}
+
+	/**
+	 * Thin wrapper around `$htmlhead` that also records the text into a
+	 * request-scoped capture array when one is present. Tests initialize
+	 * `request.$viteHeadCapture = []` to inspect what was emitted to <head>;
+	 * production code paths never set the capture and behavior is unchanged.
+	 */
+	public void function $viteHtmlHead(required string text) {
+		if (StructKeyExists(request, "$viteHeadCapture") && IsArray(request.$viteHeadCapture)) {
+			ArrayAppend(request.$viteHeadCapture, arguments.text);
+		}
+		$htmlhead(text=arguments.text);
+	}
+
+	/**
+	 * Handles a missing manifest entry. Throws `Wheels.ViteAssetNotFound` when
+	 * strict-manifest mode is enabled (default) or when `showErrorInformation`
+	 * is true. Otherwise returns silently, preserving 3.x behavior for apps that
+	 * opt out via `set(viteStrictManifest=false)`.
+	 */
+	public void function $viteMissingEntry(required string entrypoint, struct manifest = {}) {
+		local.strict = $get("viteStrictManifest");
+		if (local.strict || $get("showErrorInformation")) {
+			Throw(
+				type="Wheels.ViteAssetNotFound",
+				message="Vite entrypoint '#arguments.entrypoint#' not found in manifest.",
+				extendedInfo="Available entrypoints: #StructKeyList(arguments.manifest)#. Run your Vite build to generate the manifest, or set(viteStrictManifest=false) to silence this error."
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Closes the asset-pipeline maturity gap called out in the Wheels 4.0 feature audit. Brings production-perf parity with Rails' and Laravel's Vite integrations.

**New public API**

- `vitePreloadTag(entrypoint, head=true)` — emits `<link rel="modulepreload">` for a Vite entrypoint and its transitive chunk imports. Useful for Turbo Drive hover-preload patterns (Turbo shipped with Wheels 4.0 via the Hotwire package).

**Changed behavior**

- `viteScriptTag()` and `viteStyleTag()` now walk the manifest's `imports` tree transitively:
  - CSS from every transitive chunk is emitted as a `<link rel="stylesheet">` (previously only the entry's own CSS).
  - `<link rel="modulepreload">` is emitted into `<head>` for every transitive chunk, so the browser can start fetching shared code before the entry script parses.
- `viteStrictManifest` setting (new, default `true`) — missing manifest entries now throw `Wheels.ViteAssetNotFound` in production regardless of `showErrorInformation`. Consistent with Wheels 4.0's deny-by-default security posture. Set `false` to restore 3.x silent behavior.

**Internal refactor (Approach D, the "C lite")**

Extracted a private `$viteResolveAssets(entrypoint)` resolver inside `vendor/wheels/view/vite.cfc` that walks the manifest once and returns `{scripts, styles, preloads}`. Existing helpers and the new `vitePreloadTag()` all become thin callers. Recursive walker uses a visited struct for cycle safety and diamond-dependency dedup. Also extracted `$viteHtmlHead(text)` as a testable wrapper around `$htmlhead`.

## Test plan

- [x] Suite: 34 vite specs passing on Lucee 7 + SQLite (up from 18).
- [x] Full core test run: 3063 pass / 0 fail. The 20 remaining errors are unrelated to this change (Playwright JARs absent on local machine, expected).
- [x] Resolver correctness tested for: leaf entry, transitive three-level import tree, diamond dependency (dedup), cyclic graph (termination).
- [x] Strict-mode behavior covered: throws regardless of `showErrorInformation`; opt-out via `set(viteStrictManifest=false)` preserves 3.x silent path.
- [x] `vitePreloadTag` covered for dev mode, inline `head=false`, `head=true` via `$viteHtmlHead` capture buffer, and strict-miss throw.
- [x] Adobe CF 2025 spot-check attempted locally but the container has a pre-existing unrelated `graphqlclient` runtime issue; CI will exercise the full engine matrix.

## Docs

- Spec: [`docs/superpowers/specs/2026-04-16-vite-pipeline-maturity-design.md`](docs/superpowers/specs/2026-04-16-vite-pipeline-maturity-design.md)
- Plan: [`docs/superpowers/plans/2026-04-16-vite-pipeline-maturity.md`](docs/superpowers/plans/2026-04-16-vite-pipeline-maturity.md)
- CHANGELOG entry under `[Unreleased] > Added > Views`.
- Upgrade guide `docs/src/introduction/upgrading-to-4.0.md` gains an 11th breaking-change entry with detect / fix / opt-out guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)