### PR TITLE
docs: drop commandbox from README quick-start + monorepo description

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@ One of our biggest goals is for you to be able to get up and running with Wheels
 
 ### Quick Start
 
-Create a new Wheels application using the CLI:
+Install the Wheels CLI (Homebrew on macOS and Linux):
 
 ```bash
+brew tap wheels-dev/wheels
+brew install wheels
 wheels new myapp
 ```
+
+The CLI is powered by [LuCLI](https://github.com/cybersonic/LuCLI) — it ships with Lucee and depends only on Java 21, so no CommandBox install is required.
 
 ### Learning Wheels
 
@@ -67,8 +71,8 @@ This repository contains the complete Wheels ecosystem in a monorepo structure. 
 
 ```
 wheels-monorepo/
-├── cli/                    # Wheels CLI (CommandBox module)
-│   └── src/                # Published as 'wheels-cli'
+├── cli/                    # Wheels CLI (LuCLI-powered)
+│   └── lucli/              # LuCLI module entry point
 ├── core/                   # Framework Core
 │   └── src/wheels/         # Published as 'wheels-core'
 ├── templates/              # Application Templates
@@ -82,13 +86,13 @@ wheels-monorepo/
 ```
 
 **Key Components:**
-- **CLI** (`wheels-cli`): Development tools and generators (CommandBox module)
+- **CLI** (`wheels`): Development tools and generators, distributed via Homebrew and Chocolatey formulas that bundle [LuCLI](https://github.com/cybersonic/LuCLI)
 - **Core** (`wheels-core`): Framework runtime installed in `/vendor/wheels`
-- **Base Template** (`wheels-base-template`): Starting structure downloaded by CLI for new applications
+- **Base Template** (`wheels-base-template`): Starting structure used by the CLI for new applications
 - **Documentation**: Comprehensive guides published to wheels.dev/guides
-- **Build System**: Automated packaging and ForgeBox distribution
+- **Build System**: Automated packaging and release distribution
 
-**Package Flow**: CLI downloads base template from ForgeBox during `wheels new myapp`, which includes dependency on core framework. Documentation is automatically published to wheels.dev/guides. All components are versioned together and distributed as separate ForgeBox packages that work seamlessly together.
+**Package Flow**: the CLI stages the base template when you run `wheels new myapp`, which pulls in the core framework as a dependency. Documentation is automatically published to wheels.dev/guides. All components are versioned together and released through Homebrew, Chocolatey, and GitHub releases.
 
 **For detailed monorepo documentation**, see [MONOREPO.md](MONOREPO.md) which includes:
 - Complete directory structure breakdown


### PR DESCRIPTION
## Summary

Removes CommandBox from the user-facing install and project-description surface in the framework README, aligning with the 4.0 DX direction. Users landing on the GitHub repo now see the LuCLI-based homebrew flow that matches [wheels.dev](https://wheels.dev).

## Changes

- **Quick Start:** was \`wheels new myapp\` with no install preamble; now leads with \`brew tap wheels-dev/wheels\` + \`brew install wheels\` + \`wheels new myapp\` and notes that the CLI is LuCLI-powered so CommandBox isn't required.
- **Monorepo structure block:** \`cli/\` is no longer labeled a "CommandBox module" — it's \`LuCLI-powered\` with \`lucli/\` as the entry point.
- **Key Components list:** CLI distribution description updated to mention Homebrew + Chocolatey formulas that bundle LuCLI.
- **Package Flow paragraph:** dropped the ForgeBox-specific phrasing in favor of version-agnostic "Homebrew, Chocolatey, and GitHub releases."

## Explicitly out of scope

- **Generated guides content** (\`web/sites/guides/src/content/docs/v4-0-0-snapshot/**\`) — these files are generated from the \`wheels.dev\` sibling repo's GitBook source. Sweeping them needs a dedicated PR in that repo + a regeneration pass. Flagged as a follow-up.
- **\`RELEASE-CANDIDATE.md\`** — maintainer-facing process doc; separate small cleanup.
- **\`cli/lucli/PLAN.md\` and \`cli/WHEELS-CLI-ROADMAP.md\`** — historical architecture/migration planning docs; keep for context.

## Test plan

- [x] \`git diff\` reviewed — only README.md touched
- [ ] Reviewer: eyeball the rendered README on GitHub to confirm the install block reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)