### PR TITLE
feat(cli): canonicalize lucli stdio mcp, deprecate in-dev-server http mcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,12 +120,14 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 - CSRF cookie encryption key auto-generated when empty (apps should still set their own for stable cross-deploy cookies) (#2054)
 - CI engine testing restructured: 42 jobs reduced to 8 via engine-grouped testing (#1939)
 - `wheels mcp wheels` MCP surface curated — 7 CLI-only commands (`mcp`, `d`, `new`, `console`, `start`, `stop`, `browser`) hidden from MCP `tools/list` via the `mcpHiddenTools()` convention (requires LuCLI 0.3.4+). All remain reachable as CLI subcommands. Tool count drops from 23 to 16 for agent consumers.
+- LuCLI stdio MCP (`wheels mcp wheels`) is now the canonical AI-agent surface for Wheels. `wheels mcp setup` generates `.mcp.json` and `.opencode.json` pointing at the stdio transport. No port or running dev server required. Updated templates: `cli/src/templates/McpConfig.json`, `app/snippets/McpConfig.json`, `tools/build/base/.mcp.json`, `tools/build/base/.opencode.json`.
 
 ### Deprecated
 
 - Legacy `plugins/` folder — superseded by the new `packages/` → `vendor/` activation model. Plugins still load, with a deprecation warning. (#1995)
 - RocketUnit test style for new tests — BDD syntax (via WheelsTest) is required going forward. Existing RocketUnit specs continue to run. (#1925)
 - `wheels.Test` test base class — extend `wheels.WheelsTest` instead (#1889)
+- In-dev-server HTTP MCP endpoint at `/wheels/mcp` — superseded by the LuCLI stdio MCP server (`wheels mcp wheels`). Emits a deprecation warning to the `wheels_mcp` log on first request and advertises `deprecated: true` in the `serverInfo` handshake. Scheduled for removal in a future release. Migrate existing projects with `wheels mcp setup --force`.
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -857,6 +857,16 @@ The project name is **Wheels** (not "CFWheels"). The rebrand happened at v3.0. A
 
 ## MCP Server
 
-Endpoint: `/wheels/mcp` (routes must come before `.wildcard()` in routes.cfm).
+**Canonical surface (Wheels 4.0+):** LuCLI stdio MCP at `wheels mcp wheels`. Configure your AI IDE with:
 
-Tools: `wheels_generate`, `wheels_migrate`, `wheels_test`, `wheels_server`, `wheels_reload`, `wheels_analyze`, `wheels_validate`.
+```json
+{"mcpServers":{"wheels":{"command":"wheels","args":["mcp","wheels"]}}}
+```
+
+Or run `wheels mcp setup` to generate `.mcp.json` + `.opencode.json` automatically.
+
+Tools are auto-discovered from `cli/lucli/Module.cfc` public functions, prefixed with the module name (`wheels_generate`, `wheels_migrate`, `wheels_test`, `wheels_reload`, `wheels_seed`, `wheels_analyze`, `wheels_validate`, `wheels_routes`, `wheels_info`, `wheels_destroy`, `wheels_doctor`, `wheels_stats`, `wheels_notes`, `wheels_db`, `wheels_upgrade`, `wheels_create`). CLI-only tools (`mcp`, `d`, `new`, `console`, `start`, `stop`, `browser`) are hidden from MCP `tools/list` via `mcpHiddenTools()`.
+
+Workflow orchestration (multi-step planning, feature development) is not a framework concern — use your preferred Claude Code plugin (Superpowers, feature-dev, etc.). The framework ships deterministic Wheels operations via MCP; the model orchestrates.
+
+**Deprecated:** The in-dev-server HTTP endpoint at `/wheels/mcp` (routed from `vendor/wheels/public/views/mcp.cfm`). Emits a deprecation notice and warning log on first request. Scheduled for removal in a future release — migrate to the stdio surface. See `docs/command-line-tools/commands/mcp/mcp-configuration-guide.md`.

--- a/app/snippets/McpConfig.json
+++ b/app/snippets/McpConfig.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "wheels": {
-      "url": "http://localhost:{PORT}/wheels/mcp",
-      "type": "http"
+      "command": "wheels",
+      "args": ["mcp", "wheels"]
     },
     "browsermcp": {
       "command": "npx",

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -615,14 +615,19 @@ component extends="modules.BaseModule" {
 	 * hint: Show MCP server configuration instructions
 	 */
 	public string function mcp() {
-		out("MCP is built into LuCLI. Run:", "bold");
-		out("  lucli mcp wheels");
+		out("MCP is built into the Wheels CLI. Run:", "bold");
+		out("  wheels mcp wheels");
 		out("");
-		out("Configure in Claude Code (.claude/claude_project_config.json):", "bold");
-		out('  {"mcpServers":{"wheels":{"command":"lucli","args":["mcp","wheels"]}}}');
+		out("Configure in Claude Code (.mcp.json):", "bold");
+		out('  {"mcpServers":{"wheels":{"command":"wheels","args":["mcp","wheels"]}}}');
+		out("");
+		out("For OpenCode, Cursor, and other AI IDEs, see:");
+		out("  docs/command-line-tools/commands/mcp/mcp-configuration-guide.md");
 		out("");
 		out("All public commands in this module are auto-discovered as MCP tools.");
 		out("Tools are prefixed with the module name: wheels_generate, wheels_migrate, etc.");
+		out("Stateful/interactive commands (start, stop, new, console, ...) are hidden");
+		out("from MCP tools/list via mcpHiddenTools() — they remain CLI-only.");
 		return "";
 	}
 

--- a/cli/src/commands/wheels/mcp/setup.cfc
+++ b/cli/src/commands/wheels/mcp/setup.cfc
@@ -1,72 +1,57 @@
 /**
- * Set up MCP (Model Context Protocol) integration for AI IDE support
- * Creates .mcp.json and .opencode.json configuration files in your project root
- * Uses the native CFML MCP server built into Wheels (no Node.js required)
+ * Set up MCP (Model Context Protocol) integration for AI IDE support.
+ *
+ * Writes .mcp.json and .opencode.json configuration files in the project
+ * root. Both point your AI IDE at the LuCLI stdio MCP server (`wheels mcp
+ * wheels`) — the canonical Wheels MCP surface as of 4.0. No port or running
+ * dev server required; the IDE launches the stdio subprocess on demand.
  *
  * Examples:
  * {code:bash}
  * wheels mcp setup
- * wheels mcp setup --port=8080
  * wheels mcp setup --force
  * {code}
  **/
 component extends="../base" {
 
 	/**
-	 * @port Port number for Wheels server (auto-detected if not provided)
 	 * @force Overwrite existing configuration files
-	 * @noAutoStart Don't automatically start server if not running
 	 **/
-	function run(
-		numeric port = 0,
-		boolean force = false,
-		boolean noAutoStart = false
-	) {
+	function run(boolean force = false) {
 		print.line();
 		print.boldYellowLine("🤖 Setting up MCP Integration for Wheels");
 		print.line("=" .repeatString(50));
 		print.line();
 
-		// Check if we're in a Wheels application
 		if (!isWheelsApp()) {
 			print.redLine("❌ This doesn't appear to be a Wheels application directory.");
 			print.line("   Looking for /vendor/wheels, /config, and /app folders");
 			print.line();
 			print.yellowLine("   Run this command from your Wheels project root directory.");
 			return;
-		} else {
-			print.greenLine("✅ Wheels application detected");
 		}
+		print.greenLine("✅ Wheels application detected");
+		print.greenLine("✅ Using LuCLI stdio MCP (transport: stdio, no port needed)");
 
-		print.greenLine("✅ Using native CFML MCP server (no Node.js required)");
-
-		// Detect or use provided port
-		var serverPort = detectServerPort(arguments.port, arguments.noAutoStart);
 		print.line();
-
-		// Create configuration files
 		print.boldLine("Creating MCP configuration files...");
 
 		try {
 			var projectRoot = getCWD();
 
-			// Create .mcp.json
 			var mcpConfigPath = projectRoot & "/.mcp.json";
 			if (!fileExists(mcpConfigPath) || arguments.force) {
 				var mcpTemplate = fileRead(expandPath("/wheels-cli/templates/McpConfig.json"));
-				var mcpContent = replace(mcpTemplate, "{PORT}", serverPort, "ALL");
-				fileWrite(mcpConfigPath, mcpContent);
+				fileWrite(mcpConfigPath, mcpTemplate);
 				print.greenLine("✅ Created .mcp.json");
 			} else {
 				print.yellowLine("⚠️  .mcp.json already exists (use --force to overwrite)");
 			}
 
-			// Create .opencode.json
 			var opencodeConfigPath = projectRoot & "/.opencode.json";
 			if (!fileExists(opencodeConfigPath) || arguments.force) {
 				var opencodeTemplate = fileRead(expandPath("/wheels-cli/templates/OpenCodeConfig.json"));
-				var opencodeContent = replace(opencodeTemplate, "{PORT}", serverPort, "ALL");
-				fileWrite(opencodeConfigPath, opencodeContent);
+				fileWrite(opencodeConfigPath, opencodeTemplate);
 				print.greenLine("✅ Created .opencode.json");
 			} else {
 				print.yellowLine("⚠️  .opencode.json already exists (use --force to overwrite)");
@@ -77,21 +62,20 @@ component extends="../base" {
 			print.redLine("❌ Configuration failed: " & e.message);
 			return;
 		}
-		print.line();
 
-		// Summary
+		print.line();
 		print.boldGreenLine("✨ MCP Integration Setup Complete!");
 		print.line();
 		print.boldLine("Configuration Summary:");
-		print.indentedLine("Wheels MCP Endpoint: http://localhost:" & serverPort & "/wheels/mcp");
-		print.indentedLine("Server Type: Native CFML (no Node.js required)");
-		print.indentedLine("Files Created: .mcp.json, .opencode.json");
+		print.indentedLine("MCP transport: stdio (launched on demand by your AI IDE)");
+		print.indentedLine('Command: wheels mcp wheels');
+		print.indentedLine("Files created: .mcp.json, .opencode.json");
 		print.line();
 
 		print.boldLine("Next Steps:");
-		print.indentedLine("1. Ensure your Wheels server is running on port " & serverPort);
-		print.indentedLine("2. Configure your AI IDE to use the generated configuration files");
-		print.indentedLine("3. Test the connection: wheels mcp test");
+		print.indentedLine("1. Ensure the 'wheels' CLI binary is on PATH (brew install wheels)");
+		print.indentedLine("2. Restart your AI IDE so it re-reads .mcp.json / .opencode.json");
+		print.indentedLine("3. Verify tool discovery in the IDE's MCP panel — 16 tools should appear");
 		print.line();
 
 		print.boldLine("Available MCP Commands:");
@@ -100,116 +84,15 @@ component extends="../base" {
 		print.indentedLine("wheels mcp remove  - Remove MCP integration");
 		print.line();
 
-		print.yellowLine("💡 The generated files provide AI assistants with:");
-		print.indentedLine("• Real-time access to your Wheels project structure");
-		print.indentedLine("• Complete API documentation and guides");
-		print.indentedLine("• Ability to generate models, controllers, and migrations");
-		print.indentedLine("• Direct execution of tests and server commands");
-		print.indentedLine("• Browser automation capabilities (via Browser MCP)");
+		print.yellowLine("💡 The generated files give AI assistants:");
+		print.indentedLine("• Code generation (generate, destroy, seed, ...)");
+		print.indentedLine("• Migration + database operations (migrate, db, ...)");
+		print.indentedLine("• Project introspection (routes, info, analyze, doctor, stats, notes)");
+		print.indentedLine("• Test runner (test)");
+		print.indentedLine("• Browser automation (via Browser MCP)");
 		print.line();
-	}
-
-	private function detectServerPort(port, noAutoStart) {
-		var serverPort = 0;
-
-		if (!isNull(port) && port > 0) {
-			serverPort = port;
-			print.line("Using specified port: " & serverPort);
-		} else {
-			print.line("Detecting Wheels server port...");
-
-			// Use CommandBox serverService to get server info
-			try {
-				var cwd = getCWD();
-				var serverInfo = {};
-
-				// Try current directory first
-				serverInfo = serverService.getServerInfoByWebroot(cwd);
-
-				// If not found, try with /public subdirectory (common Wheels setup)
-				if (serverInfo.isEmpty() && directoryExists(cwd & "/public")) {
-					serverInfo = serverService.getServerInfoByWebroot(cwd & "/public");
-				}
-
-				// If still not found, try parent directory (in case we're in /public)
-				if (serverInfo.isEmpty() && getFileFromPath(cwd) == "public") {
-					var parentDir = getDirectoryFromPath(cwd.substring(1, cwd.length() - 1));
-					serverInfo = serverService.getServerInfoByWebroot(parentDir);
-				}
-
-				if (!serverInfo.isEmpty()) {
-					// Check if server is running
-					if (serverInfo.status == "running") {
-						// Get the port from the running server
-						if (structKeyExists(serverInfo, "port")) {
-							serverPort = serverInfo.port;
-							print.greenLine("✅ Detected running server on port " & serverPort);
-						} else if (structKeyExists(serverInfo, "web") &&
-								   structKeyExists(serverInfo.web, "http") &&
-								   structKeyExists(serverInfo.web.http, "port")) {
-							serverPort = serverInfo.web.http.port;
-							print.greenLine("✅ Detected running server on port " & serverPort);
-						}
-					} else if (serverInfo.status == "stopped") {
-						// Server exists but is stopped
-						print.yellowLine("⚠️  Server is configured but not running");
-
-						// Try to get configured port even if stopped
-						if (structKeyExists(serverInfo, "port")) {
-							serverPort = serverInfo.port;
-							print.line("   Using configured port: " & serverPort);
-						}
-					}
-				}
-			} catch (any e) {
-				// Fallback if serverService fails
-				print.yellowLine("⚠️  Could not detect server via CommandBox service");
-			}
-		}
-
-		// If no server detected and auto-start enabled, try to start server
-		if (serverPort == 0 && !noAutoStart) {
-			print.line("No running server detected. Attempting to start server...");
-
-			try {
-				// Start the server using serverService
-				var serverInfo = serverService.start(
-					name = "",  // Use default name for current directory
-					directory = getCWD(),
-					saveSettings = true
-				);
-
-				sleep(3000); // Wait for server to fully start
-
-				// Get the server info again after starting
-				serverInfo = serverService.getServerInfoByWebroot(getCWD());
-
-				if (!serverInfo.isEmpty() && serverInfo.status == "running") {
-					if (structKeyExists(serverInfo, "port")) {
-						serverPort = serverInfo.port;
-						print.greenLine("✅ Started server on port " & serverPort);
-					}
-				}
-			} catch (any e) {
-				print.yellowLine("⚠️  Could not start server automatically: " & e.message);
-			}
-		}
-
-		if (serverPort == 0) {
-			print.yellowLine("⚠️  Could not detect server port.");
-			print.line();
-			print.line("Options:");
-			print.indentedLine("1. Start your server: wheels server start");
-			print.indentedLine("2. Specify port manually: wheels mcp setup --port=60000");
-			print.indentedLine("3. Run with --noAutoStart to disable server auto-start");
-			print.line();
-
-			// Ask for port
-			var userPort = ask("Enter your Wheels server port (or press Enter to use 60000): ");
-			serverPort = len(trim(userPort)) ? userPort : 60000;
-		}
-
-		return serverPort;
+		print.indentedLine("Full guide: docs/command-line-tools/commands/mcp/mcp-configuration-guide.md");
+		print.line();
 	}
 
 }

--- a/cli/src/templates/McpConfig.json
+++ b/cli/src/templates/McpConfig.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "wheels": {
-      "url": "http://localhost:{PORT}/wheels/mcp",
-      "type": "http"
+      "command": "wheels",
+      "args": ["mcp", "wheels"]
     },
     "browsermcp": {
       "command": "npx",

--- a/docs/src/command-line-tools/commands/mcp/mcp-configuration-guide.md
+++ b/docs/src/command-line-tools/commands/mcp/mcp-configuration-guide.md
@@ -1,53 +1,56 @@
 ---
 description: >-
-  Configure Wheels MCP tools for Claude Code, Cursor, and VS Code. Covers both
-  LuCLI stdio transport and HTTP server transport with auto-discovered tools.
+  Configure Wheels MCP tools for Claude Code, Cursor, OpenCode, and other
+  AI-enabled editors using the canonical LuCLI stdio transport.
 ---
 
 # MCP Configuration Guide
 
 ## Overview
 
-Wheels exposes its development tools through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), giving AI coding assistants direct access to code generation, database migrations, testing, project analysis, and framework documentation. This guide covers configuring MCP for the three most popular AI-enabled editors.
+Wheels exposes its development tools through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), giving AI coding assistants direct access to code generation, database migrations, testing, project analysis, and framework documentation.
 
-### Two Transport Modes
+### Transport: stdio (canonical)
 
-Wheels supports two MCP transports. Choose the one that fits your setup:
+The Wheels CLI (`brew install wheels`) is a renamed LuCLI that includes a built-in MCP server. Your AI IDE launches `wheels mcp wheels` as a stdio subprocess — no port, no running dev server, no HTTP transport to manage. Tools are auto-discovered from `cli/lucli/Module.cfc` and prefixed with the module name (`wheels_generate`, `wheels_migrate`, etc.).
 
-| Transport | Command | Requires Running Server | Best For |
-|-----------|---------|------------------------|----------|
-| **stdio (LuCLI)** | `lucli mcp wheels` | No (for tool discovery) | LuCLI users, simpler config |
-| **HTTP** | `http://localhost:[port]/wheels/mcp` | Yes | CommandBox users, existing setups |
+| Aspect | Value |
+|-----------|-------|
+| Transport | stdio (JSON-RPC) |
+| Command | `wheels mcp wheels` |
+| Requires running server | No |
+| Requires installed `wheels` CLI | Yes (`brew install wheels` or equivalent) |
 
-**stdio (recommended)**: LuCLI auto-discovers every public command in the Wheels module as an MCP tool. The AI assistant launches `lucli` as a subprocess — no separate server process to manage.
-
-**HTTP**: The Wheels application includes a native CFML MCP server. Your development server must be running for the AI assistant to connect.
+> **Deprecated (Wheels 4.0+):** The previous HTTP MCP endpoint at `http://localhost:<port>/wheels/mcp` emits a deprecation warning and will be removed. Existing projects should run `wheels mcp setup --force` to migrate to stdio configs.
 
 ## Quick Start
 
-### Option A: LuCLI stdio (recommended)
-
 ```bash
-# Install LuCLI and the Wheels module
-brew install lucli
-lucli modules install wheels
+# Install the Wheels CLI (renamed LuCLI)
+brew install wheels
 
-# Verify MCP tools are discoverable
-lucli mcp wheels
-```
-
-Then add the configuration for your IDE (see sections below).
-
-### Option B: HTTP server
-
-```bash
-# From your Wheels project root
+# From your Wheels project root, generate IDE configs
 wheels mcp setup
 
-# This creates .mcp.json and .opencode.json in your project
+# This creates .mcp.json and .opencode.json with the stdio config.
+# Restart your AI IDE to pick them up.
 ```
 
-Or start your server and point your IDE at the endpoint:
+If you prefer to configure manually, add the following to `.mcp.json` (Claude Code, Cursor, Continue, Windsurf):
+
+```json
+{"mcpServers":{"wheels":{"command":"wheels","args":["mcp","wheels"]}}}
+```
+
+Or for OpenCode, to `.opencode.json`:
+
+```json
+{"$schema":"https://opencode.ai/config.json","mcp":{"wheels":{"type":"local","command":["wheels","mcp","wheels"],"enabled":true}}}
+```
+
+## Legacy HTTP Transport (deprecated)
+
+The pre-4.0 HTTP endpoint is still mounted at `/wheels/mcp` for compatibility but emits a deprecation warning on every session. To continue using it, start your dev server and point your IDE at:
 ```
 http://localhost:[port]/wheels/mcp
 ```

--- a/docs/src/command-line-tools/commands/mcp/mcp-setup.md
+++ b/docs/src/command-line-tools/commands/mcp/mcp-setup.md
@@ -1,14 +1,16 @@
 ---
 description: >-
   Set up MCP (Model Context Protocol) integration for AI IDE support in your
-  Wheels application.
+  Wheels application using the LuCLI stdio MCP server.
 ---
 
 # MCP Setup
 
 ## Overview
 
-The `wheels mcp setup` command configures your Wheels project to work seamlessly with AI coding assistants like Claude Code, Cursor, Continue, and Windsurf. Wheels includes a **native CFML MCP server** that runs directly within your application - no Node.js required!
+The `wheels mcp setup` command configures your Wheels project to work with AI coding assistants like Claude Code, Cursor, Continue, OpenCode, and Windsurf. Wheels uses the **LuCLI stdio MCP server** (`wheels mcp wheels`) as its canonical agent surface — your IDE launches the MCP server as a subprocess on demand; no port or running dev server required.
+
+> **Note (Wheels 4.0+):** The previous HTTP-based MCP endpoint at `/wheels/mcp` is deprecated and will be removed in a future release. Run `wheels mcp setup --force` to migrate existing projects to the stdio configuration.
 
 ## Usage
 
@@ -20,190 +22,80 @@ wheels mcp setup [options]
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `--port` | numeric | Port number for Wheels server (auto-detected if not provided) |
-| `--ide` | string | Specific IDE to configure (`claude`, `cursor`, `continue`, `windsurf`) |
-| `--all` | boolean | Configure all detected IDEs |
 | `--force` | boolean | Overwrite existing configuration files |
-| `--noAutoStart` | boolean | Don't automatically start server if not running |
 
 ## Examples
 
 ### Basic Setup
+
 ```bash
-# Auto-detect settings and configure available IDEs
+# Generate .mcp.json and .opencode.json pointing at LuCLI stdio MCP
 wheels mcp setup
 ```
 
-### IDE-Specific Setup
+### Migrate an Existing Project
+
 ```bash
-# Configure only Claude Code
-wheels mcp setup --ide=claude
-
-# Configure only Cursor
-wheels mcp setup --ide=cursor
-
-# Configure all detected IDEs
-wheels mcp setup --all
-```
-
-### Custom Configuration
-```bash
-# Use specific port
-wheels mcp setup --port=8080
-
-# Force overwrite existing configs
+# Overwrite pre-4.0 HTTP-based configs with stdio configs
 wheels mcp setup --force
-
-# Setup without auto-starting server
-wheels mcp setup --noAutoStart
 ```
 
-## How It Works
+## What Gets Created
 
-### What gets created
-The setup command creates two configuration files in your project root:
-
-- **`.mcp.json`** — Used by Claude Code, Cursor, and other MCP-compatible editors
-- **`.opencode.json`** — Used by OpenCode-compatible editors
-
-Both files point to your Wheels application's MCP endpoint.
-
-### Native CFML MCP Server
-Wheels includes a built-in MCP (Model Context Protocol) server that runs directly within your CFML application:
-
-- **No dependencies**: No Node.js installation required
-- **Integrated**: Runs within your Wheels application context
-- **Secure**: Uses your application's existing security model
-- **Performant**: Direct CFML execution without external processes
-
-### MCP Server Endpoint
-The setup command configures access to your Wheels application's MCP server at:
-```
-http://localhost:[port]/wheels/mcp
-```
-
-### LuCLI Alternative
-If using LuCLI, MCP tools are auto-discovered via stdio transport without needing `wheels mcp setup`. See the [MCP Configuration Guide](./mcp-configuration-guide.md) for details.
-
-## Supported IDEs
-
-The `wheels mcp setup` command creates project-level `.mcp.json` and `.opencode.json` files. These are auto-detected by most MCP-compatible editors:
-
-### Claude Code
-Reads `.mcp.json` from the project root automatically.
-
-### Cursor
-Copy or symlink `.mcp.json` to `.cursor/mcp.json`:
-```bash
-cp .mcp.json .cursor/mcp.json
-```
-
-### VS Code (Copilot / Continue / Cline)
-Add the MCP configuration to `.vscode/settings.json` — see the [MCP Configuration Guide](./mcp-configuration-guide.md#vs-code) for per-extension instructions.
-
-### Windsurf
-Reads `.mcp.json` from the project root.
-
-For detailed per-IDE configuration including the LuCLI stdio transport, see the [MCP Configuration Guide](./mcp-configuration-guide.md).
-
-## Prerequisites
-
-1. **Wheels Application**: Must be run from a Wheels project root directory
-2. **Running Server**: Wheels development server should be running (auto-started if needed)
-3. **IDE Installation**: Target AI IDE should be installed and configured
-
-## Verification
-
-After setup, verify the integration:
-
-### Check MCP Status
-```bash
-wheels mcp status
-```
-
-### Test Connection
-```bash
-wheels mcp test
-```
-
-### Manual Verification
-Visit the MCP endpoint directly:
-```bash
-curl http://localhost:[port]/wheels/mcp
-```
-
-## Troubleshooting
-
-### Common Issues
-
-**1. "Not a Wheels application"**
-- Ensure you're in the root directory of a Wheels project
-- Check for `/vendor/wheels`, `/config`, and `/app` folders
-
-**2. "Server not running"**
-- Start your Wheels server: `server start` (CommandBox)
-- Or use `wheels server start`
-
-**3. "Port detection failed"**
-- Specify port manually: `--port=8080`
-- Check your `server.json` configuration
-
-**4. "IDE not detected"**
-- Install the target AI IDE first
-- Use `--ide=specific` to configure manually
-- Check IDE documentation for configuration paths
-
-### Configuration File Locations
-
-The setup command creates or updates configuration files in these locations:
-
-- **macOS**: `~/.[ide]/config.json`
-- **Windows**: `%USERPROFILE%\.[ide]\config.json`
-- **Linux**: `~/.[ide]/config.json`
-
-## Advanced Usage
-
-### Custom MCP Server Configuration
-You can customize the MCP server behavior in your Wheels application settings:
-
-```cfm
-// /config/settings.cfm
-set(mcpEnabled=true);
-set(mcpAllowedOrigins="*");
-set(mcpSessionTimeout=3600);
-```
-
-### IDE-Specific Settings
-Some IDEs support additional MCP configuration options:
+### `.mcp.json` (Claude Code, Cursor, Continue, Windsurf)
 
 ```json
 {
   "mcpServers": {
     "wheels": {
-      "transport": {
-        "type": "http",
-        "url": "http://localhost:8080/wheels/mcp"
-      },
-      "capabilities": {
-        "resources": {},
-        "tools": {},
-        "prompts": {}
-      }
+      "command": "wheels",
+      "args": ["mcp", "wheels"]
+    },
+    "browsermcp": {
+      "command": "npx",
+      "args": ["@browsermcp/mcp@latest"]
     }
   }
 }
 ```
 
-## Security Considerations
+### `.opencode.json` (OpenCode)
 
-- **Development Only**: MCP integration is intended for development environments
-- **Local Access**: Default configuration allows localhost access only
-- **Authentication**: Uses your Wheels application's existing security model
-- **Firewall**: Ensure your development server is not exposed to external networks
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "wheels": {
+      "type": "local",
+      "command": ["wheels", "mcp", "wheels"],
+      "enabled": true
+    }
+  }
+}
+```
 
-## Related Commands
+## Prerequisites
 
-- [`wheels mcp status`](./mcp-status.md) - Check MCP integration status
-- [`wheels mcp test`](./mcp-test.md) - Test MCP connection
-- [`wheels mcp update`](./mcp-update.md) - Update MCP configuration
-- [`wheels mcp remove`](./mcp-remove.md) - Remove MCP integration
+- `wheels` CLI on PATH (`brew install wheels` or equivalent)
+- Your AI IDE supports MCP (Claude Code, Cursor, Continue, OpenCode, Windsurf, etc.)
+
+## What the Agent Sees
+
+After setup, your AI IDE discovers 16 Wheels tools:
+
+`wheels_generate`, `wheels_migrate`, `wheels_seed`, `wheels_test`, `wheels_reload`, `wheels_analyze`, `wheels_validate`, `wheels_routes`, `wheels_info`, `wheels_destroy`, `wheels_doctor`, `wheels_stats`, `wheels_notes`, `wheels_db`, `wheels_upgrade`, `wheels_create`.
+
+CLI-only commands (`start`, `stop`, `new`, `console`, `browser`) are hidden from the MCP surface — they remain reachable as CLI subcommands but don't make sense for agent calls.
+
+## Next Steps
+
+1. Restart your AI IDE so it re-reads the new `.mcp.json` / `.opencode.json`
+2. Verify tool discovery in the IDE's MCP panel
+3. Test a simple call: ask the agent to run `wheels_info` or `wheels_routes`
+
+## Related
+
+- [MCP Configuration Guide](mcp-configuration-guide.md) — deeper details on transports, per-IDE setup, troubleshooting
+- [MCP Status](mcp-status.md) — check current MCP configuration
+- [MCP Test](mcp-test.md) — verify MCP connectivity
+- [MCP Remove](mcp-remove.md) — remove MCP integration

--- a/tools/build/base/.mcp.json
+++ b/tools/build/base/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "wheels": {
-      "url": "http://localhost:{PORT}/wheels/mcp",
-      "type": "http"
+      "command": "wheels",
+      "args": ["mcp", "wheels"]
     },
     "browsermcp": {
       "command": "npx",

--- a/tools/build/base/.opencode.json
+++ b/tools/build/base/.opencode.json
@@ -2,8 +2,8 @@
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "wheels": {
-      "url": "http://localhost:{PORT}/wheels/mcp",
-      "type": "remote",
+      "type": "local",
+      "command": ["wheels", "mcp", "wheels"],
       "enabled": true
     },
     "browsermcp": {

--- a/vendor/wheels/public/mcp/McpServer.cfc
+++ b/vendor/wheels/public/mcp/McpServer.cfc
@@ -6,7 +6,9 @@ component output="false" displayName="MCP Server" {
 	public any function init() {
 		variables.serverInfo = {
 			"name": "wheels-mcp-server",
-			"version": "1.0.0"
+			"version": "1.0.0",
+			"deprecated": true,
+			"deprecationNotice": "The in-dev-server MCP endpoint at /wheels/mcp is deprecated as of Wheels 4.0. Use the LuCLI stdio MCP server instead: configure your AI IDE with {command: 'wheels', args: ['mcp', 'wheels']} and see docs/command-line-tools/commands/mcp/mcp-configuration-guide.md for details."
 		};
 
 		variables.capabilities = {

--- a/vendor/wheels/public/views/mcp.cfm
+++ b/vendor/wheels/public/views/mcp.cfm
@@ -1,6 +1,34 @@
 <cfscript>
 // MCP (Model Context Protocol) Server Implementation
 // Implements Streamable HTTP transport with JSON-RPC 2.0
+//
+// ⚠️ DEPRECATED as of Wheels 4.0. Use the LuCLI stdio MCP server instead:
+//
+//     wheels mcp wheels
+//
+// Configure in your AI IDE's .mcp.json:
+//     {"mcpServers":{"wheels":{"command":"wheels","args":["mcp","wheels"]}}}
+//
+// The LuCLI stdio MCP is the canonical surface for Wheels AI integration.
+// It auto-discovers tools from cli/lucli/Module.cfc, respects mcpHiddenTools(),
+// and doesn't require a running dev server for file-based operations
+// (generate, migrate, stats, etc.). This HTTP endpoint will be removed in
+// a future release. See:
+//   docs/command-line-tools/commands/mcp/mcp-configuration-guide.md
+
+// Log one-time deprecation warning per JVM
+if (!structKeyExists(application, "mcpHttpDeprecationLogged")) {
+	try {
+		writeLog(
+			file="wheels_mcp",
+			type="warning",
+			text="The in-dev-server MCP endpoint at /wheels/mcp is deprecated. "
+				& "Use 'wheels mcp wheels' (LuCLI stdio MCP) instead. "
+				& "See docs/command-line-tools/commands/mcp/mcp-configuration-guide.md"
+		);
+	} catch (any ignored) { /* logging is best-effort */ }
+	application.mcpHttpDeprecationLogged = true;
+}
 
 // ── Security: development mode only ─────────────
 if (


### PR DESCRIPTION
## Summary

Part of the ongoing [AI-surface audit](docs/superpowers/plans/2026-04-17-wheels-lucli-mcp-curation.md). Makes LuCLI stdio MCP (`wheels mcp wheels`) the canonical AI-agent surface for Wheels and stages deprecation of the pre-4.0 in-dev-server HTTP endpoint.

**Three grouped changes:**

1. **Templates + CLI setup switch to stdio.** All four shipped `.mcp.json` / `.opencode.json` templates now use `{\"command\": \"wheels\", \"args\": [\"mcp\", \"wheels\"]}` instead of the HTTP `/wheels/mcp` config. `wheels mcp setup` drops its port-detection / auto-start / `{PORT}` interpolation logic — no longer needed when the IDE launches the MCP server as a stdio subprocess on demand. Files touched: `cli/src/templates/McpConfig.json`, `app/snippets/McpConfig.json`, `tools/build/base/.mcp.json`, `tools/build/base/.opencode.json`, `cli/src/commands/wheels/mcp/setup.cfc`, `cli/lucli/Module.cfc` (`mcp()` subcommand now shows the `wheels` binary name instead of `lucli`).

2. **Deprecate the in-dev-server HTTP MCP.** `vendor/wheels/public/views/mcp.cfm` now logs a one-time per-JVM warning to the `wheels_mcp` log on first request. `McpServer.cfc`'s `serverInfo` handshake now advertises `deprecated: true` with a `deprecationNotice` string pointing users at the stdio migration. The endpoint still works for this release as a compatibility shim — removal is scheduled for a future release.

3. **Docs + CLAUDE.md.** The root `CLAUDE.md` MCP Server section now describes the stdio surface as canonical with the HTTP endpoint marked deprecated, and lists the full 16-tool inventory. `docs/src/command-line-tools/commands/mcp/mcp-setup.md` rewritten around the new stdio-based setup flow. `mcp-configuration-guide.md` overview + quick-start rewritten around stdio; legacy HTTP section retained with a deprecation callout.

## Why

The LuCLI stdio MCP architecture is strictly better for AI-agent use:

- No port, no running dev server, no HTTP endpoint to manage
- The agent's IDE launches the MCP subprocess on demand
- Tool schemas auto-discovered from `cli/lucli/Module.cfc` signatures (via LuCLI's `buildInputSchema`)
- `mcpHiddenTools()` curation (16 canonical tools, 7 CLI-only tools hidden) lands in a sibling PR
- Single source of truth: `Module.cfc` public functions define the CLI AND the MCP surface

The HTTP endpoint at `/wheels/mcp` was built during earlier explorations and kept working as-is during the LuCLI migration. It remains functional but misleading as the \"official\" MCP surface now that the stdio path is the recommended route.

## Relationship to PR #2139

PR #2139 (curate MCP tool surface via `mcpHiddenTools()`) is the sibling change that lives in the same audit plan. That PR trims the auto-discovered tool inventory from 23 → 16. This PR canonicalizes the transport + config files. They're complementary but independent — either can merge first. CLAUDE.md language here describes the combined behavior; minor wording adjustments will be a non-issue either way.

## Test plan

- [x] Manual: `wheels mcp setup --force` writes stdio configs with no port detection
- [x] Manual: `wheels mcp wheels` (sandbox testapp) returns `serverInfo.deprecated` absent and normal tool responses — only the HTTP endpoint marks itself deprecated
- [x] Manual: hitting the HTTP `/wheels/mcp` endpoint once produces a `WARNING` line in `wheels_mcp` log with the migration pointer
- [x] Manual: `/wheels/mcp` initialize response now includes `serverInfo.deprecated: true` and `serverInfo.deprecationNotice`
- [x] Docs preview renders cleanly (mcp-setup.md + mcp-configuration-guide.md)

## Prerequisite for end users

Requires the Wheels CLI (renamed LuCLI) to have PR #53 merged — already merged upstream 2026-04-17. End users will pick it up once cybersonic/LuCLI cuts a new release tag and the homebrew formula auto-updates.

## Deferred

- Updating `mcp-test.md`, `mcp-status.md`, `mcp-update.md`, `mcp-remove.md` (operational commands unchanged — next pass)
- The sibling CommandBox-era `wheels mcp test/status/update/remove` commands (logic still generic; low priority relative to the canonical-config switch)