### PR TITLE
docs: re-scope starlight phase 3 as a three-slice spec (for review)

### DIFF
--- a/docs/superpowers/specs/2026-04-18-starlight-phase-3-design.md
+++ b/docs/superpowers/specs/2026-04-18-starlight-phase-3-design.md
@@ -1,0 +1,126 @@
+# Starlight Phase 3 — C-Depth Custom Layout Design
+
+**Date:** 2026-04-18
+**Status:** Draft, pending user review — no implementation yet
+**Scope:** `web/sites/guides` and `web/sites/api` — the two Starlight-powered sites
+**Depends on:** [PR #2153](https://github.com/wheels-dev/wheels/pull/2153) (Phase 2 shipped)
+**Supersedes:** §8 of [`2026-04-17-wheels-dev-cohesion-design.md`](2026-04-17-wheels-dev-cohesion-design.md)
+
+---
+
+## Why a new spec
+
+The original cohesion spec's §8 proposed six Starlight overrides as one bundle: `PageFrame`, `Sidebar`, `PageTitle`, `TableOfContents`, `VersionSwitcher`, `EditLink`. Investigating against Starlight 0.34.8 surfaced information that reshapes the proposal:
+
+1. **EditLink is not useful for our setup.** Both Starlight sites serve *generated* content — api pages are emitted by `web/scripts/generate-api-docs.mjs` from `docs/api/v*.json`, and guides pages come from the `wheels.dev` sibling repo's GitBook source via `web/scripts/generate-guides.mjs`. A GitHub edit link on a generated file lands a user on a file whose edits will be overwritten on the next regen. Ship-ready only if we re-point edit links at the *source* (JSON/GitBook), which is out of scope for a CSS/component pass.
+2. **VersionSwitcher is a net-new UI component with real routing logic.** It needs dropdown state management, slug-equivalence detection across versions, and a fallback routing decision when the slug doesn't exist in the target version. That's a judgment call best made with user input — especially around UX details (dropdown vs popover, keyboard behavior, mobile treatment).
+3. **PageFrame override is disproportionately risky.** Starlight's `PageFrame` is the outer scaffold; overriding it means we own the skip-link + sidebar-placement + main-content plumbing that Starlight normally handles. Starlight 0.34.8 refactored its layout architecture significantly; pinning to a specific version is required to avoid breakage on upgrade.
+4. **Cosmetic parity is already largely achieved** via the Phase 2 `starlight-theme.css` token bridge. The visible remaining gaps are more about component-specific polish than full-layout reconstruction.
+
+This spec re-scopes Phase 3 into three value-ordered slices, defers the truly risky pieces, and calls out decisions needed from the user.
+
+## Decisions (summary)
+
+| Original §8 component | New plan |
+|-----------------------|----------|
+| `EditLink` | **Drop.** Edit-on-github for generated content has no clean target. Revisit only if we invest in re-pointing at source files. |
+| `VersionSwitcher` | **Keep, but brainstorm first.** Needs UX decisions and slug-equivalence rules. |
+| `Sidebar` | **Keep — highest visible impact.** Smallest-risk component override; tune section headings, active state, nested indent treatment. |
+| `PageTitle` | **Keep — moderate impact.** Adds category eyebrow + tighter typography. |
+| `TableOfContents` | **Keep — small but nice.** Sticky right-rail with branded active indicator. |
+| `PageFrame` | **Defer.** Keep Starlight's default outer scaffold; override individual slot components instead. |
+
+## Slice plan
+
+Ship as three PRs, each independently mergeable and reviewable:
+
+### Slice 1: Sidebar + PageTitle + TableOfContents (visual polish)
+
+Three focused component overrides. No new UI, no client-side logic, no Starlight internals touched beyond the documented `components: {...}` slots. Mostly CSS work.
+
+**Files to add:**
+- `web/packages/ui/src/components/starlight/Sidebar.astro`
+- `web/packages/ui/src/components/starlight/PageTitle.astro`
+- `web/packages/ui/src/components/starlight/TableOfContents.astro`
+
+**Design targets:**
+- **Sidebar:** section headings in `--text-xs` uppercase `--color-fg-subtle`; leaf links `--color-fg-muted` resting, `--color-brand` + `--color-brand-soft` bg when active, indent-only nesting (no vertical guide lines). Reuse Starlight's `SidebarSublist.astro` internals; only override the outer `Sidebar.astro`.
+- **PageTitle:** category eyebrow read from `Astro.locals.starlightRoute.entry.data.category || head of path segments`; H1 `--text-4xl` tracking-tight; breadcrumb line in `--color-fg-subtle`.
+- **TableOfContents:** sticky right rail; `--text-xs` headings; active item bold + `--color-brand` with 2px `--color-brand` left border; preserve Starlight's smooth-scroll + mobile-TOC behavior by deferring to `TableOfContentsList` for the inner list.
+
+**Starlight config additions (both guides and api):**
+```js
+components: {
+  // existing Phase 2 overrides:
+  Header: '@wheels-dev/ui/components/starlight/Header.astro',
+  Footer: '@wheels-dev/ui/components/starlight/Footer.astro',
+  SocialIcons: '@wheels-dev/ui/components/starlight/SocialIcons.astro',
+  // NEW:
+  Sidebar: '@wheels-dev/ui/components/starlight/Sidebar.astro',
+  PageTitle: '@wheels-dev/ui/components/starlight/PageTitle.astro',
+  TableOfContents: '@wheels-dev/ui/components/starlight/TableOfContents.astro',
+},
+```
+
+**Risks:**
+- Sidebar override must handle "Overview" injection (we already use this pattern in guides's `normalizeItem` helper for linked groups) and autogenerated sections (api uses `autogenerate: { directory: v.slug }`). Read both configs to confirm the override handles both data shapes.
+- Starlight 0.34.8 data shape: `Astro.locals.starlightRoute.entry` and `Astro.locals.starlightRoute.sidebar` are the expected sources. Verify at implementation time.
+
+**Acceptance:**
+- All 4 sites still build cleanly (`pnpm build`)
+- Pagefind search still returns results on guides + api
+- Visual diff of one docs page per site vs. the pre-slice baseline shows the intended changes, no regressions
+
+### Slice 2: VersionSwitcher (header dropdown)
+
+Net-new UI. Lives in the header, so it reuses the shared Header component and imports the switcher as a sibling to the nav.
+
+**Open UX questions for user review (answer before implementation):**
+
+1. **Dropdown anchor:** to the right of the site title (before the nav links), or pinned as a separate badge next to it? Current Starlight sidebar version list is already present — do we remove it from the sidebar when we add the header switcher, or keep both as complementary discovery paths?
+2. **Slug equivalence:** when a user on `guides.wheels.dev/v3-0-0/models/validations/` clicks "v4.0.0-SNAPSHOT", we navigate to `v4-0-0-snapshot/models/validations/` if it exists. If that slug doesn't exist in the target version, what's the fallback? Options:
+   - Navigate to target version's root
+   - Surface a notice: "That page isn't in v4.0.0-SNAPSHOT — here's the overview"
+   - Try a fuzzy match (substring on final path segment) before root
+3. **Current-version indicator:** badge-style (`current release`, `snapshot`, `archived`) or sub-label under the version number?
+4. **Keyboard / a11y:** is a native `<select>` acceptable (maximal accessibility, minimal styling control), or do we build a custom listbox with the standard ARIA pattern (more styling, more JS)?
+5. **Mobile:** fold into the existing hamburger drawer, or stay as an inline dropdown?
+
+**Implementation sketch (placeholder until UX decisions land):**
+- Collect version slugs from per-site config (reuse the `versions` arrays in each `astro.config.mjs`).
+- Compute "equivalent page" map at build time via an Astro virtual module so client JS only needs the map + current slug.
+- Render a `<details>`/`<summary>` pair as progressive-enhancement base (works without JS), upgrade with a custom listbox behavior when JS is available.
+
+**Deferred until brainstormed.**
+
+### Slice 3: `starlightRoute` API verification + regression test
+
+Add a simple visual-regression screenshot test that runs on PRs touching `web/**`. Rationale: the Phase 2 + Phase 3 overrides all depend on Starlight internal data shapes (`Astro.locals.starlightRoute.*`). A one-docs-page-per-site screenshot check catches regressions before they reach production.
+
+**Scope:**
+- Add `web/scripts/visual-regression.mjs` that starts each dev server, navigates to a canary page, and compares a screenshot against a stored baseline
+- CI step in `.github/workflows/web-deploy.yml` that runs it on every PR touching `web/**`
+- One baseline image per site in `web/tests/visual-baselines/`
+
+Independent of Slices 1 and 2; can be shipped any time.
+
+## What we are intentionally NOT doing in Phase 3
+
+- **EditLink override.** Would need to re-point edit links at source (JSON for api, GitBook markdown for guides in the sibling repo). Interesting future work; not cohesion work.
+- **PageFrame override.** Starlight's default scaffold works; overriding it gains little and costs real upgrade risk.
+- **Content-page layout changes** (e.g., two-column on api function pages). Separate project; pursue only if the api reference needs dedicated treatment.
+- **Search UI override.** Pagefind's default is themed adequately via Phase 2's `starlight-theme.css`. If we want a branded search UI, spec it separately.
+
+## Open questions for user
+
+1. Do you want EditLink back if we re-point at source files (api JSON + wheels.dev GitBook)? Scope implication: separate, larger project.
+2. VersionSwitcher UX questions in Slice 2 above — five decisions to make before implementation.
+3. Are you OK keeping `PageFrame` as Starlight default indefinitely, or should we revisit if specific pain points emerge?
+4. Is the proposed three-slice order (polish → switcher → regression test) the right priority, or does something else jump the queue (e.g., switcher first because users ask for it)?
+
+## References
+
+- Original cohesion spec: [`2026-04-17-wheels-dev-cohesion-design.md`](2026-04-17-wheels-dev-cohesion-design.md)
+- Phase 1 plan: [`2026-04-17-web-cohesion-foundation.md`](../plans/2026-04-17-web-cohesion-foundation.md)
+- Phase 2 plan: [`2026-04-17-web-cohesion-visual-polish.md`](../plans/2026-04-17-web-cohesion-visual-polish.md)
+- Starlight 0.34.8 source: `node_modules/.pnpm/@astrojs+starlight@0.34.8_.../components/`

--- a/docs/superpowers/specs/2026-04-18-starlight-phase-3-design.md
+++ b/docs/superpowers/specs/2026-04-18-starlight-phase-3-design.md
@@ -1,7 +1,7 @@
 # Starlight Phase 3 — C-Depth Custom Layout Design
 
 **Date:** 2026-04-18
-**Status:** Draft, pending user review — no implementation yet
+**Status:** Approved — decisions locked after interview 2026-04-18. Ready for implementation.
 **Scope:** `web/sites/guides` and `web/sites/api` — the two Starlight-powered sites
 **Depends on:** [PR #2153](https://github.com/wheels-dev/wheels/pull/2153) (Phase 2 shipped)
 **Supersedes:** §8 of [`2026-04-17-wheels-dev-cohesion-design.md`](2026-04-17-wheels-dev-cohesion-design.md)
@@ -10,113 +10,129 @@
 
 ## Why a new spec
 
-The original cohesion spec's §8 proposed six Starlight overrides as one bundle: `PageFrame`, `Sidebar`, `PageTitle`, `TableOfContents`, `VersionSwitcher`, `EditLink`. Investigating against Starlight 0.34.8 surfaced information that reshapes the proposal:
+The original cohesion spec's §8 proposed six Starlight overrides as one bundle: `PageFrame`, `Sidebar`, `PageTitle`, `TableOfContents`, `VersionSwitcher`, `EditLink`. Investigating against Starlight 0.34.8 and walking the decision tree with the user surfaced information that reshapes the proposal:
 
-1. **EditLink is not useful for our setup.** Both Starlight sites serve *generated* content — api pages are emitted by `web/scripts/generate-api-docs.mjs` from `docs/api/v*.json`, and guides pages come from the `wheels.dev` sibling repo's GitBook source via `web/scripts/generate-guides.mjs`. A GitHub edit link on a generated file lands a user on a file whose edits will be overwritten on the next regen. Ship-ready only if we re-point edit links at the *source* (JSON/GitBook), which is out of scope for a CSS/component pass.
-2. **VersionSwitcher is a net-new UI component with real routing logic.** It needs dropdown state management, slug-equivalence detection across versions, and a fallback routing decision when the slug doesn't exist in the target version. That's a judgment call best made with user input — especially around UX details (dropdown vs popover, keyboard behavior, mobile treatment).
-3. **PageFrame override is disproportionately risky.** Starlight's `PageFrame` is the outer scaffold; overriding it means we own the skip-link + sidebar-placement + main-content plumbing that Starlight normally handles. Starlight 0.34.8 refactored its layout architecture significantly; pinning to a specific version is required to avoid breakage on upgrade.
-4. **Cosmetic parity is already largely achieved** via the Phase 2 `starlight-theme.css` token bridge. The visible remaining gaps are more about component-specific polish than full-layout reconstruction.
-
-This spec re-scopes Phase 3 into three value-ordered slices, defers the truly risky pieces, and calls out decisions needed from the user.
+1. **EditLink is worth investing in**, contrary to the original assumption that our generated content made it useless. Guides are *generated* — but the source is markdown files at `docs/src/**/*.md` *in this repo*, not in a sibling repo. API pages are extracted from CFC function annotations into `docs/api/v*.json`; the json is the build artifact, but the source CFC files (`vendor/wheels/<scope>/*.cfc`) are grep-findable and we can link directly to them.
+2. **PageFrame override is disproportionately risky.** Starlight 0.34.8's layout architecture is churny; overriding the outer scaffold means owning skip-link plumbing + mobile-drawer + sidebar persistence ourselves. Deferring.
+3. **Cosmetic parity is already largely achieved** via the Phase 2 `starlight-theme.css` token bridge. The remaining gaps are component-specific polish and the VersionSwitcher UI.
+4. **VersionSwitcher UX is now specified.** The user and I walked the eight open questions through a structured interview; every decision below is locked.
 
 ## Decisions (summary)
 
-| Original §8 component | New plan |
-|-----------------------|----------|
-| `EditLink` | **Drop.** Edit-on-github for generated content has no clean target. Revisit only if we invest in re-pointing at source files. |
-| `VersionSwitcher` | **Keep, but brainstorm first.** Needs UX decisions and slug-equivalence rules. |
-| `Sidebar` | **Keep — highest visible impact.** Smallest-risk component override; tune section headings, active state, nested indent treatment. |
-| `PageTitle` | **Keep — moderate impact.** Adds category eyebrow + tighter typography. |
-| `TableOfContents` | **Keep — small but nice.** Sticky right-rail with branded active indicator. |
-| `PageFrame` | **Defer.** Keep Starlight's default outer scaffold; override individual slot components instead. |
+| Component | Decision |
+|-----------|----------|
+| `EditLink` | **Keep.** Guides link at `https://github.com/wheels-dev/wheels/edit/develop/docs/src/{path}.md`. API links at the source CFC for that function. Exact mechanism for the api mapping decided during Slice 1 implementation. |
+| `VersionSwitcher` | **Keep — UX locked.** See Slice 2. |
+| `Sidebar` | **Keep** — highest visible impact. Section headings in `--text-xs` uppercase `--color-fg-subtle`; leaf links `--color-fg-muted` resting, `--color-brand` + `--color-brand-soft` bg when active, indent-only nesting (no vertical guide lines). |
+| `PageTitle` | **Keep** — category eyebrow from frontmatter or first path segment; H1 `--text-4xl` tracking-tight; breadcrumb line in `--color-fg-subtle`. |
+| `TableOfContents` | **Keep** — sticky right rail; `--text-xs` headings; active item bold + `--color-brand` with 2px `--color-brand` left border. |
+| `PageFrame` | **Defer.** Keep Starlight's default outer scaffold. |
 
 ## Slice plan
 
-Ship as three PRs, each independently mergeable and reviewable:
+Three PRs, each independently mergeable and reviewable. Priority: polish (lowest risk) → VersionSwitcher (moderate) → regression safety net.
 
-### Slice 1: Sidebar + PageTitle + TableOfContents (visual polish)
+### Slice 1 — Sidebar + PageTitle + TableOfContents + EditLink
 
-Three focused component overrides. No new UI, no client-side logic, no Starlight internals touched beyond the documented `components: {...}` slots. Mostly CSS work.
+Four focused component overrides. No new UI, no client-side logic, no Starlight internals touched beyond the documented `components: {...}` slots.
 
 **Files to add:**
 - `web/packages/ui/src/components/starlight/Sidebar.astro`
 - `web/packages/ui/src/components/starlight/PageTitle.astro`
 - `web/packages/ui/src/components/starlight/TableOfContents.astro`
+- `web/packages/ui/src/components/starlight/EditLink.astro`
 
 **Design targets:**
-- **Sidebar:** section headings in `--text-xs` uppercase `--color-fg-subtle`; leaf links `--color-fg-muted` resting, `--color-brand` + `--color-brand-soft` bg when active, indent-only nesting (no vertical guide lines). Reuse Starlight's `SidebarSublist.astro` internals; only override the outer `Sidebar.astro`.
-- **PageTitle:** category eyebrow read from `Astro.locals.starlightRoute.entry.data.category || head of path segments`; H1 `--text-4xl` tracking-tight; breadcrumb line in `--color-fg-subtle`.
-- **TableOfContents:** sticky right rail; `--text-xs` headings; active item bold + `--color-brand` with 2px `--color-brand` left border; preserve Starlight's smooth-scroll + mobile-TOC behavior by deferring to `TableOfContentsList` for the inner list.
+- **Sidebar:** see decision table. Reuse Starlight's `SidebarSublist.astro` internals; only override the outer `Sidebar.astro`. Must handle both data shapes — manual sidebar with `normalizeItem` (guides) and `autogenerate: { directory: ... }` (api).
+- **PageTitle:** category eyebrow read from `Astro.locals.starlightRoute.entry.data.category` if present, else the first non-version path segment (e.g., `/v3-0-0/models/validations/` → "Models"). H1 `--text-4xl` tracking-tight. Breadcrumb crumbs on a thin line in `--color-fg-subtle`.
+- **TableOfContents:** sticky below header; `--text-xs` headings, `--color-fg-muted`; active item `--color-brand` bold with 2px `--color-brand` left border. Preserve Starlight's smooth-scroll + mobile-TOC drawer by rendering `TableOfContentsList` inside our shell.
+- **EditLink:**
+  - **Guides:** construct URL as `https://github.com/wheels-dev/wheels/edit/develop/docs/src/{entry.id}.md` (verify `entry.id` aligns with source path during implementation; generator may prepend the version slug — strip it if so).
+  - **API:** three candidate mechanisms for mapping `function name + availableIn scope` → CFC file path. Decide during implementation:
+    - (a) **GitHub search link** — cheapest. `https://github.com/wheels-dev/wheels/search?q=repo%3Awheels-dev%2Fwheels+function+{name}&type=code`. Zero generator change.
+    - (b) **Build-time grep** — at generate-api-docs time, walk `vendor/wheels/<availableIn[0]>/*.cfc` and record the file path per function into the generated frontmatter. Best direct-link UX, modest generator change.
+    - (c) **Enhance the upstream JSON extractor** — ask the tool that builds `docs/api/v*.json` to record source path. Cleanest long-term but depends on upstream.
+  - **Recommend starting with (b)** and falling back to (a) if ambiguity (multiple matches).
 
 **Starlight config additions (both guides and api):**
 ```js
 components: {
-  // existing Phase 2 overrides:
+  // existing Phase 2:
   Header: '@wheels-dev/ui/components/starlight/Header.astro',
   Footer: '@wheels-dev/ui/components/starlight/Footer.astro',
   SocialIcons: '@wheels-dev/ui/components/starlight/SocialIcons.astro',
-  // NEW:
+  // Slice 1:
   Sidebar: '@wheels-dev/ui/components/starlight/Sidebar.astro',
   PageTitle: '@wheels-dev/ui/components/starlight/PageTitle.astro',
   TableOfContents: '@wheels-dev/ui/components/starlight/TableOfContents.astro',
+  EditLink: '@wheels-dev/ui/components/starlight/EditLink.astro',
 },
 ```
 
-**Risks:**
-- Sidebar override must handle "Overview" injection (we already use this pattern in guides's `normalizeItem` helper for linked groups) and autogenerated sections (api uses `autogenerate: { directory: v.slug }`). Read both configs to confirm the override handles both data shapes.
-- Starlight 0.34.8 data shape: `Astro.locals.starlightRoute.entry` and `Astro.locals.starlightRoute.sidebar` are the expected sources. Verify at implementation time.
+Also wire `editLink: { baseUrl: 'https://github.com/wheels-dev/wheels/edit/develop/' }` in the Starlight config so `Astro.locals.starlightRoute.editUrl` is populated for our override to pick up.
 
 **Acceptance:**
 - All 4 sites still build cleanly (`pnpm build`)
 - Pagefind search still returns results on guides + api
 - Visual diff of one docs page per site vs. the pre-slice baseline shows the intended changes, no regressions
+- EditLink on a guides page lands on the correct `docs/src/*.md` file in GitHub's edit view
+- EditLink on an api page lands somewhere useful (target depends on which api mechanism ships first)
 
-### Slice 2: VersionSwitcher (header dropdown)
+### Slice 2 — VersionSwitcher (header dropdown)
 
-Net-new UI. Lives in the header, so it reuses the shared Header component and imports the switcher as a sibling to the nav.
+Net-new UI. Lives in the header, to the right of the wordmark lockup. Replaces the per-version grouping in the sidebar — sidebar becomes scoped to the currently selected version only.
 
-**Open UX questions for user review (answer before implementation):**
+**UX decisions (locked):**
 
-1. **Dropdown anchor:** to the right of the site title (before the nav links), or pinned as a separate badge next to it? Current Starlight sidebar version list is already present — do we remove it from the sidebar when we add the header switcher, or keep both as complementary discovery paths?
-2. **Slug equivalence:** when a user on `guides.wheels.dev/v3-0-0/models/validations/` clicks "v4.0.0-SNAPSHOT", we navigate to `v4-0-0-snapshot/models/validations/` if it exists. If that slug doesn't exist in the target version, what's the fallback? Options:
-   - Navigate to target version's root
-   - Surface a notice: "That page isn't in v4.0.0-SNAPSHOT — here's the overview"
-   - Try a fuzzy match (substring on final path segment) before root
-3. **Current-version indicator:** badge-style (`current release`, `snapshot`, `archived`) or sub-label under the version number?
-4. **Keyboard / a11y:** is a native `<select>` acceptable (maximal accessibility, minimal styling control), or do we build a custom listbox with the standard ARIA pattern (more styling, more JS)?
-5. **Mobile:** fold into the existing hamburger drawer, or stay as an inline dropdown?
+| Question | Answer |
+|----------|--------|
+| Dropdown anchor | Inline pill next to the wordmark. Sidebar drops per-version grouping; shows only the currently selected version's TOC. |
+| Slug-equivalence fallback | **Hybrid:** exact slug match first → fuzzy match on final 1-2 path segments → fall back to target version root. Computed at build time as a static map. |
+| Indicator style | Colored badge: `v3.0.0 [CURRENT]` (green), `v4.0.0-SNAPSHOT [SNAPSHOT]` (amber), `v2.5.0 [ARCHIVED]` (grey). Badge shows ambient status without requiring dropdown interaction. |
+| a11y / keyboard | `<details>`/`<summary>` progressive-enhancement base (works without JS as native disclosure). With JS, upgrade to an ARIA listbox pattern — `role="listbox"`, arrow-key navigation, enter-to-commit, escape-to-close, focus trap while open. |
+| Mobile | Fold into the hamburger drawer. Drawer shows nav + a "Switch version" section listing all versions with their badges. Inline pill in the header hides at `<720px`. |
 
-**Implementation sketch (placeholder until UX decisions land):**
-- Collect version slugs from per-site config (reuse the `versions` arrays in each `astro.config.mjs`).
-- Compute "equivalent page" map at build time via an Astro virtual module so client JS only needs the map + current slug.
-- Render a `<details>`/`<summary>` pair as progressive-enhancement base (works without JS), upgrade with a custom listbox behavior when JS is available.
+**Files to add:**
+- `web/packages/ui/src/components/starlight/VersionSwitcher.astro`
+- Some form of build-time slug-equivalence map. Options:
+  - Astro virtual module exposing `{ version, slugMap }` to client JS (recommended)
+  - Static JSON written to `web/packages/ui/src/generated/version-slugs.json` at build time via a `scripts/build-version-slugs.mjs` script
+  - Pre-computed inside each site's `astro.config.mjs` and passed as a prop
 
-**Deferred until brainstormed.**
+**Per-site config:**
+- Each `astro.config.mjs` continues to own its `versions` array. The switcher reads it via Starlight route data or a site-provided integration.
+- Add `editLink.baseUrl` (already done in Slice 1).
 
-### Slice 3: `starlightRoute` API verification + regression test
+**Where to dock the switcher:** not inside Starlight's default `Header` (that's already overridden to render our shared `Header.astro`). Instead:
+- Extend the shared `Header.astro` with an optional `<slot name="after-brand">` placement
+- Populate that slot from the Starlight Header wrapper (`@wheels-dev/ui/components/starlight/Header.astro`) so landing + blog don't render the switcher (no versions there)
 
-Add a simple visual-regression screenshot test that runs on PRs touching `web/**`. Rationale: the Phase 2 + Phase 3 overrides all depend on Starlight internal data shapes (`Astro.locals.starlightRoute.*`). A one-docs-page-per-site screenshot check catches regressions before they reach production.
+**Acceptance:**
+- All four sites still build + style-check clean
+- Switcher renders only on guides + api
+- Switching from a deep page navigates to the equivalent page in the target version when it exists; otherwise lands at target version root (fuzzy match path covered by tests)
+- Keyboard: arrow-up/down moves highlight, enter navigates, escape closes
+- Screen reader (VoiceOver / NVDA) announces as a listbox with the current selection
+- `<details>`-base still opens and navigates when JS is disabled (progressive enhancement)
+- Mobile drawer shows the "Switch version" section
+
+### Slice 3 — Visual-regression screenshot test in CI
+
+Add a minimal screenshot-comparison step that runs on PRs touching `web/**`. Catches Starlight internal-API breakage before it ships (Phase 2 + Slice 1/2 both depend on `Astro.locals.starlightRoute.*` shape, which could shift on a Starlight upgrade).
 
 **Scope:**
-- Add `web/scripts/visual-regression.mjs` that starts each dev server, navigates to a canary page, and compares a screenshot against a stored baseline
-- CI step in `.github/workflows/web-deploy.yml` that runs it on every PR touching `web/**`
-- One baseline image per site in `web/tests/visual-baselines/`
+- `web/scripts/visual-regression.mjs` — starts each dev server, navigates to one canary page per site, screenshots, compares against a stored baseline (pixel diff via `pixelmatch` or similar).
+- Baselines in `web/tests/visual-baselines/` (4 images — one per site).
+- CI step in `.github/workflows/web-deploy.yml` that runs it on every PR touching `web/**`. Failure doesn't block merge initially (soft-fail) so contributors can refresh baselines; tighten to hard-fail once stable.
+- One documented refresh command: `pnpm --filter @wheels-dev/web run visual:baseline`.
 
-Independent of Slices 1 and 2; can be shipped any time.
+**Independent of Slices 1 and 2.** Can ship at any time.
 
 ## What we are intentionally NOT doing in Phase 3
 
-- **EditLink override.** Would need to re-point edit links at source (JSON for api, GitBook markdown for guides in the sibling repo). Interesting future work; not cohesion work.
-- **PageFrame override.** Starlight's default scaffold works; overriding it gains little and costs real upgrade risk.
-- **Content-page layout changes** (e.g., two-column on api function pages). Separate project; pursue only if the api reference needs dedicated treatment.
+- **PageFrame override.** Starlight default is fine; skip the upgrade risk.
+- **Content-page layout changes** (e.g., two-column on api function pages). Separate project.
 - **Search UI override.** Pagefind's default is themed adequately via Phase 2's `starlight-theme.css`. If we want a branded search UI, spec it separately.
-
-## Open questions for user
-
-1. Do you want EditLink back if we re-point at source files (api JSON + wheels.dev GitBook)? Scope implication: separate, larger project.
-2. VersionSwitcher UX questions in Slice 2 above — five decisions to make before implementation.
-3. Are you OK keeping `PageFrame` as Starlight default indefinitely, or should we revisit if specific pain points emerge?
-4. Is the proposed three-slice order (polish → switcher → regression test) the right priority, or does something else jump the queue (e.g., switcher first because users ask for it)?
 
 ## References
 
@@ -124,3 +140,5 @@ Independent of Slices 1 and 2; can be shipped any time.
 - Phase 1 plan: [`2026-04-17-web-cohesion-foundation.md`](../plans/2026-04-17-web-cohesion-foundation.md)
 - Phase 2 plan: [`2026-04-17-web-cohesion-visual-polish.md`](../plans/2026-04-17-web-cohesion-visual-polish.md)
 - Starlight 0.34.8 source: `node_modules/.pnpm/@astrojs+starlight@0.34.8_.../components/`
+- Guides markdown source: `docs/src/**/*.md`
+- API JSON source: `docs/api/v*.json`; CFC origin under `vendor/wheels/<scope>/*.cfc`


### PR DESCRIPTION
## Summary

Stops before shipping Phase 3 UI and captures what I learned while investigating Starlight 0.34.8 + our generated-content pipeline. **Docs-only PR** — no code changes.

The original cohesion spec treated Phase 3 (\"C-depth custom layout\") as a single 6-component bundle. Investigation surfaced three reasons to re-scope:

1. **EditLink doesn't fit our setup.** Both Starlight sites serve generated content (api pages from \`docs/api/v*.json\`, guides from \`wheels.dev\` GitBook source). A GitHub \"edit this page\" link on a generated file lands on a file whose edits get overwritten on next regen.
2. **VersionSwitcher needs UX decisions first** — dropdown anchor, slug-equivalence fallback, mobile behavior, keyboard model. Best brainstormed rather than guessed autonomously.
3. **PageFrame override is disproportionately risky** — Starlight 0.34.8's layout architecture makes this a real upgrade hazard. Skip it; override slot components inside the default PageFrame instead.

## What the new spec proposes

Three independent slices in priority order:

- **Slice 1:** Sidebar + PageTitle + TableOfContents overrides (pure visual polish, no new logic)
- **Slice 2:** VersionSwitcher — after UX brainstorm with you (five specific questions flagged in spec)
- **Slice 3:** Visual-regression screenshot test in CI (safety net for Phase 2/3 overrides depending on Starlight internals)

Plus: explicit \"NOT doing\" list, open questions for you, pointer to the Starlight source we'd be integrating against.

## Why ship this as-is

I was operating autonomously while you stepped away and hit the point where the remaining Phase 3 work needs your judgment (UX decisions, scope tradeoffs). Shipping a spec for your review is the honest stopping point — ships the learning, doesn't ship risky UI blind.

## Read order

[docs/superpowers/specs/2026-04-18-starlight-phase-3-design.md](docs/superpowers/specs/2026-04-18-starlight-phase-3-design.md) — start at \"Decisions (summary)\" and \"Open questions for user\".

## Test plan

- [x] \`git diff\` reviewed — only the new spec file added
- [ ] You: read and decide on the five open questions in Slice 2, plus whether we keep EditLink permanently dropped and PageFrame as Starlight default.