### PR TITLE
docs: remove commandbox refs from cli/ docs and release-candidate guide

### DIFF
--- a/RELEASE-CANDIDATE.md
+++ b/RELEASE-CANDIDATE.md
@@ -97,12 +97,19 @@ Once pushed, GitHub Actions will automatically:
 
 ### Installation
 
-Users can install the RC from ForgeBox:
+Testers install the RC by tapping the release-candidate formula or by
+pinning to the RC tag in the main formula. Example using the current
+Homebrew tap:
 
 ```bash
-box install wheels@3.1.0-rc.1
-box install wheels-core@3.1.0-rc.1
+brew tap wheels-dev/wheels
+brew install wheels@4.0.0-rc.1      # if an RC-specific formula is published
+# or download the tagged release directly:
+#   https://github.com/wheels-dev/wheels/releases/tag/v4.0.0-rc.1
 ```
+
+Users on the `develop` snapshot channel can also run `wheels upgrade` to
+pick up the RC once it has been published.
 
 ### Testing Checklist
 
@@ -211,11 +218,12 @@ Post announcement in:
 
 Example announcement:
 ```
-🎉 Wheels 3.1.0-rc.1 is now available for testing!
+🎉 Wheels 4.0.0-rc.1 is now available for testing!
 
 We need your help testing this major release before final publication.
 
-Install: box install wheels@3.1.0-rc.1
+Install: brew install wheels-dev/wheels/wheels@4.0.0-rc.1
+(or grab the tagged release from GitHub)
 
 Please report issues: https://github.com/wheels-dev/wheels/issues
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,14 +1,27 @@
-# Wheels CLI commands for CommandBox
+# Wheels CLI
 
-This is a basic port of the Rails command line;
-Skips things like `rails server` which are provided by CommandBox already.
+The `wheels` command is a Rails-inspired CLI for scaffolding and running Wheels applications. In 4.0 it is distributed as a Homebrew / Chocolatey formula that bundles [LuCLI](https://github.com/cybersonic/LuCLI), so no CommandBox installation is required.
 
 ## Install
 
-Simply run `install wheels-cli` from CommandBox to install the latest release.
+**macOS / Linux (Homebrew):**
+
+```bash
+brew tap wheels-dev/wheels
+brew install wheels
+```
+
+**Windows (Chocolatey):**
+
+```powershell
+choco install wheels
+```
+
+Both installers depend only on Java 21, which is pulled in automatically.
 
 ## Commands
-See [the CLI command guides](https://guides.wheels.dev/wheels-guides/3.1.0-snapshot/command-line-tools/cli-commands) or use `help wheels` in Commandbox.
+
+See [the CLI command guides](https://guides.wheels.dev/v4-0-0-snapshot/command-line-tools/) or run `wheels --help` in your terminal.
 
 ## Template Customization
 
@@ -25,4 +38,4 @@ To customize a template:
 2. Modify it to match your needs
 3. The CLI will automatically use your custom template
 
-See the [Template System Guide](https://guides.wheels.dev/wheels-guides/3.1.0-snapshot/command-line-tools/cli-guides/template-system) for detailed documentation.
+See the [Template System Guide](https://guides.wheels.dev/v4-0-0-snapshot/command-line-tools/) for detailed documentation.

--- a/cli/docs/CONFIG-COMMANDS.md
+++ b/cli/docs/CONFIG-COMMANDS.md
@@ -145,9 +145,9 @@ wheels secret --type=uuid         # UUID format
 ## Integration with Existing Tools
 
 These commands integrate with:
-- **commandbox-dotenv**: For .env file management
+- **`.env` loader**: Wheels reads `.env` files at application start; the CLI respects the same convention
 - **Wheels configuration system**: Reads from config/environment/*.cfm files
-- **CommandBox server management**: Uses server.json for server configuration
+- **Server configuration**: Uses server.json for LuCLI server settings
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Continues the 4.0 DX cleanup (after #2155). Updates three more user-facing docs to reflect the LuCLI-based distribution model.

## Changes

- **`cli/README.md`** — rewrote install section for homebrew (macOS/Linux) and chocolatey (Windows). Dropped the "Wheels CLI commands for CommandBox" framing, fixed stale `help wheels` wording and broken guide links pointing to `3.1.0-snapshot` (now `v4-0-0-snapshot`).
- **`cli/docs/CONFIG-COMMANDS.md`** — replaced the `commandbox-dotenv` reference with generic `.env` loader language. Kept `server.json` mention but re-contextualized for LuCLI server settings.
- **`RELEASE-CANDIDATE.md`** — install examples now use `brew install` / tagged GitHub releases. Example social announcement also uses the homebrew form. Version bumped from `3.1.0-rc.1` examples to `4.0.0-rc.1`.

## Explicitly out of scope

- **Generated guides content** (`web/sites/guides/src/content/docs/v4-0-0-snapshot/**`) — lives in `wheels.dev` sibling repo as GitBook source; needs a cross-repo PR and a regeneration pass.
- **`cli/WHEELS-CLI-ROADMAP.md` / `cli/lucli/PLAN.md`** — historical architectural docs that describe the *migration* from CommandBox; they should stay for context.

## Test plan

- [x] `git diff` reviewed — three files touched, no code changes, no link rot introduced
- [ ] Reviewer: skim `cli/README.md` on GitHub to confirm it reads cleanly for someone browsing the cli/ directory cold.