### PR TITLE
docs(docs): add .ai/ reference sections for MCP and packages

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -23,6 +23,10 @@ Searchable reference for CFML language and Wheels framework patterns.
 - `cli/` — Generators, server management
 - `communication/` — Email sending
 - `files/` — File uploads and downloads
+- `jobs/` — Background job processing
+- `mcp/` — AI agent integration via LuCLI stdio MCP
+- `middleware/` — Request pipeline (rate limiting, tenant resolver, pipeline structure)
+- `packages/` — First-party packages (sentry, hotwire, basecoat) and activation model
 - `security/` — CSRF, authentication, authorization
 - `patterns/` — Common development patterns, validation templates
 - `snippets/` — Code examples for all component types

--- a/.ai/wheels/README.md
+++ b/.ai/wheels/README.md
@@ -63,6 +63,24 @@ Background job processing:
 - Job creation, enqueueing, and processing
 - Queue statistics and management
 
+### [MCP](./mcp/)
+AI agent integration via Model Context Protocol:
+- LuCLI stdio MCP architecture and tool surface
+- Per-IDE setup (.mcp.json / .opencode.json)
+- Tool reference for the 16 MCP-exposed commands
+
+### [Middleware](./middleware/)
+Request-pipeline middleware:
+- Middleware pipeline structure (global + route-scoped)
+- Rate limiting (fixed window, sliding window, token bucket)
+- Tenant resolver for multi-tenant apps
+
+### [Packages](./packages/)
+First-party optional modules (replacing the legacy plugins/):
+- Package manifest format (package.json)
+- Activation model (packages/ → vendor/)
+- First-party packages: sentry, hotwire, basecoat
+
 ### [Patterns](./patterns/)
 Common development patterns in Wheels:
 - Design patterns and best practices

--- a/.ai/wheels/mcp/overview.md
+++ b/.ai/wheels/mcp/overview.md
@@ -1,0 +1,115 @@
+# Wheels MCP Server
+
+Wheels ships an MCP (Model Context Protocol) server so AI coding agents — Claude Code, Cursor, OpenCode, Continue, Windsurf — can call the CLI's generators, runners, and introspection tools directly. The canonical surface is the LuCLI stdio MCP server, invoked as `wheels mcp wheels`.
+
+## Architecture
+
+The Wheels CLI binary (`wheels`) is a renamed LuCLI. When an AI IDE is configured with `.mcp.json`, it launches `wheels mcp wheels` as a stdio subprocess on demand. LuCLI's `McpCommand` handles the JSON-RPC transport; tools are auto-discovered from the public functions in `cli/lucli/Module.cfc`.
+
+```
+AI IDE (Claude Code / Cursor / ...)
+        │
+        ▼  stdio subprocess (JSON-RPC)
+  wheels mcp wheels
+        │
+        ▼
+  LuCLI McpCommand.java
+        │
+        ▼  getComponentMetadata("modules.wheels.Module")
+  cli/lucli/Module.cfc   ← tool inventory + schemas
+```
+
+**Key properties:**
+
+- **No port**, no dev server required for tool discovery or invocation
+- **Auto-discovered schemas**: LuCLI reads each public function's parameter metadata (name, type, hint, default, required) and emits JSONSchema per tool
+- **Curated surface**: `mcpHiddenTools()` returns a list of public functions to hide from MCP `tools/list` (stateful, interactive, or meta commands stay CLI-only)
+- **Dev server bridge**: tools that inspect live app state (`routes`, `info`, `reload`) HTTP-bridge to a running Wheels dev server. Tools that operate on the filesystem (`generate`, `stats`, `notes`) run in-process without a server
+
+## Tool inventory (16 MCP-exposed)
+
+| Tool | What it does |
+|---|---|
+| `wheels_generate` | Scaffold components (model, controller, view, migration, scaffold, api-resource, route, test, property, helper, snippets, admin) |
+| `wheels_migrate` | Run database migrations (latest / up / down / info) |
+| `wheels_seed` | Run convention-based or generated seeds |
+| `wheels_test` | Run the WheelsTest suite (optional filter + reporter + db) |
+| `wheels_reload` | Reload the running Wheels app |
+| `wheels_analyze` | Static analysis for anti-patterns, complexity, code smells |
+| `wheels_validate` | Validate app structure for common errors |
+| `wheels_routes` | List configured routes (method, path, controller#action) |
+| `wheels_info` | Framework version, environment, config summary |
+| `wheels_destroy` | Remove generated components (inverse of generate) |
+| `wheels_doctor` | Health checks (directories, files, config, permissions, database) |
+| `wheels_stats` | Code statistics (files, LOC, comments) |
+| `wheels_notes` | Extract TODO / FIXME / OPTIMIZE annotations |
+| `wheels_db` | Database management (reset, status, version) |
+| `wheels_upgrade` | Pre-upgrade breaking-change check |
+| `wheels_create` | Create application components (`create app <name>`) |
+
+## Tools hidden from MCP
+
+These remain CLI-only via `mcpHiddenTools()`:
+
+- `mcp` — meta command (shows MCP setup instructions)
+- `d` — alias for `destroy` (avoids duplicate surface)
+- `new` — scaffolds a whole new Wheels project (too destructive for an agent to do unprompted)
+- `console` — interactive CFML REPL (not usable over stdio JSON-RPC)
+- `start` / `stop` — dev server process lifecycle (stateful, side-effectful)
+- `browser` — multi-step browser testing flow
+
+All are reachable as CLI subcommands (`wheels start`, `wheels new myapp`, etc.) — this filter is purely about which tools an AI agent sees.
+
+## Auto-discovery: how schemas are generated
+
+LuCLI walks each public function's parameter metadata and emits a JSONSchema. Example:
+
+```cfm
+/**
+ * hint: Generate Wheels components (model, controller, view, ...)
+ * @type Component type
+ * @name Component name
+ * @attributes Space-separated attributes
+ */
+public string function generate(
+    string type = "",
+    string name = "",
+    string attributes = ""
+) { ... }
+```
+
+becomes:
+
+```json
+{
+  "name": "generate",
+  "description": "Generate Wheels components (model, controller, view, ...)",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "type": {"type": "string", "description": "Component type"},
+      "name": {"type": "string", "description": "Component name"},
+      "attributes": {"type": "string", "description": "Space-separated attributes"}
+    },
+    "additionalProperties": false
+  }
+}
+```
+
+Required parameters (CFML `required` attribute) appear in the `required` array. Defaults appear as `default` on each property.
+
+## Transport details
+
+- **Stdio JSON-RPC**: one message per line, newline-delimited. Server must never emit non-protocol data to stdout.
+- **Output capture**: LuCLI redirects `System.out` / `System.err` / its own `StringOutput` streams to a buffer during each tool call. `BaseModule.out()` writes via dynamic `createObject("java","java.lang.System").out.println(...)` so the capture sees the output.
+- **Initialize handshake**: protocol version `2024-11-05`; server advertises `tools` capability only (no `resources` or `prompts`).
+
+## Legacy HTTP MCP (deprecated)
+
+A legacy HTTP endpoint at `http://localhost:<port>/wheels/mcp` still exists for backward compatibility but is deprecated. It emits a one-time warning to the `wheels_mcp` log on first request and advertises `deprecated: true` in its `serverInfo` handshake. Use `wheels mcp setup --force` to migrate projects from HTTP to stdio config.
+
+## See also
+
+- [setup.md](setup.md) — configure `.mcp.json` / `.opencode.json` for your AI IDE
+- [tool-reference.md](tool-reference.md) — quick reference for each of the 16 tools
+- [../../docs/command-line-tools/commands/mcp/mcp-configuration-guide.md](../../../docs/src/command-line-tools/commands/mcp/mcp-configuration-guide.md) — per-IDE configuration details

--- a/.ai/wheels/mcp/setup.md
+++ b/.ai/wheels/mcp/setup.md
@@ -1,0 +1,113 @@
+# MCP Setup
+
+Configure your AI IDE to use the Wheels MCP server. The same stdio config works for Claude Code, Cursor, Continue, and Windsurf; OpenCode uses a slightly different shape.
+
+## Prerequisites
+
+- Install the `wheels` CLI on PATH: `brew install wheels` (macOS) or the Chocolatey equivalent on Windows
+- Confirm with: `wheels --version` (should show 0.3.8 or later — 0.3.7 and earlier miss the output-capture fix)
+
+## Fast path
+
+From your Wheels project root:
+
+```bash
+wheels mcp setup
+```
+
+This writes `.mcp.json` + `.opencode.json` with the stdio config. Restart your AI IDE to pick them up.
+
+To migrate an existing project away from the legacy HTTP config:
+
+```bash
+wheels mcp setup --force
+```
+
+## Manual config
+
+### `.mcp.json` (Claude Code, Cursor, Continue, Windsurf)
+
+```json
+{
+  "mcpServers": {
+    "wheels": {
+      "command": "wheels",
+      "args": ["mcp", "wheels"]
+    }
+  }
+}
+```
+
+If you want the Browser MCP alongside Wheels:
+
+```json
+{
+  "mcpServers": {
+    "wheels": {
+      "command": "wheels",
+      "args": ["mcp", "wheels"]
+    },
+    "browsermcp": {
+      "command": "npx",
+      "args": ["@browsermcp/mcp@latest"]
+    }
+  }
+}
+```
+
+### `.opencode.json` (OpenCode)
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "wheels": {
+      "type": "local",
+      "command": ["wheels", "mcp", "wheels"],
+      "enabled": true
+    }
+  }
+}
+```
+
+## Verify the connection
+
+After restarting the IDE, open its MCP panel and confirm 16 tools are visible:
+
+```
+wheels_generate    wheels_migrate    wheels_seed       wheels_test
+wheels_reload      wheels_analyze    wheels_validate   wheels_routes
+wheels_info        wheels_destroy    wheels_doctor     wheels_stats
+wheels_notes       wheels_db         wheels_upgrade    wheels_create
+```
+
+Ask the agent to run a safe read-only tool like `wheels_info` or `wheels_routes` to confirm the bridge works end-to-end.
+
+## Troubleshooting
+
+### Tools list is empty or wrong count
+
+- Older LuCLI (<0.3.4) doesn't honor `mcpHiddenTools()` — you'd see 23–24 tools including `mcp`, `d`, `new`, `console`, `start`, `stop`, `browser`, `mcphiddentools`. Upgrade: `brew upgrade wheels`.
+- Older LuCLI (<0.3.7) has broken MCP output capture — tools return empty content. Same fix: upgrade.
+
+### `command not found: wheels` from the IDE
+
+The IDE may not inherit your shell PATH. Either:
+
+- Use an absolute path: `"command": "/opt/homebrew/bin/wheels"` (macOS) or the equivalent path from `which wheels`
+- Configure the IDE's MCP integration to source your shell profile before launching subprocesses
+
+### Agent sees empty input schemas
+
+- The function's signature is untyped (`public string function foo()` with no declared parameters). Rich schemas require typed signatures — see [overview.md](overview.md) for the pattern.
+- Requires LuCLI ≥ v0.3.8 for CLI positional args to bind to typed params. MCP named args work on any version.
+
+### Tool runs but response is truncated or incomplete
+
+- Deprecation notice from the HTTP endpoint? You're still pointed at the old HTTP MCP. Run `wheels mcp setup --force` and restart the IDE.
+- Stdio output capture issue: upgrade to LuCLI ≥ v0.3.7.
+
+## See also
+
+- [overview.md](overview.md) — architecture and tool inventory
+- [tool-reference.md](tool-reference.md) — per-tool input parameters

--- a/.ai/wheels/mcp/tool-reference.md
+++ b/.ai/wheels/mcp/tool-reference.md
@@ -1,0 +1,165 @@
+# MCP Tool Reference
+
+Quick reference for the 16 MCP-exposed tools. Tool names are prefixed with the module name: `wheels_` + function name.
+
+> **Note:** rich JSONSchema (types, defaults, required flags, descriptions) is auto-discovered from each function's typed parameters. This reference summarizes each tool's contract; run `tools/list` against a live `wheels mcp wheels` session for the exact current schemas.
+
+## Code generation
+
+### `wheels_generate`
+Scaffold Wheels components.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `type` | string | yes | model \| controller \| view \| migration \| scaffold \| api-resource \| route \| test \| property \| helper \| snippets \| admin |
+| `name` | string | yes | Component name (PascalCase for models/controllers) |
+| `attributes` | string | no | Space-separated attributes: `name email:string active:boolean` |
+
+Variadic attributes: additional positional args beyond `attributes` are collected as extra attributes.
+
+### `wheels_destroy`
+Remove a generated component.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Component name to destroy |
+| `type` | string | no | `resource` (default), `model`, `controller`, `view` |
+
+### `wheels_create`
+Create a new application component (typically `create app <name>`).
+
+## Database
+
+### `wheels_migrate`
+Run database migrations.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `action` | string | no | `latest` (default), `up`, `down`, `info` |
+
+### `wheels_seed`
+Run database seeds.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `mode` | string | no | `auto` (default), `convention`, `generate` |
+| `environment` | string | no | Target environment (defaults to current) |
+| `generate` | boolean | no | Shortcut for `mode=generate` |
+
+### `wheels_db`
+Database management.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `action` | string | yes | `reset`, `status`, `version` |
+| `skipSeed` | boolean | no | Skip seeding when `action=reset` |
+| `pending` | boolean | no | Show only pending migrations (for `status`) |
+| `detailed` | boolean | no | Show detailed version info |
+
+## Testing & validation
+
+### `wheels_test`
+Run the test suite.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `filter` | string | no | Test directory or spec path |
+| `reporter` | string | no | `simple` (default), `json`, `junit` |
+| `db` | string | no | Database to test against (default: `sqlite`) |
+| `verbose` | boolean | no | Verbose output |
+| `ci` | boolean | no | CI mode (exit code reflects failures) |
+| `core` | boolean | no | Run framework core tests instead of app tests |
+
+### `wheels_validate`
+Validate app structure for common errors.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `target` | string | no | What to validate (default: `all`) |
+| `strict` | boolean | no | Fail on warnings |
+
+### `wheels_analyze`
+Static analysis: anti-patterns, complexity, code smells.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `target` | string | no | `all` (default), `models`, `controllers`, `routes`, `config` |
+
+## Project introspection
+
+### `wheels_routes`
+List configured routes.
+
+No parameters. Returns method / path / controller#action for every registered route.
+
+### `wheels_info`
+Framework version, environment, configuration.
+
+No parameters.
+
+### `wheels_doctor`
+Health checks.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `verbose` | boolean | no | Show all passed checks (default shows only issues) |
+
+### `wheels_stats`
+Code statistics.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `verbose` | boolean | no | Include top 10 largest files |
+
+### `wheels_notes`
+Extract annotations (TODO, FIXME, OPTIMIZE).
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `annotations` | string | no | Comma-separated types (default: `TODO,FIXME,OPTIMIZE`) |
+| `custom` | string | no | Additional annotation types |
+
+## Operational
+
+### `wheels_reload`
+Reload the running Wheels application.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `password` | string | no | Reload password (auto-resolved from `.env` if omitted) |
+
+### `wheels_upgrade`
+Pre-upgrade breaking-change check.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `to` | string | no | Target version (defaults to latest release) |
+
+## Calling conventions
+
+**MCP invocation** (named args):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "generate",
+    "arguments": {"type": "model", "name": "User", "attributes": "email:string active:boolean"}
+  }
+}
+```
+
+**CLI invocation** (positional args; LuCLI auto-binds to typed params):
+
+```bash
+wheels generate model User email:string active:boolean
+```
+
+Both paths reach the same function body with `arguments.type = "model"`, `arguments.name = "User"`, `arguments.attributes = "email:string active:boolean"`.
+
+## See also
+
+- [overview.md](overview.md) — architecture, auto-discovery, tool surface curation
+- [setup.md](setup.md) — IDE configuration

--- a/.ai/wheels/packages/overview.md
+++ b/.ai/wheels/packages/overview.md
@@ -1,0 +1,100 @@
+# Wheels Packages
+
+Packages are first-party optional modules that ship in the Wheels monorepo. They replace the legacy `plugins/` folder introduced pre-3.0 with a cleaner activation model: packages live in `packages/` (not auto-loaded) and are copied or symlinked to `vendor/` to activate.
+
+## Directory layout
+
+```
+packages/              ← source / staging (never auto-loaded)
+  sentry/              ← wheels-sentry package
+  hotwire/             ← wheels-hotwire package
+  basecoat/            ← wheels-basecoat package
+vendor/                ← runtime auto-discovery at app startup
+  wheels/              ← framework core (excluded from package discovery)
+  sentry/              ← activated package (copied from packages/sentry)
+plugins/               ← DEPRECATED; legacy plugins still load with warning
+```
+
+On startup, Wheels's `PackageLoader.cfc` scans `vendor/*/package.json` and activates each discovered package in its own try/catch (so a broken package is logged and skipped rather than crashing the app).
+
+## Activating a package
+
+```bash
+# Copy
+cp -r packages/sentry vendor/sentry
+
+# Or symlink (easier for development)
+ln -s ../../packages/sentry vendor/sentry
+```
+
+Then restart or reload the app. Deactivate by removing the `vendor/<package>` directory.
+
+## `package.json` manifest
+
+Every package declares a `package.json` at its root:
+
+```json
+{
+    "name": "wheels-sentry",
+    "version": "1.0.0",
+    "author": "PAI Industries",
+    "description": "Sentry error tracking for Wheels",
+    "wheelsVersion": ">=3.0",
+    "provides": {
+        "mixins": "controller",
+        "services": [],
+        "middleware": []
+    },
+    "dependencies": {}
+}
+```
+
+**`provides.mixins`** determines which framework components receive the package's public methods:
+
+- `controller` — mix into controllers
+- `view` — mix into views
+- `model` — mix into models
+- `global` — mix into all three
+- `none` (default) — no mixin; the package provides services/middleware only
+
+The default is `none` (explicit opt-in). Legacy plugins defaulted to `global`, which was part of why they were hard to reason about.
+
+## First-party packages shipping with Wheels
+
+| Package | Purpose |
+|---|---|
+| `sentry/` | Error tracking — captures exceptions with framework context and ships to Sentry |
+| `hotwire/` | Turbo + Stimulus integration for server-driven UI |
+| `basecoat/` | UI component library (forms, buttons, layouts) styled for Wheels conventions |
+
+Each has its own `CLAUDE.md` with usage instructions. Check `packages/<name>/CLAUDE.md` for package-specific details.
+
+## Error isolation
+
+Each package loads inside its own try/catch. Common failure modes:
+
+- **Missing `package.json`**: the package is silently skipped
+- **Invalid JSON**: logged to `wheels` log, package skipped
+- **Wheels version mismatch** (`wheelsVersion` range fails): logged, package skipped
+- **Exception during load**: logged with stack, package skipped
+
+A broken package never crashes the host app.
+
+## Testing a package
+
+Once a package is activated in `vendor/`, run its tests via:
+
+```bash
+curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&directory=vendor.sentry.tests"
+```
+
+The `directory` parameter names the package under `vendor/` and scopes the TestBox run to that subdirectory.
+
+## Legacy plugins
+
+The `plugins/` folder still works, but emits a deprecation warning on app startup. New work should use `packages/`. Existing plugins continue to function but should be migrated to the package format when touched.
+
+## See also
+
+- `packages/<name>/CLAUDE.md` — per-package documentation
+- `vendor/wheels/PackageLoader.cfc` — implementation of the discovery + activation logic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -832,14 +832,23 @@ Full reference: `.ai/wheels/testing/browser-testing.md`.
 
 Deeper documentation lives in `.ai/` — Claude will search it automatically when needed:
 - `.ai/wheels/cross-engine-compatibility.md` — **Start here** for Lucee/Adobe cross-engine gotchas
-- `.ai/cfml/` — CFML language reference (syntax, data types, components)
-- `.ai/wheels/models/` — ORM details, associations, validations, scopes, enums
-- `.ai/wheels/controllers/` — filters, rendering, security
-- `.ai/wheels/views/` — layouts, partials, form helpers (including HTML5), link helpers
-- `.ai/wheels/database/` — migrations, queries, seeding, advanced operations
-- `.ai/wheels/cli/` — generators (including admin generator)
-- `.ai/wheels/testing/` — unit testing with WheelsTest, test infrastructure, common gotchas
-- `.ai/wheels/configuration/` — routing, environments, settings, DI container
+- `.ai/cfml/` — CFML language reference (syntax, data types, components, control flow, best practices)
+- `.ai/wheels/core-concepts/` — MVC architecture, ORM mapping, routing conventions, Rails comparison
+- `.ai/wheels/models/` — ORM details, associations, validations, scopes, enums, batch processing
+- `.ai/wheels/controllers/` — actions, filters, rendering (JSON/views/redirects), security, SSE, parameter verification
+- `.ai/wheels/views/` — layouts, partials, form helpers (including HTML5), link helpers, pagination, forms
+- `.ai/wheels/database/` — migrations, queries, associations, validations, seeding
+- `.ai/wheels/configuration/` — routing, environments, settings, DI container, multi-tenancy, security
+- `.ai/wheels/middleware/` — pipeline structure, rate limiting, tenant resolver
+- `.ai/wheels/jobs/` — background job queue, retries, priority queues
+- `.ai/wheels/mcp/` — AI agent integration via LuCLI stdio MCP (setup, tool reference, auto-discovery)
+- `.ai/wheels/packages/` — first-party packages (sentry, hotwire, basecoat) + activation model
+- `.ai/wheels/cli/` — generators (model, controller, scaffold, admin, migrations)
+- `.ai/wheels/testing/` — WheelsTest BDD, browser testing, browser automation patterns
+- `.ai/wheels/security/` — CSRF protection, HTTPS detection
+- `.ai/wheels/patterns/` — authentication, CRUD, validation templates
+- `.ai/wheels/snippets/` — copy-paste model + controller examples
+- `.ai/wheels/troubleshooting/` — common errors, form helper errors
 
 ## Commit Message Conventions
 


### PR DESCRIPTION
## Summary

Closes two gaps in `.ai/` reference documentation that surfaced during the [AI-surface audit](../../docs/superpowers/plans/2026-04-17-wheels-lucli-mcp-curation.md):

1. **`.ai/wheels/mcp/`** — new. Three files covering LuCLI stdio MCP architecture, per-IDE setup (.mcp.json + .opencode.json), and a quick reference for the 16 MCP-exposed tools. `.ai/` previously had zero MCP coverage despite the MCP server being the canonical AI-agent integration surface in 4.0.

2. **`.ai/wheels/packages/`** — new. Overview of the `packages/` → `vendor/` activation model, `package.json` manifest format, first-party packages (sentry, hotwire, basecoat), error-isolation semantics. Previously only referenced obliquely from root CLAUDE.md.

Plus two index refreshes:

3. **`.ai/README.md` + `.ai/wheels/README.md`** — now list the new mcp/ and packages/ sections alongside the existing middleware/ and jobs/ sections that weren't previously indexed.

4. **Root `CLAUDE.md` Reference Docs** — previously listed 9 `.ai/wheels/` subsections out of ~18 that exist. Now lists all 18 with one-line descriptions so Claude can pick the right path on first load without needing to browse.

## Why

When Claude loads a session and hits the root `CLAUDE.md`, the Reference Docs list is where it goes to find deep detail. If MCP isn't in that list (or in `.ai/wheels/` at all), the model either guesses or skips documentation lookups entirely. Now every major Wheels 4.0 surface has a clear `.ai/` path.

## What's in each new file

- `.ai/wheels/mcp/overview.md` — LuCLI stdio architecture diagram, 16-tool inventory, 7-tool hidden list, auto-discovery from typed CFML signatures, transport details, deprecation of the HTTP endpoint
- `.ai/wheels/mcp/setup.md` — fast path (`wheels mcp setup`), manual `.mcp.json` / `.opencode.json` configs, verification steps, troubleshooting (wrong tool count, empty schemas, PATH issues)
- `.ai/wheels/mcp/tool-reference.md` — every tool grouped by category (code generation / database / testing / introspection / operational) with parameter tables
- `.ai/wheels/packages/overview.md` — directory layout, activation via `cp`/`ln -s`, manifest format, `provides.mixins` semantics, first-party package summary, error isolation, testing packages

## Test plan

- [x] `.ai/README.md` + `.ai/wheels/README.md` indexes render cleanly with new entries
- [x] Root `CLAUDE.md` Reference Docs section lists every existing `.ai/wheels/` subdirectory
- [x] No broken intra-doc links (spot-checked `../` references)
- [x] No LuCLI or Wheels version claims that aren't accurate at 4.0-SNAPSHOT

## Scope notes

- Does not touch documentation under `docs/src/` (that's the external-facing site docs, different audience). The MCP configuration guide at `docs/src/command-line-tools/commands/mcp/mcp-configuration-guide.md` was refreshed in #2140 and stays the canonical user-facing setup doc; `.ai/wheels/mcp/setup.md` is the agent-facing quick ref that points at it.
- Doesn't add a CHANGELOG entry — these are reference docs for AI agents, not user-facing features.