### PR TITLE
feat(web/ui): .btn :focus-visible + :active + disabled states

### DIFF
--- a/web/packages/ui/src/styles/base.css
+++ b/web/packages/ui/src/styles/base.css
@@ -64,6 +64,22 @@ video {
 	transform: translateY(-1px);
 }
 
+.btn:focus-visible {
+	outline: 2px solid var(--color-brand);
+	outline-offset: 2px;
+}
+
+.btn:active {
+	transform: translateY(0);
+}
+
+.btn[disabled],
+.btn[aria-disabled='true'] {
+	opacity: 0.55;
+	cursor: not-allowed;
+	pointer-events: none;
+}
+
 .btn--primary {
 	background: var(--color-brand);
 	color: #fff;


### PR DESCRIPTION
## Summary

Small a11y polish on the shared `.btn` class from the PR 1 design system. Flagged as a follow-up during PR 1 code review.

- `:focus-visible` — 2px brand-red outline with 2px offset (keyboard users now see a clear focus ring)
- `:active` — resets the hover `translateY(-1px)` lift so the button feels pressed rather than stuck floating
- `[disabled]` / `[aria-disabled='true']` — 55% opacity, `not-allowed` cursor, `pointer-events: none`

## Test plan

- [x] `pnpm build` — all four sites build clean
- [x] `pnpm format:check` — passes
- [x] Visually verified focus ring on landing "Get started" via preview (screenshot in PR log)
- [ ] Reviewer: tab through landing hero to confirm focus ring is visible on both CTAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)