### PR TITLE
feat(web/starlight): phase 3 slice 1 — pagetitle eyebrow, editlink, themed sidebar + TOC

### DIFF
--- a/web/packages/ui/package.json
+++ b/web/packages/ui/package.json
@@ -11,6 +11,8 @@
 		"./components/starlight/Header.astro": "./src/components/starlight/Header.astro",
 		"./components/starlight/Footer.astro": "./src/components/starlight/Footer.astro",
 		"./components/starlight/SocialIcons.astro": "./src/components/starlight/SocialIcons.astro",
+		"./components/starlight/PageTitle.astro": "./src/components/starlight/PageTitle.astro",
+		"./components/starlight/EditLink.astro": "./src/components/starlight/EditLink.astro",
 		"./styles/tokens.css": "./src/styles/tokens.css",
 		"./styles/base.css": "./src/styles/base.css",
 		"./styles/starlight-theme.css": "./src/styles/starlight-theme.css",

--- a/web/packages/ui/src/components/starlight/EditLink.astro
+++ b/web/packages/ui/src/components/starlight/EditLink.astro
@@ -1,0 +1,100 @@
+---
+// EditLink override.
+//
+// Both Starlight sites serve GENERATED content:
+//   - guides: rendered from markdown at docs/src/**/*.md in this repo
+//   - api:    rendered from docs/api/v{version}.json (extracted from CFC source)
+//
+// The default Starlight editUrl composes baseUrl + entry.filePath, which for
+// our setup points at the generated file (wrong — edits get overwritten on
+// regen). This override ignores editUrl and composes its own target:
+//
+//   - guides: strip the v{slug}/ prefix from entry.id → link at
+//     https://github.com/wheels-dev/wheels/edit/develop/docs/src/<path>.md
+//   - api:    GitHub code-search for the function name scoped to the repo.
+//     A follow-up could enhance generate-api-docs.mjs to record a
+//     sourcePath per function; for now, search is good enough.
+
+const route = Astro.locals.starlightRoute;
+const entry = route.entry;
+const id = entry.id;
+
+// Distinguish guides vs api by the page title's frontmatter shape. API
+// pages have titles like 'resources()' — a bare identifier with empty
+// parens. Guides pages have prose titles ('Beginner Tutorial: Hello
+// World'). This signal is stable in dev + prod and doesn't depend on
+// Astro.site being set to a specific hostname.
+const titleRaw = String(entry.data.title ?? '');
+const isApiFunction = /^[A-Za-z_]\w*\(\)\s*$/.test(titleRaw);
+
+let href: string | null = null;
+let label = 'Edit this page on GitHub';
+
+if (isApiFunction) {
+	const fnName = titleRaw.replace(/\(\)\s*$/, '').trim();
+	if (fnName) {
+		const q = encodeURIComponent(`function ${fnName}`);
+		href = `https://github.com/wheels-dev/wheels/search?q=repo%3Awheels-dev%2Fwheels+${q}&type=code`;
+		label = 'View source on GitHub';
+	}
+} else {
+	// Guides. Strip leading 'v4-0-0-snapshot/' (or similar) version segment.
+	const withoutVersion = id.replace(/^v[^/]+\//, '');
+	href = `https://github.com/wheels-dev/wheels/edit/develop/docs/src/${withoutVersion}.md`;
+}
+---
+
+{
+	href && (
+		<a class="wd-edit-link" href={href} rel="noopener">
+			<svg
+				class="wd-edit-link__icon"
+				width="14"
+				height="14"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				aria-hidden="true"
+			>
+				<path d="M12 20h9" />
+				<path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+			</svg>
+			<span>{label}</span>
+		</a>
+	)
+}
+
+<style>
+	.wd-edit-link {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-2) var(--space-3);
+		margin-top: var(--space-5);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius);
+		background: transparent;
+		color: var(--color-fg-muted);
+		font-size: var(--text-sm);
+		font-weight: 500;
+		text-decoration: none;
+		transition:
+			border-color 0.15s,
+			color 0.15s,
+			background 0.15s;
+	}
+
+	.wd-edit-link:hover {
+		border-color: var(--color-brand);
+		color: var(--color-brand);
+		background: var(--color-brand-soft);
+	}
+
+	.wd-edit-link__icon {
+		color: var(--color-brand);
+		flex-shrink: 0;
+	}
+</style>

--- a/web/packages/ui/src/components/starlight/Footer.astro
+++ b/web/packages/ui/src/components/starlight/Footer.astro
@@ -1,5 +1,49 @@
 ---
+// Starlight Footer override.
+//
+// Two jobs, stacked vertically:
+//
+// 1. DOCS FOOTER (in-content) — Starlight's default Footer slot is the
+//    meta row beneath every docs page: EditLink + LastUpdated +
+//    Pagination (prev/next). If we just substitute our brand footer
+//    here, those controls disappear — which is what happened through
+//    Phase 2. Re-render them explicitly.
+//
+// 2. BRAND FOOTER (site-wide) — the same three-column wd-footer that
+//    landing and blog use, so guides + api match the rest of the site.
+
+import EditLink from 'virtual:starlight/components/EditLink';
+import LastUpdated from 'virtual:starlight/components/LastUpdated';
+import Pagination from 'virtual:starlight/components/Pagination';
 import Footer from '../Footer.astro';
 ---
 
+<div class="wd-docs-footer">
+	<div class="wd-docs-footer__meta">
+		<EditLink />
+		<LastUpdated />
+	</div>
+	<Pagination />
+</div>
+
 <Footer />
+
+<style>
+	.wd-docs-footer {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+		margin-top: var(--space-7);
+		padding-top: var(--space-5);
+		border-top: 1px solid var(--color-border);
+	}
+
+	.wd-docs-footer__meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-3) var(--space-5);
+		justify-content: space-between;
+		color: var(--color-fg-muted);
+		font-size: var(--text-sm);
+	}
+</style>

--- a/web/packages/ui/src/components/starlight/PageTitle.astro
+++ b/web/packages/ui/src/components/starlight/PageTitle.astro
@@ -1,0 +1,57 @@
+---
+// PageTitle override.
+//
+// Adds a category eyebrow above the H1 and tightens typography to match
+// the landing/blog design system. Category resolves in this order:
+//   1. entry.data.category (if the author set it in frontmatter)
+//   2. First non-version path segment (e.g., v3-0-0/models/foo → "Models")
+
+const route = Astro.locals.starlightRoute;
+const entry = route.entry;
+const id = entry.id;
+
+const frontmatterCategory = (entry.data as { category?: string }).category;
+let eyebrow: string | null = frontmatterCategory ?? null;
+
+if (!eyebrow) {
+	// id looks like 'v4-0-0-snapshot/command-line-tools/quick-start'.
+	// Strip the version prefix, then take the first segment.
+	const withoutVersion = id.replace(/^v[^/]+\//, '');
+	const firstSegment = withoutVersion.split('/')[0] ?? '';
+	if (firstSegment && firstSegment !== 'index') {
+		eyebrow = firstSegment
+			.split('-')
+			.map((w) => (w.length > 0 ? w[0]!.toUpperCase() + w.slice(1) : w))
+			.join(' ');
+	}
+}
+---
+
+<div class="wd-page-title">
+	{eyebrow && <p class="wd-page-title__eyebrow">{eyebrow}</p>}
+	<h1 id="_top">{entry.data.title}</h1>
+</div>
+
+<style>
+	.wd-page-title {
+		margin-top: var(--space-3);
+	}
+
+	.wd-page-title__eyebrow {
+		font-size: var(--text-xs);
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		color: var(--color-brand);
+		margin: 0 0 var(--space-2);
+	}
+
+	.wd-page-title h1 {
+		font-size: var(--text-4xl);
+		line-height: var(--leading-tight);
+		letter-spacing: var(--tracking-tight);
+		font-weight: 700;
+		color: var(--color-fg);
+		margin: 0;
+	}
+</style>

--- a/web/packages/ui/src/styles/starlight-theme.css
+++ b/web/packages/ui/src/styles/starlight-theme.css
@@ -61,3 +61,94 @@
 	border-radius: var(--radius-lg);
 	box-shadow: var(--shadow-sm);
 }
+
+/* ── Sidebar (Phase 3 Slice 1) ────────────────────────────────────
+ * Rules are unlayered so they beat Starlight's @layer starlight.core
+ * defaults. Scoped under #starlight__sidebar to stay narrow.
+ */
+
+/* Kill the vertical guide rule between nested levels. */
+#starlight__sidebar ul ul li {
+	border-inline-start-color: transparent;
+}
+
+/* Group labels: smaller, uppercase, muted — was lg + color-white. */
+#starlight__sidebar .large {
+	font-size: var(--text-xs);
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	color: var(--color-fg-subtle);
+}
+
+@media (min-width: 50rem) {
+	#starlight__sidebar .large {
+		font-size: var(--text-xs);
+	}
+}
+
+/* Leaf links: smaller, muted resting, surface hover. */
+#starlight__sidebar a {
+	font-size: var(--text-sm);
+	color: var(--color-fg-muted);
+	border-radius: var(--radius);
+}
+
+#starlight__sidebar a:hover,
+#starlight__sidebar a:focus {
+	color: var(--color-fg);
+	background: var(--color-surface-2);
+}
+
+/* Active page — brand-soft bg + brand-ink fg (was text-invert on accent). */
+#starlight__sidebar [aria-current='page'],
+#starlight__sidebar [aria-current='page']:hover,
+#starlight__sidebar [aria-current='page']:focus {
+	font-weight: 600;
+	color: var(--color-brand-ink);
+	background-color: var(--color-brand-soft);
+}
+
+/* Slightly tighter spacing between top-level groups. */
+#starlight__sidebar .top-level > li + li {
+	margin-top: var(--space-3);
+}
+
+/* ── Right-rail TOC (Phase 3 Slice 1) ────────────────────────────── */
+
+starlight-toc h2 {
+	font-size: var(--text-xs);
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	color: var(--color-fg-subtle);
+	margin: 0 0 var(--space-3);
+}
+
+starlight-toc a {
+	color: var(--color-fg-muted);
+	font-size: var(--text-sm);
+	line-height: var(--leading-normal);
+	border-inline-start: 2px solid transparent;
+	text-decoration: none;
+	transition:
+		color 0.1s,
+		border-color 0.1s;
+}
+
+starlight-toc a:hover,
+starlight-toc a:focus {
+	color: var(--color-fg);
+}
+
+starlight-toc a[aria-current='true'] {
+	color: var(--color-brand);
+	border-inline-start-color: var(--color-brand);
+	font-weight: 600;
+}
+
+/* ── PageTitle surround spacing (Phase 3 Slice 1) ───────────────── */
+
+.wd-page-title {
+	margin-bottom: var(--space-5);
+}

--- a/web/sites/api/astro.config.mjs
+++ b/web/sites/api/astro.config.mjs
@@ -27,6 +27,14 @@ export default defineConfig({
 				Header: '@wheels-dev/ui/components/starlight/Header.astro',
 				Footer: '@wheels-dev/ui/components/starlight/Footer.astro',
 				SocialIcons: '@wheels-dev/ui/components/starlight/SocialIcons.astro',
+				PageTitle: '@wheels-dev/ui/components/starlight/PageTitle.astro',
+				EditLink: '@wheels-dev/ui/components/starlight/EditLink.astro',
+			},
+			editLink: {
+				// Vestigial — our EditLink override composes a GitHub code-search
+				// URL from the function name in frontmatter. Setting baseUrl so
+				// Starlight renders the EditLink component at all.
+				baseUrl: 'https://github.com/wheels-dev/wheels/edit/develop/docs/api/',
 			},
 			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/wheels-dev/wheels' }],
 			sidebar: [

--- a/web/sites/guides/astro.config.mjs
+++ b/web/sites/guides/astro.config.mjs
@@ -68,6 +68,15 @@ export default defineConfig({
 				Header: '@wheels-dev/ui/components/starlight/Header.astro',
 				Footer: '@wheels-dev/ui/components/starlight/Footer.astro',
 				SocialIcons: '@wheels-dev/ui/components/starlight/SocialIcons.astro',
+				PageTitle: '@wheels-dev/ui/components/starlight/PageTitle.astro',
+				EditLink: '@wheels-dev/ui/components/starlight/EditLink.astro',
+			},
+			editLink: {
+				// Our EditLink override computes its own target (strips the version
+				// slug and points at docs/src/*.md), so the value here is mostly
+				// vestigial — but Starlight only renders EditLink when editLink is
+				// configured, so we still need this.
+				baseUrl: 'https://github.com/wheels-dev/wheels/edit/develop/docs/src/',
 			},
 			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/wheels-dev/wheels' }],
 			sidebar: [{ label: 'Overview', link: '/' }, ...versions.map(buildSidebarForVersion)],


### PR DESCRIPTION
## Summary

First slice of Phase 3 per the [locked spec](docs/superpowers/specs/2026-04-18-starlight-phase-3-design.md). Visual polish for the two Starlight sites, plus restoration of the docs-footer meta row that was silently dropped in Phase 2.

## What changed

**New component overrides (`web/packages/ui/src/components/starlight/`):**
- **`PageTitle.astro`** — adds a red uppercase category eyebrow above the H1. Category resolves from `entry.data.category` frontmatter if set, else the first non-version path segment title-cased (`v3-0-0/models/foo` → `Models`).
- **`EditLink.astro`** — per-site URL composition. Guides pages strip the `v{slug}/` prefix from `entry.id` and link at `github.com/wheels-dev/wheels/edit/develop/docs/src/<path>.md`. API pages (detected by title shape like `resources()`) link at a GitHub code-search for `function <name>` scoped to the repo.

**Sidebar + TOC as CSS-only in `starlight-theme.css`:**
- Originally spec'd as component overrides, but both need Starlight internals that aren't in Starlight 0.34.8's package `exports` (`SidebarPersister`, `TableOfContentsList`). CSS-only preserves persistence + scroll-spy behavior without forking internals.
- Sidebar: no vertical guide lines, uppercase section headings in muted grey, brand-soft bg + brand-ink fg for active page, warm-palette hover states.
- TOC: uppercase heading, muted list, active item gets bold + red + 2px red left border.

**Starlight Footer override reshaped:**
- Phase 2 substituted our brand footer for Starlight's docs-footer slot — which silently dropped EditLink + LastUpdated + Pagination from every docs page. This PR stacks: docs-meta row (EditLink + LastUpdated) + prev/next Pagination + brand footer.
- Result: docs pages now have prev/next cards again, edit links work, brand footer still present at the bottom.

**`editLink.baseUrl` added to both Starlight configs** so Starlight renders the EditLink slot at all. Our override ignores the default composed URL and builds its own target.

## Test plan

- [x] `pnpm build` — all four sites build clean (guides 444 pages, api 2352 pages)
- [x] `pnpm format:check` — passes
- [x] All four sites: `astro check` reports 0 errors
- [x] Visual spot-check on guides page: red `INTRODUCTION` eyebrow above H1, themed sidebar with brand-soft active, themed TOC with red left-border active item, edit link pointing at `docs/src/introduction/readme/beginner-tutorial-hello-world.md`, prev/next pagination cards, brand footer
- [x] Visual spot-check on api page: `CONFIGURATION` eyebrow above `addFormat()`, "View source on GitHub" button linking to GitHub code-search for `function addFormat`
- [ ] Reviewer: click the edit link on one guides page and one api page, confirm the targets land where expected

## Known caveats for later slices

- **API → CFC source mapping** is currently a GitHub code-search (cheap, works for unique names). Follow-up could enhance `generate-api-docs.mjs` to grep `vendor/wheels/<availableIn>/*.cfc` during generation and record the source path in frontmatter for a direct link.
- **Duplicate H1** in guides (one from PageTitle override, one from the markdown body starting with `# Title`) pre-exists this PR — lives in the source markdown. Fixing it belongs to the `docs/src/**` cleanup track, not Phase 3 Slice 1.

## Next in Phase 3

- Slice 2 — VersionSwitcher (header dropdown), UX already locked in spec
- Slice 3 — visual-regression screenshot test in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)