### PR TITLE
commit: fix for issue #2166

### DIFF
--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -1828,8 +1828,14 @@ component output="false" {
 				Throw(type = "Wheels.InvalidTimeStampMode", message = "Timestamp mode #arguments.timeStampMode# is invalid");
 		}
 
+		// Ensure adapterName is set (may not be if no model has been called yet)
+		if (!StructKeyExists(application[$appKey()], "adapterName")) {
+			local.dbType = $getDBType();
+			$set(adapterName = "#local.dbType#Model");
+		}
+
 		// Handle SQLite (TEXT storage)
-		if (get("adapterName") == "SQLiteModel") {
+		if ($get("adapterName") == "SQLiteModel") {
 			// Store as quoted ISO 8601 string (standard for SQLite)
 			if (IsDate(local.rv)) {
 				local.rv = "'#DateFormat(local.rv, 'yyyy-mm-dd')# #TimeFormat(local.rv, 'HH:mm:ss')#'";


### PR DESCRIPTION
## Summary:
Running database migrations that include data operations (insert, update, delete) was causing an error when the application was started: key [adapterName] doesn't exist.
This happened because adapterName was not always initialized during migrations, especially when no model had been called before.

## Changes:
- Added a check to ensure adapterName is set before using it.
- If missing, it is now initialized using the database type ($getDBType()).
- This prevents errors when running migrations that perform data operations.