### PR TITLE
ci(web): generate and deploy v4.0.0 snapshot api docs on develop

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -165,6 +165,31 @@ jobs:
           path: /tmp/junit-results/
           if-no-files-found: warn
 
+      - name: Generate API docs JSON (snapshot)
+        run: |
+          mkdir -p docs/api
+          VERSION=$(jq -r '.version' box.json)
+          # Lowercase "-snapshot" matches the URL slug convention used by
+          # web/scripts/generate-api-docs.mjs (version.replace(/\./g, '-')).
+          SNAPSHOT_FILE="docs/api/v${VERSION}-snapshot.json"
+          curl -sf --max-time 60 \
+            "http://localhost:60007/wheels/api?format=json&type=core" \
+            -o "$SNAPSHOT_FILE"
+          if ! jq -e '.functions and .sections' "$SNAPSHOT_FILE" > /dev/null 2>&1; then
+            echo "::error::API docs JSON invalid or empty"
+            head -c 500 "$SNAPSHOT_FILE" || true
+            exit 1
+          fi
+          echo "Generated $SNAPSHOT_FILE ($(wc -c < "$SNAPSHOT_FILE") bytes)"
+
+      - name: Upload API docs snapshot
+        uses: actions/upload-artifact@v6
+        with:
+          name: api-docs-snapshot
+          path: docs/api/v*-snapshot.json
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Debug server logs
         if: failure()
         run: cat /tmp/lucli-server.log 2>/dev/null || true
@@ -187,6 +212,69 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       FORGEBOX_API_TOKEN: ${{ secrets.FORGEBOX_API_TOKEN }}
       FORGEBOX_PASS: ${{ secrets.FORGEBOX_PASS }}
+
+  #############################################
+  # Deploy API docs snapshot to Cloudflare Pages
+  #############################################
+  # Regenerates the v{version}-snapshot markdown from the JSON produced by
+  # fast-test, builds the Starlight api site, and deploys to the wheels-api
+  # Cloudflare Pages project. Runs on every develop push so the snapshot
+  # version on api.wheels.dev tracks the current framework state.
+  deploy-api-snapshot:
+    needs: fast-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    concurrency:
+      group: deploy-api-snapshot-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download API docs snapshot artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: api-docs-snapshot
+          path: docs/api/
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: web
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate snapshot markdown from JSON
+        run: |
+          VERSION=$(jq -r '.version' box.json)
+          node web/scripts/generate-api-docs.mjs "${VERSION}-snapshot"
+
+      - name: Build api site
+        working-directory: web
+        run: pnpm --filter @wheels-dev/site-api build
+
+      - name: Deploy to Cloudflare Pages
+        working-directory: web
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DEPLOY_BRANCH: ${{ github.ref_name }}
+        run: |
+          pnpm dlx wrangler@4.78.0 pages deploy "sites/api/dist" \
+            --project-name="wheels-api" \
+            --branch="${DEPLOY_BRANCH}" \
+            --commit-hash="${GITHUB_SHA}"
 
   #############################################
   # Sync Docs in Wheels.dev

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ web/tests/visual-diffs/
 
 # Local wrangler state (from local runs of wrangler pages deploy)
 .wrangler/
+
+# API docs snapshot artifacts — generated fresh from the running Wheels server
+# on every develop CI run, then used to build the api site. Never committed.
+/docs/api/v*-snapshot.json
+/web/sites/api/src/content/docs/v*-snapshot/

--- a/web/sites/api/astro.config.mjs
+++ b/web/sites/api/astro.config.mjs
@@ -1,7 +1,22 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const contentRoot = resolve(__dirname, 'src/content/docs');
+
+// Snapshot content is generated in CI from the running Wheels server and is
+// NOT committed. Include it in the sidebar only when the directory actually
+// exists, so local `pnpm build` without a prior generate step still succeeds.
+const snapshotSlug = 'v4-0-0-snapshot';
+const hasSnapshot = existsSync(resolve(contentRoot, snapshotSlug));
 
 const versions = [
+	...(hasSnapshot
+		? [{ slug: snapshotSlug, label: 'v4.0.0 (snapshot)', collapsed: true }]
+		: []),
 	{ slug: 'v3-0-0', label: 'v3.0.0 (current)', collapsed: false },
 	{ slug: 'v2-5-0', label: 'v2.5.0', collapsed: true },
 	{ slug: 'v2-4-0', label: 'v2.4.0', collapsed: true },


### PR DESCRIPTION
## Summary

- Added `/wheels/api?format=json&type=core` curl step to the `fast-test` job in `snapshot.yml` — produces `docs/api/v4.0.0-snapshot.json` from the running LuCLI server on every develop push and uploads it as an artifact.
- New `deploy-api-snapshot` job downloads the artifact, runs `web/scripts/generate-api-docs.mjs 4.0.0-snapshot` to regenerate markdown under `web/sites/api/src/content/docs/v4-0-0-snapshot/`, builds the Starlight api site, and deploys to the `wheels-api` Cloudflare Pages project (branch `develop` → `api.wheels.dev`).
- `web/sites/api/astro.config.mjs` now lists `v4.0.0 (snapshot)` in the sidebar, guarded by an `existsSync` check so local builds and web-only CI runs (which don't regenerate the snapshot content) still succeed.
- Snapshot JSON and generated content dir are gitignored — regenerated fresh every CI run, never committed.

## Why

The 4.0 snapshot version of the API reference has been missing from `api.wheels.dev`: the framework app exposes a runtime introspection endpoint for its public controller/model/mapper/migrator functions, but nothing was wiring it into the static-site build. This closes the loop.

## Test plan

- [ ] Merge lands → next push to `develop` triggers `snapshot.yml`
- [ ] `fast-test` job's "Generate API docs JSON (snapshot)" step succeeds and uploads `api-docs-snapshot` artifact
- [ ] `deploy-api-snapshot` job runs the generator, builds `@wheels-dev/site-api`, and deploys via wrangler without error
- [ ] `api.wheels.dev` sidebar shows `v4.0.0 (snapshot)` entry
- [ ] Clicking into it renders function pages sourced from current develop-branch framework code

## Unresolved

- When `develop` is promoted to `main` post-4.0, the `DEPLOY_BRANCH` in `deploy-api-snapshot` and in `web-deploy.yml` will both need revisiting — this PR does not address that transition.
- `docs-sync.yml` (syncs to the retired `wheels-dev/wheels.dev` repo) is still wired up via the `sync-docs` job in `snapshot.yml`. Separate cleanup recommended once the retirement is formalized.
- Race condition possible between `web-deploy.yml` (pure web changes) and `deploy-api-snapshot` on commits that touch both — both target the `wheels-api` project; last write wins. If ordering becomes a problem, removing `api` from `web-deploy.yml`'s matrix and owning it solely from `snapshot.yml` resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)