### PR TITLE
ci(web): promote visual regression to hard gate

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -68,9 +68,12 @@ jobs:
 
   visual-regression:
     name: Visual regression
-    # Soft-fail phase: don't block merges while baselines stabilize.
-    # Drop continue-on-error once the check is trusted as a hard gate.
-    continue-on-error: true
+    # Hard gate as of 2026-04. Baselines soaked through the initial
+    # Phase 3 rollout (#2158, #2159, #2160, #2161, #2162). If this job
+    # fails on your PR and the change is intentional, download the
+    # `visual-regression-diffs` artifact and copy each `*.actual.png`
+    # over the matching `web/tests/visual-baselines/*.png`, commit,
+    # and push.
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/web/scripts/visual-regression.mjs
+++ b/web/scripts/visual-regression.mjs
@@ -268,8 +268,21 @@ async function runCheck({ update, siteFilter }) {
 
 	if (anyFailed) {
 		console.error('\nVisual regression failures detected.');
-		console.error('If the changes are intentional, refresh baselines:');
-		console.error('  pnpm visual:baseline');
+		console.error('');
+		if (process.env.CI) {
+			console.error('Next steps:');
+			console.error('  1. Download the `visual-regression-diffs` artifact from this CI run.');
+			console.error('  2. Inspect the *.diff.png images to see what changed.');
+			console.error('  3. If the change is intentional: copy each *.actual.png over the matching');
+			console.error('     web/tests/visual-baselines/*.png, commit, and push.');
+			console.error('  4. If the change is unintentional: debug the regression on the PR branch.');
+		} else {
+			console.error('If the changes are intentional, refresh baselines:');
+			console.error('  pnpm visual:baseline');
+			console.error('');
+			console.error('Note: baselines are CI-captured (Linux font rendering). Local refreshes');
+			console.error('may still diff against CI — prefer pulling the CI artifact for final baselines.');
+		}
 		process.exit(1);
 	}
 	console.log('\nAll visual checks passed.');


### PR DESCRIPTION
## Summary

Final Phase 3 follow-up: drops `continue-on-error: true` from the visual-regression job so future pixel diffs block merges instead of quietly producing warnings.

## Why now

Baselines have soaked through every Phase 3 PR without a false positive:

| PR | Check result | Notes |
|----|--------------|-------|
| [#2161](https://github.com/wheels-dev/wheels/pull/2161) | pass (after first-run baseline capture from CI artifact) | Initial landing/blog/guides/api baselines |
| [#2158](https://github.com/wheels-dev/wheels/pull/2158) | n/a (pre-dated the job) | — |
| [#2159](https://github.com/wheels-dev/wheels/pull/2159) | pass | VersionSwitcher desktop — no canary page change |
| [#2160](https://github.com/wheels-dev/wheels/pull/2160) | pass | Mobile drawer — no desktop canary change |
| [#2162](https://github.com/wheels-dev/wheels/pull/2162) | pass (after refresh) | Canary text changed; baseline correctly flagged, refreshed from artifact, re-pushed |

The check fires exactly when content changes and has a documented recovery path. Time to make it a real gate.

## What changed

- **`.github/workflows/web-deploy.yml`** — removes `continue-on-error: true` from the `visual-regression` job. Inline comment now documents the baseline-refresh workflow for future PR authors.
- **`web/scripts/visual-regression.mjs`** — failure output branches on `$CI`:
  - In CI: step-by-step instructions for downloading the diff artifact, inspecting the `*.diff.png`, and copying `*.actual.png` files as new baselines.
  - Locally: hints toward `pnpm visual:baseline` plus a note that local macOS-captured baselines may still diff against Linux CI font rendering.

## Test plan

- [x] `pnpm format:check` — passes
- [x] Diff reviewed — only the two files above touched
- [ ] CI run on this PR passes (validates the hardened job still works on a no-op visual change)

## Reverting

If hardening turns out to be premature, adding back the `continue-on-error: true` line restores soft-fail behavior without any other changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)