### PR TITLE
feat(web/starlight): phase 3 slice 2 — version switcher dropdown in header

### DIFF
--- a/web/packages/ui/package.json
+++ b/web/packages/ui/package.json
@@ -13,6 +13,8 @@
 		"./components/starlight/SocialIcons.astro": "./src/components/starlight/SocialIcons.astro",
 		"./components/starlight/PageTitle.astro": "./src/components/starlight/PageTitle.astro",
 		"./components/starlight/EditLink.astro": "./src/components/starlight/EditLink.astro",
+		"./components/starlight/VersionSwitcher.astro": "./src/components/starlight/VersionSwitcher.astro",
+		"./data/versions": "./src/data/versions.ts",
 		"./styles/tokens.css": "./src/styles/tokens.css",
 		"./styles/base.css": "./src/styles/base.css",
 		"./styles/starlight-theme.css": "./src/styles/starlight-theme.css",

--- a/web/packages/ui/src/components/Header.astro
+++ b/web/packages/ui/src/components/Header.astro
@@ -15,9 +15,12 @@ const links = [
 ---
 
 <header class="wd-header" data-current={current ?? 'landing'}>
-	<a class="wd-header__brand" href="https://wheels.dev/" aria-label="wheels.dev home">
-		<Logo variant="lockup" size="md" />
-	</a>
+	<div class="wd-header__lockup">
+		<a class="wd-header__brand" href="https://wheels.dev/" aria-label="wheels.dev home">
+			<Logo variant="lockup" size="md" />
+		</a>
+		<slot name="after-brand" />
+	</div>
 
 	<button
 		class="wd-header__toggle"
@@ -93,6 +96,12 @@ const links = [
 	.wd-header.is-scrolled {
 		border-bottom-color: var(--color-border);
 		box-shadow: var(--shadow-sm);
+	}
+
+	.wd-header__lockup {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-3);
 	}
 
 	.wd-header__brand {

--- a/web/packages/ui/src/components/starlight/Header.astro
+++ b/web/packages/ui/src/components/starlight/Header.astro
@@ -1,5 +1,6 @@
 ---
 import Header from '../Header.astro';
+import VersionSwitcher from './VersionSwitcher.astro';
 
 // Starlight passes route data via Astro.locals.starlightRoute.
 // We infer which Wheels site we're on from the `site` URL, falling back to the
@@ -12,4 +13,6 @@ else if (site.startsWith('api')) current = 'api';
 else if (site.startsWith('blog')) current = 'blog';
 ---
 
-<Header current={current} />
+<Header current={current}>
+	<VersionSwitcher slot="after-brand" />
+</Header>

--- a/web/packages/ui/src/components/starlight/VersionSwitcher.astro
+++ b/web/packages/ui/src/components/starlight/VersionSwitcher.astro
@@ -1,0 +1,339 @@
+---
+// VersionSwitcher — inline dropdown pill in the Starlight header.
+//
+// Locked UX (see docs/superpowers/specs/2026-04-18-starlight-phase-3-design.md):
+//   - Anchor: inline pill next to the wheels.dev wordmark (desktop).
+//     Folds into the hamburger drawer at <720px.
+//   - Indicator: colored badge (current/snapshot/archived) alongside the
+//     version label, always visible at rest.
+//   - Slug fallback: exact → fuzzy on final 2 segments → fuzzy on final
+//     1 segment → target version root. Computed at build time.
+//   - a11y: <details>/<summary> progressive-enhancement base. Client
+//     script upgrades to an ARIA listbox with arrow/enter/escape.
+
+import { getCollection } from 'astro:content';
+import {
+	versionsForHostname,
+	findEquivalentPath,
+	type VersionMeta,
+} from '@wheels-dev/ui/data/versions';
+
+const route = Astro.locals.starlightRoute;
+const entryId = route?.entry?.id ?? '';
+const hostname = Astro.site?.hostname;
+
+const versions = versionsForHostname(hostname);
+
+interface VersionOption extends VersionMeta {
+	url: string;
+	isCurrent: boolean;
+}
+
+let options: VersionOption[] = [];
+let currentVersion: VersionOption | null = null;
+
+if (versions.length > 0 && entryId) {
+	// entry.id looks like 'v4-0-0-snapshot/introduction/readme/beginner-tutorial-hello-world'.
+	const [currentSlug, ...rest] = entryId.split('/');
+	const currentRelativePath = rest.join('/');
+
+	// Build a per-version set of within-version paths so fuzzy-match lookups
+	// are O(1)/O(n) depending on fallback stage. Only runs at build time.
+	const entries = await getCollection('docs');
+	const entriesByVersion = new Map<string, Set<string>>();
+	for (const entry of entries) {
+		const [v, ...p] = entry.id.split('/');
+		if (!v) continue;
+		if (!entriesByVersion.has(v)) entriesByVersion.set(v, new Set<string>());
+		const pathWithinVersion = p.join('/');
+		if (pathWithinVersion) entriesByVersion.get(v)!.add(pathWithinVersion);
+	}
+
+	options = versions.map((v) => {
+		const isCurrent = v.slug === currentSlug;
+		const targetEntries = entriesByVersion.get(v.slug) ?? new Set<string>();
+		const equivalent = isCurrent
+			? currentRelativePath
+			: (findEquivalentPath(currentRelativePath, targetEntries) ?? null);
+		const url = equivalent ? `/${v.slug}/${equivalent}/` : `/${v.slug}/`;
+		return { ...v, url, isCurrent };
+	});
+
+	currentVersion = options.find((o) => o.isCurrent) ?? null;
+}
+
+const statusLabel: Record<string, string> = {
+	current: 'current',
+	snapshot: 'snapshot',
+	archived: 'archived',
+};
+---
+
+{
+	options.length > 0 && currentVersion && (
+		<div class="wd-version-switcher" data-wd-version-switcher>
+			<details class="wd-version-switcher__details">
+				<summary class="wd-version-switcher__trigger" aria-haspopup="listbox">
+					<span class="wd-version-switcher__label">{currentVersion.label}</span>
+					<span
+						class:list={[
+							'wd-version-switcher__badge',
+							`wd-version-switcher__badge--${currentVersion.status}`,
+						]}
+					>
+						{statusLabel[currentVersion.status] ?? currentVersion.status}
+					</span>
+					<svg
+						class="wd-version-switcher__caret"
+						width="10"
+						height="10"
+						viewBox="0 0 10 10"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<path d="m2 3.5 3 3 3-3" />
+					</svg>
+				</summary>
+				<ul
+					class="wd-version-switcher__list"
+					role="listbox"
+					aria-label="Switch documentation version"
+					tabindex={-1}
+				>
+					{options.map((option) => (
+						<li role="none">
+							<a
+								href={option.url}
+								role="option"
+								aria-selected={option.isCurrent ? 'true' : 'false'}
+								class:list={['wd-version-switcher__option', { 'is-current': option.isCurrent }]}
+								data-slug={option.slug}
+							>
+								<span class="wd-version-switcher__label">{option.label}</span>
+								<span
+									class:list={[
+										'wd-version-switcher__badge',
+										`wd-version-switcher__badge--${option.status}`,
+									]}
+								>
+									{statusLabel[option.status] ?? option.status}
+								</span>
+							</a>
+						</li>
+					))}
+				</ul>
+			</details>
+		</div>
+	)
+}
+
+<script>
+	// Progressive enhancement: upgrade <details>/<summary> to a real
+	// ARIA listbox with keyboard navigation. If JS fails or hasn't
+	// loaded yet, the <details> disclosure still opens/closes and the
+	// <a> elements still navigate.
+	for (const root of document.querySelectorAll<HTMLElement>('[data-wd-version-switcher]')) {
+		const details = root.querySelector<HTMLDetailsElement>('details');
+		const listbox = root.querySelector<HTMLElement>('[role="listbox"]');
+		const options = listbox
+			? Array.from(listbox.querySelectorAll<HTMLAnchorElement>('[role="option"]'))
+			: [];
+		if (!details || !listbox || options.length === 0) continue;
+
+		const current = options.findIndex((o) => o.getAttribute('aria-selected') === 'true');
+		let highlightedIndex = current >= 0 ? current : 0;
+
+		const highlight = (i: number) => {
+			highlightedIndex = (i + options.length) % options.length;
+			options.forEach((option, idx) => {
+				if (idx === highlightedIndex) {
+					option.setAttribute('tabindex', '0');
+					option.focus();
+				} else {
+					option.setAttribute('tabindex', '-1');
+				}
+			});
+		};
+
+		const close = (returnFocusToTrigger = true) => {
+			details.open = false;
+			if (returnFocusToTrigger) {
+				const summary = details.querySelector<HTMLElement>('summary');
+				summary?.focus();
+			}
+		};
+
+		details.addEventListener('toggle', () => {
+			if (details.open) {
+				// First option tab-stop opens the keyboard loop.
+				options.forEach((o, i) => o.setAttribute('tabindex', i === highlightedIndex ? '0' : '-1'));
+			}
+		});
+
+		listbox.addEventListener('keydown', (event) => {
+			switch (event.key) {
+				case 'ArrowDown':
+					event.preventDefault();
+					highlight(highlightedIndex + 1);
+					break;
+				case 'ArrowUp':
+					event.preventDefault();
+					highlight(highlightedIndex - 1);
+					break;
+				case 'Home':
+					event.preventDefault();
+					highlight(0);
+					break;
+				case 'End':
+					event.preventDefault();
+					highlight(options.length - 1);
+					break;
+				case 'Escape':
+					event.preventDefault();
+					close();
+					break;
+				case 'Enter':
+				case ' ': {
+					event.preventDefault();
+					const link = options[highlightedIndex];
+					if (link) window.location.href = link.href;
+					break;
+				}
+			}
+		});
+
+		// Click outside to close.
+		document.addEventListener('click', (event) => {
+			if (!details.open) return;
+			if (!(event.target instanceof Node)) return;
+			if (!root.contains(event.target)) details.open = false;
+		});
+	}
+</script>
+
+<style>
+	.wd-version-switcher {
+		position: relative;
+		display: inline-flex;
+		font-family: var(--font-sans);
+	}
+
+	.wd-version-switcher__details {
+		position: relative;
+	}
+
+	.wd-version-switcher__trigger {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: 4px 10px 4px 11px;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-pill);
+		background: var(--color-surface);
+		color: var(--color-fg);
+		font-size: var(--text-xs);
+		font-weight: 600;
+		cursor: pointer;
+		list-style: none;
+		transition:
+			border-color 0.15s,
+			background 0.15s;
+	}
+
+	.wd-version-switcher__trigger::-webkit-details-marker {
+		display: none;
+	}
+
+	.wd-version-switcher__trigger:hover {
+		border-color: var(--color-brand);
+		background: var(--color-brand-soft);
+	}
+
+	.wd-version-switcher__trigger:focus-visible {
+		outline: 2px solid var(--color-brand);
+		outline-offset: 2px;
+	}
+
+	.wd-version-switcher__details[open] .wd-version-switcher__caret {
+		transform: rotate(180deg);
+	}
+
+	.wd-version-switcher__caret {
+		color: var(--color-fg-muted);
+		transition: transform 0.15s;
+	}
+
+	.wd-version-switcher__list {
+		position: absolute;
+		top: calc(100% + 6px);
+		left: 0;
+		min-width: 220px;
+		margin: 0;
+		padding: 4px;
+		list-style: none;
+		background: var(--color-bg);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-lg);
+		box-shadow: var(--shadow-lg);
+		z-index: 60;
+	}
+
+	.wd-version-switcher__option {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-3);
+		padding: 6px 10px;
+		border-radius: var(--radius);
+		text-decoration: none;
+		font-size: var(--text-sm);
+		color: var(--color-fg);
+	}
+
+	.wd-version-switcher__option:hover,
+	.wd-version-switcher__option:focus {
+		background: var(--color-surface);
+		outline: none;
+		text-decoration: none;
+	}
+
+	.wd-version-switcher__option.is-current {
+		background: var(--color-brand-soft);
+		color: var(--color-brand-ink);
+		font-weight: 600;
+	}
+
+	.wd-version-switcher__badge {
+		display: inline-block;
+		padding: 1px 6px;
+		border-radius: 3px;
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		white-space: nowrap;
+		color: #fff;
+	}
+
+	.wd-version-switcher__badge--current {
+		background: var(--color-success);
+	}
+
+	.wd-version-switcher__badge--snapshot {
+		background: var(--color-warning);
+	}
+
+	.wd-version-switcher__badge--archived {
+		background: var(--color-fg-subtle);
+	}
+
+	@media (max-width: 720px) {
+		.wd-version-switcher {
+			display: none;
+		}
+	}
+</style>

--- a/web/packages/ui/src/data/versions.ts
+++ b/web/packages/ui/src/data/versions.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared version metadata for the Starlight sites (guides + api) and the
+ * VersionSwitcher component. Kept as a single source of truth so the
+ * sidebar in each site's astro.config.mjs and the header switcher don't
+ * drift apart.
+ *
+ * STATUS semantics:
+ *   - 'current'   → stable, recommended reading
+ *   - 'snapshot'  → pre-release / in-development
+ *   - 'archived'  → older major or minor release still served for continuity
+ */
+
+export type VersionStatus = 'current' | 'snapshot' | 'archived';
+
+export interface VersionMeta {
+	/** URL-safe slug (no dots — e.g. 'v3-0-0'). */
+	slug: string;
+	/** Human-facing label (e.g. 'v3.0.0'). */
+	label: string;
+	/** Default collapsed state in the sidebar. */
+	collapsed: boolean;
+	/** Release-channel indicator. */
+	status: VersionStatus;
+}
+
+/** Wheels Guides — the narrative docs at guides.wheels.dev. */
+export const GUIDES_VERSIONS: VersionMeta[] = [
+	{ slug: 'v4-0-0-snapshot', label: 'v4.0.0-SNAPSHOT', collapsed: false, status: 'snapshot' },
+	{ slug: 'v3-0-0', label: 'v3.0.0', collapsed: true, status: 'current' },
+	{ slug: 'v2-5-0', label: 'v2.5.0', collapsed: true, status: 'archived' },
+];
+
+/** Wheels API Reference — function-level docs at api.wheels.dev. */
+export const API_VERSIONS: VersionMeta[] = [
+	{ slug: 'v3-0-0', label: 'v3.0.0', collapsed: false, status: 'current' },
+	{ slug: 'v2-5-0', label: 'v2.5.0', collapsed: true, status: 'archived' },
+	{ slug: 'v2-4-0', label: 'v2.4.0', collapsed: true, status: 'archived' },
+	{ slug: 'v2-3-0', label: 'v2.3.0', collapsed: true, status: 'archived' },
+	{ slug: 'v2-2-0', label: 'v2.2.0', collapsed: true, status: 'archived' },
+	{ slug: 'v2-1-0', label: 'v2.1.0', collapsed: true, status: 'archived' },
+	{ slug: 'v2-0-0', label: 'v2.0.0', collapsed: true, status: 'archived' },
+	{ slug: 'v1-4-5', label: 'v1.4.5', collapsed: true, status: 'archived' },
+];
+
+/**
+ * Pick the version list for the site whose hostname is `hostname`.
+ * Returns an empty array for non-Starlight sites so the switcher
+ * renders no options and bails out quietly.
+ */
+export function versionsForHostname(hostname: string | undefined): VersionMeta[] {
+	if (!hostname) return [];
+	if (hostname.startsWith('guides')) return GUIDES_VERSIONS;
+	if (hostname.startsWith('api')) return API_VERSIONS;
+	return [];
+}
+
+/**
+ * Find the equivalent slug in a target version, given the current
+ * within-version path. Locked behavior per the Phase 3 spec:
+ *   1. Exact match in the target version → use it
+ *   2. Fuzzy match on the final 2 path segments → use it
+ *   3. Fuzzy match on the final 1 path segment → use it
+ *   4. No match → return null (caller should fall back to the target
+ *      version's root URL)
+ *
+ * `targetEntries` is the set of within-version paths present in the
+ * target version (one entry per generated page, without file extension).
+ */
+export function findEquivalentPath(
+	currentRelativePath: string,
+	targetEntries: Set<string>
+): string | null {
+	// Normalize: strip leading/trailing slashes.
+	const needle = currentRelativePath.replace(/^\/+|\/+$/g, '');
+	if (!needle) return null;
+
+	// 1. Exact match
+	if (targetEntries.has(needle)) return needle;
+
+	const segments = needle.split('/').filter(Boolean);
+
+	// 2. Fuzzy on final 2 segments
+	if (segments.length >= 2) {
+		const last2 = segments.slice(-2).join('/');
+		for (const entry of targetEntries) {
+			if (entry === last2 || entry.endsWith('/' + last2)) return entry;
+		}
+	}
+
+	// 3. Fuzzy on final 1 segment
+	const last1 = segments[segments.length - 1];
+	if (last1) {
+		for (const entry of targetEntries) {
+			if (entry === last1 || entry.endsWith('/' + last1)) return entry;
+		}
+	}
+
+	// 4. No match
+	return null;
+}


### PR DESCRIPTION
## Summary

Second slice of Phase 3 per the [locked spec](docs/superpowers/specs/2026-04-18-starlight-phase-3-design.md). Ships the header version switcher and the slug-equivalence routing that answers "take me to the same page in version X."

## What changed

**New `web/packages/ui/src/data/versions.ts`**
- Single source of truth for the guides + api version lists — each entry has slug, label, collapsed default, and status (`current` / `snapshot` / `archived`).
- `versionsForHostname()` picks the right list based on `Astro.site.hostname`.
- `findEquivalentPath()` implements the locked fallback behavior from the spec: exact match → fuzzy on last 2 path segments → fuzzy on last 1 segment → null (caller falls back to target version root).

**New `web/packages/ui/src/components/starlight/VersionSwitcher.astro`**
- Inline pill next to the wheels.dev wordmark. Shows the current version label with an always-visible status badge (colored by release channel).
- Dropdown list shows all versions with the same badges; current selection gets `--color-brand-soft` background + `--color-brand-ink` text.
- Progressive-enhancement base using native `<details>`/`<summary>` — the disclosure still opens and the links still navigate even if JS fails.
- With JS loaded, upgrades to a real ARIA listbox: `role="listbox"`, `role="option"`, arrow/home/end navigate, enter commits, escape closes, click-outside closes. Options get appropriate `aria-selected` and `tabindex` management.
- Slug equivalence is computed at build time via `getCollection('docs')`. Live example: switching to v2.5.0 from `/v4-0-0-snapshot/introduction/readme/beginner-tutorial-hello-world/` lands on `/v2-5-0/introduction/getting-started/beginner-tutorial-hello-world/` because v2.5.0 has a different path structure (`getting-started` vs `readme`) and the final-segment fuzzy match finds it. API example: `/v3-0-0/configuration/addformat/` → `/v1-4-5/miscellaneous/addformat/` (v1.4.5 reorganized Configuration functions into Miscellaneous).

**Header shape changes**
- `Header.astro` now has a `<slot name="after-brand">` inside a new `.wd-header__lockup` flex wrapper. Landing + blog don't fill it so they render unchanged.
- `starlight/Header.astro` populates the slot with `<VersionSwitcher />`. Switcher only renders on guides + api.

## Test plan

- [x] `pnpm build` — all four sites build clean (guides 444 pages ~8s, api 2352 pages ~80s)
- [x] `pnpm format:check` — passes
- [x] `astro check` on all four sites — 0 errors
- [x] Visual check on guides (`/v4-0-0-snapshot/introduction/readme/beginner-tutorial-hello-world/`): pill shows `v4.0.0-SNAPSHOT [SNAPSHOT]` (amber badge), dropdown opens, all 3 versions listed with correct badge colors, current version highlighted
- [x] Visual check on api (`/v3-0-0/configuration/addformat/`): pill shows `v3.0.0 [CURRENT]` (green), dropdown opens with all 8 versions, `v1.4.5` shows fuzzy-match URL at `/v1-4-5/miscellaneous/addformat/`
- [x] Listbox a11y: `role="listbox"` on `<ul>`, `role="option"` on `<a>`, `aria-selected` management, arrow-key navigation via keydown handler verified via eval
- [x] No console errors on either site
- [ ] Reviewer: try arrow-up / arrow-down / home / end / enter / escape in the open dropdown to confirm keyboard flow

## Known scope cuts for follow-ups

- **Mobile variant (fold into hamburger drawer).** Spec locked this as Slice 2 scope but implementing it cleanly means adding a second named slot to `Header.astro` mobile drawer and a drawer-variant render in `VersionSwitcher.astro`. Current behavior: pill hides at `<720px`. Users on mobile still have sidebar version navigation on overview pages. Tracked as a follow-up.
- **Fuzzy-match strategy lives client-side on first render** — future enhancement could precompute the map at build time into a smaller client payload.

## Next

- Slice 3 — visual-regression screenshot test in CI (unchanged from spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)