### PR TITLE
fix(test): resolve 20 browser-spec errors with root-cause fixes

### DIFF
--- a/.ai/wheels/cross-engine-compatibility.md
+++ b/.ai/wheels/cross-engine-compatibility.md
@@ -92,6 +92,39 @@ application.$wheels.myNewSetting = "value";
 application.wheels.myNewSetting = "value";
 ```
 
+### `createDynamicProxy` Requires a CFC on Lucee 7
+
+Lucee 6 accepted a CFML struct with named function entries as the first argument to `createDynamicProxy` — Lucee wired struct keys to interface methods. Lucee 7 tightened the signature to require a Component instance. Passing a struct fails with a misleading error: `"Can't cast Complex Object Type Struct to String"` — Lucee 7 is trying the CFC-path-string overload and choking on the struct argument.
+
+```cfm
+// WRONG — works on Lucee 6, fails on Lucee 7
+var handler = {
+    accept: function(dialog) {
+        dialog.accept();
+    }
+};
+createDynamicProxy(handler, ["java.util.function.Consumer"]);
+
+// RIGHT — CFC instance, works on Lucee 6 AND Lucee 7
+component MyConsumer {
+    public any function init(required struct state) {
+        variables.state = arguments.state;
+        return this;
+    }
+    public void function accept(required any dialog) {
+        variables.state.value = dialog.message();
+        dialog.accept();
+    }
+}
+
+var consumer = new MyConsumer(state={value: ""});
+createDynamicProxy(consumer, ["java.util.function.Consumer"]);
+```
+
+**Why**: Lucee 7 adds overload dispatch prefers the `createDynamicProxy(cfcPathString, interfaces)` signature and rejects struct arguments at the cast step. The struct-argument legacy path was removed.
+
+**Reference example**: [`vendor/wheels/wheelstest/DialogConsumer.cfc`](../../vendor/wheels/wheelstest/DialogConsumer.cfc) shows the CFC-based pattern used by `BrowserClient` to proxy Playwright's `Consumer<Dialog>`. The probe in `$requireDialogSupport` mirrors the real call shape so engine compatibility is verified on the same code path.
+
 ### Private View Helpers Not Integrated
 
 `$integrateComponents()` only copies `public` methods into controllers. Private helper functions in view CFCs are never available.

--- a/.ai/wheels/testing/browser-testing.md
+++ b/.ai/wheels/testing/browser-testing.md
@@ -306,13 +306,32 @@ If you're building another URLClassLoader-backed Java library on top of the mani
 
 Playwright's `DriverJar.getDriverResourceURI()` uses `Thread.currentThread().getContextClassLoader()` to locate the bundled Node runtime inside `driver-bundle.jar`. Default TCCL is the AppClassLoader, which doesn't see our JARs — so the lookup returns null and `Playwright.create()` fails with an NPE that Lucee swallows silently (looks like a hang — it's not). `BrowserLauncher.acquireBrowser()` swaps TCCL to our URLClassLoader for the duration of the Playwright call chain. If you call Playwright methods outside the DSL (directly via `this.browser.getPage()`), you may need `$pushTCCL()` / `$popTCCL()` manually.
 
-### `createDynamicProxy` for Java interface implementation (Lucee-only)
+### `createDynamicProxy` requires a CFC instance on Lucee 7
 
-Dialog handling requires implementing Playwright's `Consumer<Dialog>` Java interface. Lucee's `createDynamicProxy` creates a Java proxy from a CFML struct of handler functions. This is Lucee-specific — Adobe CF and BoxLang don't support it. Browser specs that test dialogs should check `server.lucee` or wrap in try/catch with engine-aware skip logic.
+Dialog handling implements Playwright's `Consumer<Dialog>` Java interface via `createDynamicProxy`. Two constraints:
 
-### Fixture routes must mount before `.wildcard()`
+1. **Engine support**: Lucee only. Adobe CF and BoxLang don't support `createDynamicProxy`. `BrowserClient.$requireDialogSupport()` probes the engine on first use and throws `Wheels.BrowserDialogNotSupported` on unsupported engines; specs can check `server.lucee` or rely on that probe.
 
-The `/_browser/*` fixture routes (login-as, logout, login form, protected page) are mounted by the framework in test mode. They must come before `.wildcard()` in `config/routes.cfm` or the wildcard catches them first. The framework handles this automatically, but custom route files that override the default order should be aware.
+2. **Lucee 7 tightened the first-argument type**: Lucee 6 accepted a struct of handler functions; Lucee 7 requires a Component instance. Passing a struct fails with the misleading error `"Can't cast Complex Object Type Struct to String"` as Lucee 7 tries the CFC-path-string overload. Fix: wrap the handler logic in a CFC with an `init()` that captures shared state via variables. See [`vendor/wheels/wheelstest/DialogConsumer.cfc`](../../../vendor/wheels/wheelstest/DialogConsumer.cfc) for the canonical pattern. Both the probe and the real call now pass a CFC instance so compatibility is verified on the same code path. See also the cross-engine-compatibility doc's entry on this.
+
+### Fixture routes: two places, both required
+
+The `/_browser/*` fixture routes (home, login, login-as, dashboard, authenticate, logout) must be registered in BOTH:
+
+- **`config/routes.cfm`** — for app-level tests (`/wheels/app/tests`) and any time the app is run in a dev/test environment without the core test runner. Must come before `.wildcard()` or the wildcard catches them first.
+- **`vendor/wheels/tests/routes.cfm`** — for core tests (`/wheels/core/tests`). The core test runner swaps the route table when `$_setTestboxEnv()` runs, so app-level route declarations are not visible. Without this, `BrowserRouteSpec` throws `"Could not find the browserTestHome route"`.
+
+The fixture **controllers + views** likewise live in two places:
+- `app/controllers/BrowserTestHome.cfc` + `app/views/browsertesthome/*.cfm` for app tests.
+- `vendor/wheels/tests/_assets/controllers/BrowserTestHome.cfc` + `vendor/wheels/tests/_assets/views/browsertesthome/*.cfm` for core tests (the test runner sets `controllerPath` / `viewPath` to the `_assets` tree).
+
+Both sets must be kept in sync when the fixture surface changes.
+
+### Sibling specs wipe routes without restoring
+
+Several specs (`mapperSpec`, `security/PaginationXssSpec`, `view/linksSpec`, `view/formsSpec`) legitimately call `$clearRoutes()` in their `beforeEach` / `beforeAll` to test route-registration behavior. They do **not** restore the route table afterwards. Because bundles run alphabetically, any spec that depends on named routes and runs after these will find an empty `application.wheels.namedRoutePositions`.
+
+Defensive fix for route-dependent specs: re-include `/wheels/tests/routes.cfm` and call `$setNamedRoutePositions()` in your own `beforeAll`. `BrowserTest.beforeAll` already does this — new route-dependent specs should follow the same pattern.
 
 ### Fat arrow closures in WheelsTest suites
 

--- a/tools/test-local.sh
+++ b/tools/test-local.sh
@@ -12,6 +12,14 @@
 #   bash tools/test-local.sh security     # run security tests only
 #   PORT=9090 bash tools/test-local.sh    # use custom port
 #
+# Browser-test behavior:
+#   Browser specs (BrowserDialog/Login/Route) run against the local
+#   LuCLI server via Playwright. Requires Playwright JARs installed in
+#   ~/.wheels/browser/lib/ — run `wheels browser:install` once if not.
+#   WHEELS_BROWSER_TEST_BASE_URL is auto-set to match the local PORT so
+#   specs hit the right server; CI sets its own override before invoking
+#   this script so the ${VAR:-default} preserves it.
+#
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -20,6 +28,11 @@ FILTER="${1:-}"
 DB="${DB:-sqlite}"
 PASSWORD="wheels"
 RESULT_FILE="/tmp/wheels-local-test-results.json"
+
+# Browser specs call back into the local LuCLI server — point Playwright
+# at the right port. CI sets this explicitly before invoking the script;
+# the ${VAR:-default} preserves the CI override.
+export WHEELS_BROWSER_TEST_BASE_URL="${WHEELS_BROWSER_TEST_BASE_URL:-http://localhost:${PORT}}"
 
 cd "$PROJECT_ROOT"
 

--- a/vendor/wheels/tests/_assets/controllers/BrowserTestHome.cfc
+++ b/vendor/wheels/tests/_assets/controllers/BrowserTestHome.cfc
@@ -1,0 +1,19 @@
+component extends="Controller" {
+
+    function config() {
+        filters(through="$requireLogin", except="index");
+    }
+
+    function index() {
+    }
+
+    function dashboard() {
+        user = {email: session.userEmail ?: ""};
+    }
+
+    private function $requireLogin() {
+        if (!structKeyExists(session, "userId")) {
+            redirectTo(route="browserTestLogin");
+        }
+    }
+}

--- a/vendor/wheels/tests/_assets/controllers/BrowserTestLogin.cfc
+++ b/vendor/wheels/tests/_assets/controllers/BrowserTestLogin.cfc
@@ -1,0 +1,14 @@
+component extends="Controller" {
+
+    function config() {
+    }
+
+    function create() {
+        // Fixture-only: the env gate in the app version uses
+        // application.$wheels, which is cleared post-init. Here we just
+        // accept the login in test mode since the route file is only
+        // loaded by the core test runner.
+        session.userId = 1;
+        session.userEmail = params.identifier;
+    }
+}

--- a/vendor/wheels/tests/_assets/controllers/BrowserTestSessions.cfc
+++ b/vendor/wheels/tests/_assets/controllers/BrowserTestSessions.cfc
@@ -1,0 +1,22 @@
+component extends="Controller" {
+
+    function new() {
+        flashError = flash("error") ?: "";
+    }
+
+    function create() {
+        if (params.email == "alice@example.com" && params.password == "secret") {
+            session.userId = 1;
+            session.userEmail = params.email;
+            redirectTo(route="browserTestDashboard");
+        } else {
+            flashInsert(error="Invalid credentials");
+            redirectTo(route="browserTestLogin");
+        }
+    }
+
+    function destroy() {
+        structClear(session);
+        redirectTo(route="browserTestLogin");
+    }
+}

--- a/vendor/wheels/tests/_assets/views/browsertesthome/dashboard.cfm
+++ b/vendor/wheels/tests/_assets/views/browsertesthome/dashboard.cfm
@@ -1,0 +1,8 @@
+<cfparam name="user" default="#{}#">
+<cfoutput>
+<h1>Dashboard</h1>
+<p>Welcome, <span id="user-email">#encodeForHTML(user.email)#</span></p>
+<form method="post" action="#urlFor(route='browserTestLogout')#">
+    <button type="submit">Log out</button>
+</form>
+</cfoutput>

--- a/vendor/wheels/tests/_assets/views/browsertesthome/index.cfm
+++ b/vendor/wheels/tests/_assets/views/browsertesthome/index.cfm
@@ -1,0 +1,5 @@
+<cfoutput>
+<h1>Home</h1>
+<p>Welcome to the browser test fixture app.</p>
+<a href="#urlFor(route='browserTestLogin')#">Log in</a>
+</cfoutput>

--- a/vendor/wheels/tests/_assets/views/browsertesthome/layout.cfm
+++ b/vendor/wheels/tests/_assets/views/browsertesthome/layout.cfm
@@ -1,0 +1,12 @@
+<cfoutput>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Browser Test Fixture</title>
+</head>
+<body>
+    #contentForLayout()#
+</body>
+</html>
+</cfoutput>

--- a/vendor/wheels/tests/_assets/views/browsertestlogin/create.cfm
+++ b/vendor/wheels/tests/_assets/views/browsertestlogin/create.cfm
@@ -1,0 +1,4 @@
+<cfparam name="params" default="#{}#">
+<cfoutput>
+<p id="login-status">Logged in as #encodeForHTML(params.identifier ?: "unknown")#</p>
+</cfoutput>

--- a/vendor/wheels/tests/_assets/views/browsertestlogin/layout.cfm
+++ b/vendor/wheels/tests/_assets/views/browsertestlogin/layout.cfm
@@ -1,0 +1,12 @@
+<cfoutput>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Browser Test Fixture</title>
+</head>
+<body>
+    #contentForLayout()#
+</body>
+</html>
+</cfoutput>

--- a/vendor/wheels/tests/_assets/views/browsertestsessions/layout.cfm
+++ b/vendor/wheels/tests/_assets/views/browsertestsessions/layout.cfm
@@ -1,0 +1,12 @@
+<cfoutput>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Browser Test Fixture</title>
+</head>
+<body>
+    #contentForLayout()#
+</body>
+</html>
+</cfoutput>

--- a/vendor/wheels/tests/_assets/views/browsertestsessions/new.cfm
+++ b/vendor/wheels/tests/_assets/views/browsertestsessions/new.cfm
@@ -1,0 +1,14 @@
+<cfparam name="flashError" default="">
+<cfoutput>
+<h1>Log in</h1>
+<cfif len(flashError)>
+    <div class="error" id="error-message">#flashError#</div>
+</cfif>
+<form method="post" action="#urlFor(route='browserTestAuthenticate')#">
+    <label for="email">Email</label>
+    <input type="email" name="email" id="email">
+    <label for="password">Password</label>
+    <input type="password" name="password" id="password">
+    <button type="submit">Sign in</button>
+</form>
+</cfoutput>

--- a/vendor/wheels/tests/routes.cfm
+++ b/vendor/wheels/tests/routes.cfm
@@ -4,6 +4,19 @@
  * TODO: formalise how the cli interacts
  **/
 mapper()
+    // Browser test fixture routes — mounted during core tests so
+    // wheels.tests.specs.wheelstest.Browser* specs can resolve named
+    // routes (browserTestHome, browserTestLogin, etc.). Test-asset
+    // controllers live in vendor/wheels/tests/_assets/controllers/.
+    // Must come before .wildcard().
+    .scope(path="/_browser")
+        .get(name="browserTestHome", pattern="/home", to="BrowserTestHome##index")
+        .get(name="browserTestLogin", pattern="/login", to="BrowserTestSessions##new")
+        .post(name="browserTestAuthenticate", pattern="/login", to="BrowserTestSessions##create")
+        .get(name="browserTestDashboard", pattern="/dashboard", to="BrowserTestHome##dashboard")
+        .post(name="browserTestLogout", pattern="/logout", to="BrowserTestSessions##destroy")
+        .get(name="browserTestLoginAs", pattern="/login-as", to="BrowserTestLogin##create")
+    .end()
     .wildcard()
 	.get(name="wheelstestbox", pattern="wheels/core/tests", to="wheels##public##tests")
 	.get(name="sampleLinkToTest", pattern="sample/linktotest", to="sample##linktotest")

--- a/vendor/wheels/wheelstest/BrowserClient.cfc
+++ b/vendor/wheels/wheelstest/BrowserClient.cfc
@@ -919,16 +919,24 @@ component {
             );
         }
         try {
-            createDynamicProxy(
-                {accept: function(x) {}},
-                ["java.lang.Runnable"]
+            // Probe with the same shape used for real handling: a CFC
+            // instance exposing accept(dialog), proxied as
+            // java.util.function.Consumer. Lucee 7 tightened
+            // createDynamicProxy to require a Component — a struct with
+            // inline closures fails with "Can't cast Struct to String"
+            // as Lucee tries the CFC-path string overload.
+            var probeConsumer = new wheels.wheelstest.DialogConsumer(
+                state={lastMessage: "", handled: false},
+                action={type: "dismiss", text: ""}
             );
+            createDynamicProxy(probeConsumer, ["java.util.function.Consumer"]);
             variables.$dialogSupported = true;
         } catch (any e) {
             variables.$dialogSupported = false;
             throw(
                 type="Wheels.BrowserDialogNotSupported",
-                message="Dialog handling requires Lucee. This engine does not support createDynamicProxy."
+                message="Dialog handling requires Lucee. This engine does not support createDynamicProxy.",
+                extendedInfo="Underlying error: #e.type# — #e.message#"
             );
         }
     }
@@ -945,23 +953,11 @@ component {
         var state = {lastMessage: "", handled: false};
         variables.$dialogState = state;
 
-        var handler = {
-            accept: function(dialog) {
-                state.lastMessage = dialog.message();
-                state.handled = true;
-                if (action.type == "accept") {
-                    if (len(action.text)) {
-                        dialog.accept(action.text);
-                    } else {
-                        dialog.accept();
-                    }
-                } else {
-                    dialog.dismiss();
-                }
-            }
-        };
-
-        variables.$dialogProxy = createDynamicProxy(handler, ["java.util.function.Consumer"]);
+        // Lucee 7 rejects struct-based createDynamicProxy targets — the
+        // handler must be a CFC instance so Lucee can resolve the
+        // interface-method-to-CFC-function mapping cleanly.
+        var consumer = new wheels.wheelstest.DialogConsumer(state=state, action=action);
+        variables.$dialogProxy = createDynamicProxy(consumer, ["java.util.function.Consumer"]);
         variables.page.onDialog(variables.$dialogProxy);
     }
 

--- a/vendor/wheels/wheelstest/BrowserTest.cfc
+++ b/vendor/wheels/wheelstest/BrowserTest.cfc
@@ -56,6 +56,19 @@ component extends="wheels.WheelsTest" {
             this.browserTestSkipped = true;
             return;
         }
+
+        // Browser specs depend on named fixture routes (browserTestHome,
+        // browserTestLogin, etc.) declared in vendor/wheels/tests/routes.cfm.
+        // Other specs in the suite (mapperSpec, security/PaginationXssSpec,
+        // view/formsSpec, view/linksSpec) legitimately clear the route table
+        // via `$clearRoutes()` to test route-registration behavior, and do
+        // not restore it afterwards. If those specs run before browser
+        // specs — which happens alphabetically in the core suite — the
+        // fixture routes are gone by the time browser specs execute.
+        // Re-include the test routes here so browser specs are self-contained.
+        application.wo.$include(template="/wheels/tests/routes.cfm");
+        application.wo.$setNamedRoutePositions();
+
         try {
             variables.$launcher = $ensureLauncher();
         } catch (Wheels.BrowserNotInstalled e) {

--- a/vendor/wheels/wheelstest/DialogConsumer.cfc
+++ b/vendor/wheels/wheelstest/DialogConsumer.cfc
@@ -1,0 +1,37 @@
+/**
+ * Consumer<Dialog> target for Playwright's page.onDialog handler.
+ *
+ * Lucee 7 tightened `createDynamicProxy` to require a Component (CFC)
+ * instance as the first argument — passing a struct with inline closures
+ * fails with "Can't cast Complex Object Type Struct to String" as Lucee
+ * tries the overload that accepts a CFC path string. This CFC is that
+ * proxy target, parameterized with the caller's `state` and `action`
+ * structs so the handler logic stays in BrowserClient.
+ */
+component {
+
+	public any function init(required struct state, required struct action) {
+		variables.state = arguments.state;
+		variables.action = arguments.action;
+		return this;
+	}
+
+	/**
+	 * Called by Playwright when a dialog surfaces on the page. Matches
+	 * java.util.function.Consumer#accept(Object).
+	 */
+	public void function accept(required any dialog) {
+		variables.state.lastMessage = arguments.dialog.message();
+		variables.state.handled = true;
+		if (variables.action.type == "accept") {
+			if (Len(variables.action.text)) {
+				arguments.dialog.accept(variables.action.text);
+			} else {
+				arguments.dialog.accept();
+			}
+		} else {
+			arguments.dialog.dismiss();
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary

Resolves the 20 browser-test errors that surface when running `bash tools/test-local.sh` on Lucee 7 + SQLite. **Prior state:** 3063 pass / 0 fail / 20 error. **New state:** 3067 pass / 0 fail / 0 error. All 119 browser specs (BrowserDialog/Integration/Launcher/Login/Route/TestLifecycle) are now green.

Three distinct root causes, each fixed directly — no skip/gate workarounds.

### 1. Lucee 7 rejects struct-based `createDynamicProxy` targets (8 dialog errors)

`BrowserClient.$requireDialogSupport()` and `$registerDialogListener()` passed an inline struct with an `accept` closure as the proxy target. Lucee 7 tightened the first-argument type to require a Component — structs now fail with `"Can't cast Complex Object Type Struct to String"` as Lucee tries the CFC-path-string overload first.

**Fix:** new `wheels.wheelstest.DialogConsumer` CFC that encapsulates the `Consumer<Dialog>` handler logic, parameterized with the caller's `state` and `action` structs. Both the probe and the real handler now pass a CFC instance. Probe also corrected from `java.lang.Runnable` (method `run()`) to `java.util.function.Consumer` (method `accept(T)`) to match the interface actually used in dialog handling.

### 2. Named fixture routes not visible during core tests (5 route errors)

Two sub-problems:

a) `vendor/wheels/tests/routes.cfm` (the core test runner's route file) did not declare the `_browser/*` fixture routes — only the app's `config/routes.cfm` did.

b) Other specs in the core suite (`mapperSpec`, `security/PaginationXssSpec`, `view/linksSpec`, `view/formsSpec`) legitimately call `$clearRoutes()` to test route-registration behavior and do not restore afterwards. Bundles run alphabetically, so those specs wipe the route table before browser specs execute.

**Fix A:** register `_browser/*` fixture routes in `vendor/wheels/tests/routes.cfm`.
**Fix B:** `BrowserTest.beforeAll()` re-includes the test routes file and calls `$setNamedRoutePositions()`, making browser specs self-contained regardless of earlier specs' route-wiping.

### 3. Fixture controllers + views only existed in the app tree (7 login errors)

The core test runner swaps `controllerPath` to `/wheels/tests/_assets/controllers`, so the app-tree `BrowserTestHome.cfc`, `BrowserTestLogin.cfc`, `BrowserTestSessions.cfc` and their views are invisible during core tests. Playwright requests returned empty responses, failing assertions like "Expected page to contain 'alice@example.com'".

**Fix:** copied the three fixture controllers + six view templates into `vendor/wheels/tests/_assets/`. The `loginAs` env-gate in the app copy references `application.$wheels` which is cleared post-init — the vendor copy omits the gate since these routes are only loaded by the core test runner.

### Also

- `tools/test-local.sh` exports `WHEELS_BROWSER_TEST_BASE_URL=http://localhost:${PORT}` so Playwright hits the running server instead of the default `localhost:8080`. CI's own export is preserved via the `${VAR:-default}` pattern.

## Test plan

- [x] `PORT=9090 bash tools/test-local.sh` on Lucee 7 + SQLite: **3067 pass / 0 fail / 0 error** (was 3063 pass / 0 fail / 20 error).
- [x] Verified all 6 browser bundles green: BrowserDialog (9/9), BrowserIntegration (63/63), BrowserLauncher (26/26), BrowserLogin (7/7), BrowserRoute (5/5), BrowserTestLifecycle (9/9).
- [x] Confirmed non-browser specs unaffected by route re-registration in `BrowserTest.beforeAll` — full suite passes cleanly.
- [x] Confirmed DialogConsumer CFC works when multiple dialog assertions run sequentially (probe caches the `$dialogSupported=true` result on first call).

## Why not just skip?

Skipping via `WHEELS_CI=true` masked three real bugs:
- The Lucee 7 struct-proxy incompatibility would have continued to break any code path that tried to proxy a CFML struct to a Java interface.
- The fixture-route gap would have left a latent coupling between app routes and core tests.
- The test-asset controllers being missing was a long-standing drift from when the app fixtures were introduced.

Each root-cause fix unlocks the actual capability rather than hiding the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)