### PR TITLE
fix(web/guides): apply Phase 3 sidebar + landing config

### DIFF
--- a/web/sites/guides/astro.config.mjs
+++ b/web/sites/guides/astro.config.mjs
@@ -1,5 +1,57 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadSidebar(version) {
+  const path = resolve(__dirname, 'src/sidebars', `${version}.json`);
+  const groups = JSON.parse(readFileSync(path, 'utf8'));
+  return groups;
+}
+
+const versions = [
+  { slug: 'v3-1-0', label: 'v3.1.0 (current)', collapsed: false },
+  { slug: 'v3-0-0', label: 'v3.0.0', collapsed: true },
+  { slug: 'v2-5-0', label: 'v2.5.0', collapsed: true },
+];
+
+// Starlight doesn't support a "linked group" (item with both link + items).
+// Flatten: if a group was also a link in the source, prepend an "Overview"
+// child that carries the link.
+function normalizeItem(item) {
+  if (item.items && Array.isArray(item.items) && item.items.length > 0) {
+    const children = item.items.map(normalizeItem);
+    if (item.link) {
+      children.unshift({ label: 'Overview', link: item.link });
+    }
+    return {
+      label: item.label,
+      items: children,
+      collapsed: true,
+    };
+  }
+  if (item.link) {
+    return { label: item.label, link: item.link };
+  }
+  // Unlinked leaf — skip
+  return null;
+}
+
+function buildSidebarForVersion(version) {
+  const groups = loadSidebar(version.slug);
+  return {
+    label: version.label,
+    collapsed: version.collapsed,
+    items: groups.map((g) => ({
+      label: g.label,
+      collapsed: version.collapsed,
+      items: (g.items || []).map(normalizeItem).filter(Boolean),
+    })),
+  };
+}
 
 export default defineConfig({
   site: 'https://guides.wheels.dev',
@@ -7,9 +59,12 @@ export default defineConfig({
     starlight({
       title: 'Wheels Guides',
       description: 'Official guides for the Wheels CFML MVC framework.',
-      social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/wheels-dev/wheels' }],
+      social: [
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/wheels-dev/wheels' },
+      ],
       sidebar: [
-        { label: 'Coming soon', link: '/' },
+        { label: 'Overview', link: '/' },
+        ...versions.map(buildSidebarForVersion),
       ],
     }),
   ],

--- a/web/sites/guides/src/content/docs/index.md
+++ b/web/sites/guides/src/content/docs/index.md
@@ -3,7 +3,23 @@ title: Wheels Guides
 description: Official guides for the Wheels CFML MVC framework.
 ---
 
-Coming soon — the complete Wheels guides will live here.
+Welcome to the Wheels CFML MVC framework guides. Browse by version below,
+or use the search bar (top right) to find a topic across all versions.
 
-In the meantime, the current guides are at
-[wheels-dev/wheels/docs/src](https://github.com/wheels-dev/wheels/tree/main/docs/src).
+## Available versions
+
+- **[v3.1.0 (current)](/v3-1-0/)** — latest guides for Wheels 3.x
+- [v3.0.0](/v3-0-0/) — frozen snapshot for the 3.0 release
+- [v2.5.0](/v2-5-0/) — frozen snapshot for the 2.5 release
+
+## What's in a guide
+
+Each guide walks you through a specific topic in the framework:
+
+- **Introduction** — getting started, frameworks overview, installation
+- **Command Line Tools** — the `wheels` CLI for scaffolding, testing, deployment
+- **Handling Requests with Controllers** — request lifecycle, routing, filters
+- **Displaying Views to Users** — templates, layouts, view helpers
+- **Database Interaction Through Models** — ORM, associations, validations
+- **Working with Wheels** — configuration, testing, debugging
+- **Plugins** — extending Wheels with community plugins


### PR DESCRIPTION
Follow-up to Phase 3 — the astro.config.mjs and landing index.md edits didn't make it into the Phase 3 commit due to a Write tool error I missed. Apex-facing effect: guides.wheels.dev was serving real guide content at /v3-1-0/ etc but the landing still said 'Coming soon' and the sidebar had one stale 'Coming soon' link. Fixes both.