### PR TITLE
Framework gap fixes: batch 1 — scaffold, routing, forms, cli polish

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -2290,7 +2290,7 @@ component extends="modules.BaseModule" {
 		var serverPort = detectServerPort();
 		if (!serverPort) {
 			out("No running Wheels server detected.", "red");
-			out("Migrations require a running server. Start with: wheels server start");
+			out("Migrations require a running server. Start with: wheels start");
 			return "";
 		}
 
@@ -2337,7 +2337,7 @@ component extends="modules.BaseModule" {
 		var serverPort = detectServerPort();
 		if (!serverPort) {
 			out("No running Wheels server detected.", "red");
-			out("Seeding requires a running server. Start with: wheels server start");
+			out("Seeding requires a running server. Start with: wheels start");
 			return "";
 		}
 
@@ -2952,7 +2952,7 @@ component extends="modules.BaseModule" {
 		out("");
 		out("Next steps:", "bold");
 		out("  cd #appName#");
-		out("  wheels server start");
+		out("  wheels start");
 		return "";
 	}
 

--- a/cli/lucli/templates/app/app/jobs/README.md
+++ b/cli/lucli/templates/app/app/jobs/README.md
@@ -1,0 +1,51 @@
+# app/jobs/
+
+Background jobs. Each job is a `.cfc` extending `wheels.Job`.
+
+## Quick start
+
+Define a job:
+
+```cfm
+// app/jobs/SendWelcomeEmailJob.cfc
+component extends="wheels.Job" {
+    function config() {
+        super.config();
+        this.queue = "mailers";
+        this.maxRetries = 5;
+    }
+
+    public void function perform(struct data = {}) {
+        sendEmail(to=arguments.data.email, subject="Welcome!", from="app@example.com");
+    }
+}
+```
+
+Enqueue from a controller:
+
+```cfm
+var job = new app.jobs.SendWelcomeEmailJob();
+job.enqueue(data={email: user.email});           // immediate
+job.enqueueIn(seconds=300, data={email: "..."}); // delayed 5 minutes
+```
+
+## Running jobs
+
+Jobs persist to a `wheels_jobs` table and are dequeued by a worker process:
+
+```bash
+wheels jobs work                          # process all queues
+wheels jobs work --queue=mailers          # specific queue
+wheels jobs status                        # per-queue breakdown
+```
+
+## Requirements
+
+The first job enqueued needs the job table. Generate and run the migration:
+
+```bash
+wheels generate migration create_wheels_jobs_table
+wheels migrate latest
+```
+
+See [Background Jobs](https://wheels.dev/v4-0-0-snapshot/digging-deeper/) in the guides for retries, backoff, priority queues, and the monitoring dashboard.

--- a/cli/lucli/templates/app/app/lib/README.md
+++ b/cli/lucli/templates/app/app/lib/README.md
@@ -1,0 +1,35 @@
+# app/lib/
+
+App-specific utility code. Plain CFCs, no framework conventions required.
+
+Use this directory for:
+
+- Domain logic that doesn't belong on a model or controller
+- Service objects orchestrating multiple models
+- Value objects, calculators, formatters
+- Integration clients (third-party API wrappers)
+- Anything shared across controllers
+
+## Auto-discovery
+
+Wheels maps components under `app/lib/` to the `app.lib` path automatically. Create `app/lib/PriceCalculator.cfc` and reference it as:
+
+```cfm
+var calc = createObject("component", "app.lib.PriceCalculator").init();
+```
+
+Or register it with the DI container in `config/services.cfm`:
+
+```cfm
+injector().map("priceCalculator").to("app.lib.PriceCalculator").asSingleton();
+```
+
+Then resolve anywhere with `service("priceCalculator")`.
+
+## When to reach elsewhere
+
+- **Model behavior** → `app/models/`
+- **Request handling** → `app/controllers/`
+- **Background work** → `app/jobs/`
+- **Email** → `app/mailers/`
+- **Cross-app reusable feature** → create a package in `vendor/<name>/`

--- a/cli/lucli/templates/app/app/mailers/README.md
+++ b/cli/lucli/templates/app/app/mailers/README.md
@@ -1,0 +1,34 @@
+# app/mailers/
+
+Components that send email. Each mailer is a `.cfc` extending `Mailer`.
+
+## Quick start
+
+Generate one:
+
+```bash
+wheels generate mailer WelcomeMailer welcome
+```
+
+Creates:
+- `app/mailers/WelcomeMailer.cfc` — the mailer definition
+- `app/views/welcomemailer/welcome.cfm` — the email body template
+
+A mailer action sets headers (`this.from`, `this.to`, `this.subject`) and hands rendering to the matching view.
+
+Send from a controller with `sendMail(mailer="WelcomeMailer", method="welcome", user=user)`.
+
+## Configuration
+
+SMTP settings live in `config/settings.cfm`:
+
+```cfm
+set(mailerSettings = {
+    server: "smtp.example.com",
+    port: 587,
+    username: "you@example.com",
+    password: application.wo.env("SMTP_PASSWORD")
+});
+```
+
+See [Sending Email](https://wheels.dev/v4-0-0-snapshot/digging-deeper/sending-email/) in the guides for the full walkthrough.

--- a/cli/lucli/templates/app/app/plugins/README.md
+++ b/cli/lucli/templates/app/app/plugins/README.md
@@ -1,0 +1,26 @@
+# app/plugins/
+
+**Legacy plugin drop-in (deprecated in v4.0).**
+
+Wheels 3.x used this directory for the plugin system. For v4.0 and beyond, plugins have been replaced by **packages** under `vendor/`.
+
+## What to use instead
+
+Copy a package from `packages/<name>` into `vendor/<name>` to activate it. Example:
+
+```bash
+cp -r packages/hotwire vendor/hotwire
+wheels reload
+```
+
+See [Packages](https://wheels.dev/v4-0-0-snapshot/digging-deeper/) in the guides for details.
+
+## Migrating from a 3.x plugin
+
+If you have an existing plugin here from a 3.x upgrade:
+
+1. Read the plugin's code — many can be moved into `app/lib/` as regular CFCs.
+2. If it provides middleware, migrate to the middleware pipeline (`config/settings.cfm` → `set(middleware = [...])`).
+3. If it provides cross-cutting mixins (controller/model/view), wrap it as a package with a `package.json` declaring `provides.mixins`.
+
+Plugins still load during app boot, so existing code keeps working — this directory stays functional. New code should go under `app/lib/` or a package under `vendor/`.

--- a/cli/lucli/templates/app/app/snippets/ActionContent.txt
+++ b/cli/lucli/templates/app/app/snippets/ActionContent.txt
@@ -1,0 +1,7 @@
+
+	/**
+	* |ActionHint| Action
+	**/
+	function |Action|() {
+
+	}

--- a/cli/lucli/templates/app/app/snippets/ApiControllerContent.txt
+++ b/cli/lucli/templates/app/app/snippets/ApiControllerContent.txt
@@ -1,0 +1,87 @@
+|DescriptionComment|component extends="wheels.Controller" {
+
+    function config() {
+        provides("json");
+				filters(through="setJsonResponse");
+    }
+
+    /**
+     * GET /#objectNamePlural#
+     * Returns a list of all #objectNamePlural#
+     */
+    function index() {
+        local.#objectNamePlural# = model("|ObjectNameSingular|").findAll();
+        renderWith(data={ #objectNamePlural#=local.#objectNamePlural# });
+    }
+
+    /**
+     * GET /#objectNamePlural#/:key
+     * Returns a specific #objectNameSingular# by ID
+     */
+    function show() {
+        local.#objectNameSingular# = model("|ObjectNameSingular|").findByKey(params.key);
+
+        if (IsObject(local.#objectNameSingular#)) {
+            renderWith(data={ #objectNameSingular#=local.#objectNameSingular# });
+        } else {
+            renderWith(data={ error="Record not found" }, status=404);
+        }
+    }
+
+    /**
+     * POST /#objectNamePlural#
+     * Creates a new #objectNameSingular#
+     */
+    function create() {
+        local.#objectNameSingular# = model("|ObjectNameSingular|").new(params.#objectNameSingular#);
+
+        if (local.#objectNameSingular#.save()) {
+            renderWith(data={ #objectNameSingular#=local.#objectNameSingular# }, status=201);
+        } else {
+            renderWith(data={ error="Validation failed", errors=local.#objectNameSingular#.allErrors() }, status=422);
+        }
+    }
+
+    /**
+     * PUT /#objectNamePlural#/:key
+     * Updates an existing #objectNameSingular#
+     */
+    function update() {
+        local.#objectNameSingular# = model("|ObjectNameSingular|").findByKey(params.key);
+
+        if (IsObject(local.#objectNameSingular#)) {
+            local.#objectNameSingular#.update(params.#objectNameSingular#);
+
+            if (local.#objectNameSingular#.hasErrors()) {
+                renderWith(data={ error="Validation failed", errors=local.#objectNameSingular#.allErrors() }, status=422);
+            } else {
+                renderWith(data={ #objectNameSingular#=local.#objectNameSingular# });
+            }
+        } else {
+            renderWith(data={ error="Record not found" }, status=404);
+        }
+    }
+
+    /**
+     * DELETE /#objectNamePlural#/:key
+     * Deletes a #objectNameSingular#
+     */
+    function delete() {
+        local.#objectNameSingular# = model("|ObjectNameSingular|").findByKey(params.key);
+
+        if (IsObject(local.#objectNameSingular#)) {
+            local.#objectNameSingular#.delete();
+            renderWith(data={}, status=204);
+        } else {
+            renderWith(data={ error="Record not found" }, status=404);
+        }
+    }
+
+		/**
+		* Set Response to JSON
+		*/
+		private function setJsonResponse() {
+			params.format = "json";
+		}
+
+}

--- a/cli/lucli/templates/app/app/snippets/BoxJSON.txt
+++ b/cli/lucli/templates/app/app/snippets/BoxJSON.txt
@@ -1,0 +1,48 @@
+{
+    "name":"|appName|",
+    "version":"1.0.0",
+    "author":"Wheels Core Team and Community, repackaged by Peter Amiri",
+    "shortDescription":"Wheels MVC Framework Base Template",
+    "location":"",
+    "slug":"|appName|",
+    "createPackageDirectory":false,
+    "type":"wheels-templates",
+    "keywords":[
+        "mvc",
+        "rails",
+        "wheels",
+        "wheels",
+        "core"
+    ],
+    "homepage":"https://wheels.dev/",
+    "documentation":"https://docs.wheels.dev/",
+    "repository":{
+        "type":"git",
+        "URL":"https://github.com/wheels-dev/wheels"
+    },
+    "bugs":"https://github.com/wheels-dev/wheels/issues",
+    "contributors":[
+        "Peter Amiri <peter@alurium.com>"
+    ],
+    "ignore":[],
+    "devDependencies":{
+        "commandbox-dotenv":"*",
+        "commandbox-cfconfig":"*",
+        "commandbox-cfformat":"*"
+    },
+    "installPaths":{
+        "wheels":"wheels/"
+    },
+    "dependencies":{
+        "wheels":"|version|",
+        "orgh213172lex":"lex:https://ext.lucee.org/org.lucee.h2-2.1.214.0001L.lex"
+    },
+    "private":false,
+    "license":[
+        {
+            "type":"Apache License 2.0",
+            "URL":"https://github.com/wheels-dev/wheels/blob/master/LICENSE"
+        }
+    ],
+    "scripts":{}
+}

--- a/cli/lucli/templates/app/app/snippets/CRUDContent.txt
+++ b/cli/lucli/templates/app/app/snippets/CRUDContent.txt
@@ -1,0 +1,74 @@
+|DescriptionComment|component extends="Controller" {
+
+	function config() {
+		verifies(except="index,new,create", params="key", paramsTypes="integer", handler="objectNotFound");
+	}
+
+	/**
+	* View all |ObjectNamePluralC|
+	**/
+	function index() {
+		|ObjectNamePlural|=model("|ObjectNameSingular|").findAll();
+	}
+
+	/**
+	* View |ObjectNameSingularC|
+	**/
+	function show() {
+		|ObjectNameSingular|=model("|ObjectNameSingular|").findByKey(params.key);
+	}
+
+	/**
+	* Add New |ObjectNameSingularC|
+	**/
+	function new() {
+		|ObjectNameSingular|=model("|ObjectNameSingular|").new();
+	}
+
+	/**
+	* Create |ObjectNameSingularC|
+	**/
+	function create() {
+		|ObjectNameSingular|=model("|ObjectNameSingular|").create(params.|ObjectNameSingular|);
+		if(|ObjectNameSingular|.hasErrors()){
+			renderView(action="new");
+		} else {
+			redirectTo(action="index", success="|ObjectNameSingularC| successfully created");
+		}
+	}
+
+	/**
+	* Edit |ObjectNameSingularC|
+	**/
+	function edit() {
+		|ObjectNameSingular|=model("|ObjectNameSingular|").findByKey(params.key);
+	}
+
+	/**
+	* Update |ObjectNameSingularC|
+	**/
+	function update() {
+		|ObjectNameSingular|=model("|ObjectNameSingular|").findByKey(params.key);
+		if(|ObjectNameSingular|.update(params.|ObjectNameSingular|)){
+			redirectTo(action="index", success="|ObjectNameSingularC| successfully updated");
+		} else {
+			renderView(action="edit");
+		}
+	}
+
+	/**
+	* Delete |ObjectNameSingularC|
+	**/
+	function delete() {
+		|ObjectNameSingular|=model("|ObjectNameSingular|").deleteByKey(params.key);
+		redirectTo(action="index", success="|ObjectNameSingularC| successfully deleted");
+	}
+
+	/**
+	* Redirect away if verifies fails, or if an object can't be found
+	**/
+	function objectNotFound() {
+		redirectTo(action="index", error="That |ObjectNameSingularC| wasn't found");
+	}
+
+}

--- a/cli/lucli/templates/app/app/snippets/ConfigAppContent.txt
+++ b/cli/lucli/templates/app/app/snippets/ConfigAppContent.txt
@@ -1,0 +1,13 @@
+<cfscript>
+	/*
+		Place settings that should go in the Application.cfc's "this" scope here.
+
+		Examples:
+		this.name = "MyAppName";
+		this.sessionTimeout = CreateTimeSpan(0,0,5,0);
+	*/
+
+	// Added via Wheels CLI
+	this.name = "|appName|";
+	// CLI-Appends-Here
+</cfscript>

--- a/cli/lucli/templates/app/app/snippets/ConfigDataSourceH2Content.txt
+++ b/cli/lucli/templates/app/app/snippets/ConfigDataSourceH2Content.txt
@@ -1,0 +1,23 @@
+<cfscript>
+	/*
+		If you leave these settings commented out, Wheels will set the data source name to the same name as the folder the application resides in.
+	*/
+
+	// set(dataSourceName="");
+	// set(dataSourceUserName="");
+	// set(dataSourcePassword="");
+
+	/*
+		If you leave this setting commented out, Wheels will try to determine the URL rewrite capabilities automatically.
+		The "URLRewriting" setting can bet set to "on", "partial" or "off".
+		To run with "partial" rewriting, the "cgi.path_info" variable needs to be supported by the web server.
+		To run with rewriting set to "on", you need to apply the necessary rewrite rules on the web server first.
+	*/
+
+	// Added via Wheels CLI
+	set(dataSourceName="|datasourceName|");
+	set(URLRewriting="On");
+	// Reload your application with ?reload=true&password=|reloadPassword|
+	set(reloadPassword="|reloadPassword|");
+	// CLI-Appends-Here
+</cfscript>

--- a/cli/lucli/templates/app/app/snippets/ConfigReloadPasswordContent.txt
+++ b/cli/lucli/templates/app/app/snippets/ConfigReloadPasswordContent.txt
@@ -1,0 +1,23 @@
+<cfscript>
+	/*
+		If you leave these settings commented out, Wheels will set the data source name to the same name as the folder the application resides in.
+	*/
+
+	// set(dataSourceName="");
+	// set(dataSourceUserName="");
+	// set(dataSourcePassword="");
+
+	/*
+		If you leave this setting commented out, Wheels will try to determine the URL rewrite capabilities automatically.
+		The "URLRewriting" setting can bet set to "on", "partial" or "off".
+		To run with "partial" rewriting, the "cgi.path_info" variable needs to be supported by the web server.
+		To run with rewriting set to "on", you need to apply the necessary rewrite rules on the web server first.
+	*/
+
+	// Added via Wheels CLI
+	set(dataSourceName="|datasourceName|");
+	set(URLRewriting="On");
+	// Reload your application with ?reload=true&password=|reloadPassword|
+	set(reloadPassword="|reloadPassword|");
+	// CLI-Appends-Here
+</cfscript>

--- a/cli/lucli/templates/app/app/snippets/ConfigRoutes.txt
+++ b/cli/lucli/templates/app/app/snippets/ConfigRoutes.txt
@@ -1,0 +1,18 @@
+<cfscript>
+
+	// Use this file to add routes to your application and point the root route to a controller action.
+	// Don't forget to issue a reload request (e.g. reload=true) after making changes.
+	// See https://guides.wheels.dev/docs/routing for more info.
+
+	mapper()
+		// CLI-Appends-Here
+		// The "wildcard" call below enables automatic mapping of "controller/action" type routes.
+		// This way you don't need to explicitly add a route every time you create a new action in a controller.
+		.wildcard()
+
+		// The root route below is the one that will be called on your application's home page (e.g. http://127.0.0.1/).
+		// You can, for example, change "wheels##wheels" to "home##index" to call the "index" action on the "home" controller instead.
+		.root(to="wheels##wheels", method="get")
+	.end();
+
+</cfscript>

--- a/cli/lucli/templates/app/app/snippets/ControllerContent.txt
+++ b/cli/lucli/templates/app/app/snippets/ControllerContent.txt
@@ -1,0 +1,10 @@
+|DescriptionComment|component extends="Controller" {
+
+  /**
+	* Controller config settings
+	**/
+	function config() {
+
+	}
+|Actions|
+}

--- a/cli/lucli/templates/app/app/snippets/DBMigrate.txt
+++ b/cli/lucli/templates/app/app/snippets/DBMigrate.txt
@@ -1,0 +1,37 @@
+component extends="wheels.migrator.Migration" hint="|DBMigrateHINT|" {
+
+	function up() {
+		transaction {
+			try {
+				|DBMigrateUP|
+			} catch (any e) {
+				local.exception = e;
+			}
+
+			if (StructKeyExists(local, "exception")) {
+				transaction action="rollback";
+				throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");
+			} else {
+				transaction action="commit";
+			}
+		}
+	}
+
+	function down() {
+		transaction {
+		  try {
+				|DBMigrateDOWN|
+			} catch (any e) {
+				local.exception = e;
+			}
+
+			if (StructKeyExists(local, "exception")) {
+				transaction action="rollback";
+				throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");
+			} else {
+				transaction action="commit";
+			}
+		}
+	}
+
+}

--- a/cli/lucli/templates/app/app/snippets/ModelContent.txt
+++ b/cli/lucli/templates/app/app/snippets/ModelContent.txt
@@ -1,0 +1,10 @@
+|DescriptionComment|component extends="Model" {
+
+	function config() {
+		|TableName|
+		{{belongsToRelationships}}
+		{{hasManyRelationships}}
+		{{hasOneRelationships}}
+	}
+
+}

--- a/cli/lucli/templates/app/app/snippets/README.md
+++ b/cli/lucli/templates/app/app/snippets/README.md
@@ -1,0 +1,27 @@
+# app/snippets/
+
+Template overrides for `wheels generate`.
+
+The generators (`wheels generate model`, `controller`, `scaffold`, `migration`, `mailer`, etc.) emit files built from `.txt` templates. When a template exists in this directory, it overrides the framework default. When it doesn't, the generator falls back to the bundled template.
+
+## Customizing a template
+
+1. Find the framework's version of the template you want to override in `vendor/wheels/` or the generator source.
+2. Copy it into this directory with the same filename.
+3. Edit to taste.
+
+Next run of `wheels generate` picks up your override.
+
+## Common template files
+
+- `ModelContent.txt` — the body of a generated model
+- `ControllerContent.txt` — the body of a generated controller
+- `CRUDContent.txt` — the full scaffold controller
+- `ActionContent.txt` — a single action stub
+- `ConfigAppContent.txt` — `config/app.cfm` body
+- `BoxJSON.txt` — `box.json` seed
+
+## Notes
+
+- Overrides are per-app. They ship with your app's repository — treat them as code.
+- Overrides don't extend the generator surface. If you want a new generator command, extend the CLI instead.

--- a/cli/lucli/templates/app/app/snippets/ServerJSON.txt
+++ b/cli/lucli/templates/app/app/snippets/ServerJSON.txt
@@ -1,0 +1,16 @@
+{
+    "name": "|appName|",
+    "web": {
+        "host":"localhost",
+        "webroot": "public",
+        "rewrites": {
+            "enable": true,
+            "config": "public/urlrewrite.xml"
+        }
+    },
+    "app": {
+        "cfengine": "|setEngine|",
+        "serverHomeDirectory": ".wheels/server",
+        "libDirs":"app/lib"
+    }
+}

--- a/cli/lucli/templates/app/app/snippets/ViewContent.txt
+++ b/cli/lucli/templates/app/app/snippets/ViewContent.txt
@@ -1,0 +1,3 @@
+<cfoutput>
+<!--- CLI-Appends-Here --->
+</cfoutput>

--- a/cli/lucli/templates/app/app/snippets/WheelsBoxJSON.txt
+++ b/cli/lucli/templates/app/app/snippets/WheelsBoxJSON.txt
@@ -1,0 +1,5 @@
+{
+    "VERSION":"|version|",
+    "SLUG":"wheels",
+    "TYPE":"mvc"
+}

--- a/cli/lucli/templates/app/app/snippets/mcp-server.js.txt
+++ b/cli/lucli/templates/app/app/snippets/mcp-server.js.txt
@@ -1,0 +1,481 @@
+#!/usr/bin/env node
+
+/**
+ * MCP Server for Wheels Framework
+ *
+ * This server provides documentation and tools for Wheels framework
+ * to AI coding assistants via the Model Context Protocol (MCP)
+ */
+
+const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
+const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
+const {
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
+} = require('@modelcontextprotocol/sdk/types.js');
+
+const http = require('http');
+const { exec } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+class WheelsMCPServer {
+  constructor() {
+    this.server = new Server(
+      {
+        name: 'wheels-mcp-server',
+        version: '1.0.0',
+      },
+      {
+        capabilities: {
+          resources: {},
+          tools: {},
+          prompts: {},
+        },
+      }
+    );
+
+    this.projectPath = process.env.WHEELS_PROJECT_PATH || process.cwd();
+    this.devServerUrl = process.env.WHEELS_DEV_SERVER || 'http://localhost:{{PORT}}';
+
+    this.setupHandlers();
+  }
+
+  setupHandlers() {
+    // Resources handler
+    this.server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+      resources: [
+        {
+          uri: 'wheels://api/documentation',
+          name: 'Wheels API Documentation',
+          description: 'Complete API documentation for all Wheels functions',
+          mimeType: 'application/json',
+        },
+        {
+          uri: 'wheels://guides/all',
+          name: 'Wheels Guides',
+          description: 'All Wheels framework guides and tutorials',
+          mimeType: 'application/json',
+        },
+        {
+          uri: 'wheels://project/context',
+          name: 'Project Context',
+          description: 'Current project structure, models, controllers, and configuration',
+          mimeType: 'application/json',
+        },
+        {
+          uri: 'wheels://patterns/common',
+          name: 'Common Patterns',
+          description: 'Common Wheels patterns and best practices',
+          mimeType: 'application/json',
+        },
+      ],
+    }));
+
+    // Read resource handler
+    this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+      const { uri } = request.params;
+
+      switch (uri) {
+        case 'wheels://api/documentation':
+          return {
+            contents: [
+              {
+                uri,
+                mimeType: 'application/json',
+                text: await this.fetchFromDevServer('/wheels/ai?context=all'),
+              },
+            ],
+          };
+
+        case 'wheels://guides/all':
+          return {
+            contents: [
+              {
+                uri,
+                mimeType: 'application/json',
+                text: await this.fetchFromDevServer('/wheels/guides?format=json'),
+              },
+            ],
+          };
+
+        case 'wheels://project/context':
+          return {
+            contents: [
+              {
+                uri,
+                mimeType: 'application/json',
+                text: await this.fetchFromDevServer('/wheels/ai?mode=project'),
+              },
+            ],
+          };
+
+        case 'wheels://patterns/common':
+          return {
+            contents: [
+              {
+                uri,
+                mimeType: 'application/json',
+                text: await this.fetchFromDevServer('/wheels/ai?mode=chunk&id=patterns'),
+              },
+            ],
+          };
+
+        default:
+          throw new Error(`Unknown resource: ${uri}`);
+      }
+    });
+
+    // Tools handler
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+
+      switch (name) {
+        case 'wheels_generate':
+          return await this.handleGenerate(args);
+        case 'wheels_migrate':
+          return await this.handleMigrate(args);
+        case 'wheels_test':
+          return await this.handleTest(args);
+        case 'wheels_server':
+          return await this.handleServer(args);
+        case 'wheels_reload':
+          return await this.handleReload(args);
+        case 'wheels_info':
+          return await this.handleInfo(args);
+        case 'wheels_routes':
+          return await this.handleRoutes(args);
+        case 'wheels_plugins':
+          return await this.handlePlugins(args);
+        case 'wheels_test_status':
+          return await this.handleTestStatus(args);
+        default:
+          throw new Error(`Unknown tool: ${name}`);
+      }
+    });
+
+    // Prompts handler
+    this.server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+      prompts: [
+        {
+          name: 'wheels_model_help',
+          description: 'Get help with Wheels model development',
+          arguments: [
+            {
+              name: 'task',
+              description: 'The model development task you need help with',
+              required: true,
+            },
+          ],
+        },
+        {
+          name: 'wheels_controller_help',
+          description: 'Get help with Wheels controller development',
+          arguments: [
+            {
+              name: 'task',
+              description: 'The controller development task you need help with',
+              required: true,
+            },
+          ],
+        },
+        {
+          name: 'wheels_migration_help',
+          description: 'Get help with database migrations',
+          arguments: [
+            {
+              name: 'task',
+              description: 'The migration task you need help with',
+              required: true,
+            },
+          ],
+        },
+      ],
+    }));
+
+    this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+
+      const prompts = {
+        wheels_model_help: `You are helping with Wheels model development. The user needs assistance with: ${args.task}.
+
+Key Wheels model concepts:
+- Models extend the Model component
+- Use config() function for setup
+- Validations: validatesPresenceOf(), validatesUniquenessOf(), validatesFormatOf()
+- Associations: hasMany(), belongsTo(), hasOne()
+- Callbacks: beforeSave(), afterCreate(), etc.
+- CRUD: findAll(), findOne(), create(), update(), delete()
+
+Provide specific code examples using Wheels conventions.`,
+
+        wheels_controller_help: `You are helping with Wheels controller development. The user needs assistance with: ${args.task}.
+
+Key Wheels controller concepts:
+- Controllers extend the Controller component
+- Use config() function for filters and settings
+- Filters: filters(through="authenticate", except="index")
+- Rendering: renderView(), renderWith(), redirectTo()
+- Content types: provides("html,json")
+- CSRF: protectFromForgery()
+
+Focus on RESTful patterns and Wheels conventions.`,
+
+        wheels_migration_help: `You are helping with Wheels database migrations. The user needs to: ${args.task}.
+
+Key migration concepts:
+- Migrations extend wheels.migrator.Migration
+- up() function for forward migration
+- down() function for rollback
+- Table operations: createTable(), dropTable(), changeTable()
+- Column types: string(), integer(), boolean(), decimal(), timestamps()
+- Indexes: addIndex(), removeIndex()
+
+Provide migration code following Wheels conventions.`,
+      };
+
+      return {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: prompts[name] || 'Unknown prompt',
+            },
+          },
+        ],
+      };
+    });
+  }
+
+  async fetchFromDevServer(endpoint) {
+    return new Promise((resolve, reject) => {
+      const url = `${this.devServerUrl}${endpoint}`;
+
+      http.get(url, (res) => {
+        let data = '';
+
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+
+        res.on('end', () => {
+          resolve(data);
+        });
+      }).on('error', (err) => {
+        // If dev server is not running, return fallback data
+        resolve(JSON.stringify({
+          error: 'Dev server not available',
+          message: 'Start the Wheels dev server to access live documentation',
+          fallback: true,
+        }));
+      });
+    });
+  }
+
+  async executeCommand(command) {
+    return new Promise((resolve, reject) => {
+      exec(command, { cwd: this.projectPath }, (error, stdout, stderr) => {
+        if (error) {
+          resolve({
+            content: [
+              {
+                type: 'text',
+                text: `Error: ${error.message}\n${stderr}`,
+              },
+            ],
+          });
+        } else {
+          resolve({
+            content: [
+              {
+                type: 'text',
+                text: stdout || 'Command executed successfully',
+              },
+            ],
+          });
+        }
+      });
+    });
+  }
+
+  async handleGenerate(args) {
+    const { type, name, attributes, actions } = args;
+
+    let command = `wheels g ${type} ${name}`;
+
+    if (attributes) {
+      command += ` ${attributes}`;
+    }
+
+    if (actions && type === 'controller') {
+      command += ` ${actions}`;
+    }
+
+    return await this.executeCommand(command);
+  }
+
+  async handleMigrate(args) {
+    const { action } = args;
+    const command = `wheels dbmigrate ${action}`;
+    return await this.executeCommand(command);
+  }
+
+  async handleTest(args) {
+    const { target, verbose } = args;
+
+    let command = 'wheels test run';
+
+    if (target) {
+      command += ` ${target}`;
+    }
+
+    if (verbose) {
+      command += ' --verbose';
+    }
+
+    return await this.executeCommand(command);
+  }
+
+  async handleServer(args) {
+    const { action } = args;
+    const command = `wheels server ${action}`;
+    return await this.executeCommand(command);
+  }
+
+  async handleReload(args) {
+    const { password } = args;
+
+    // Construct reload URL
+    let reloadUrl = `${this.devServerUrl}/?reload=true`;
+    if (password) {
+      reloadUrl += `&password=${password}`;
+    }
+
+    return new Promise((resolve) => {
+      http.get(reloadUrl, (res) => {
+        resolve({
+          content: [
+            {
+              type: 'text',
+              text: 'Application reloaded successfully',
+            },
+          ],
+        });
+      }).on('error', (err) => {
+        resolve({
+          content: [
+            {
+              type: 'text',
+              text: `Failed to reload: ${err.message}`,
+            },
+          ],
+        });
+      });
+    });
+  }
+
+  async handleInfo(args) {
+    // Fetch system info from AI endpoint
+    return await this.fetchFromAIEndpoint('info');
+  }
+
+  async handleRoutes(args) {
+    // Fetch routes from AI endpoint
+    return await this.fetchFromAIEndpoint('routes');
+  }
+
+  async handlePlugins(args) {
+    // Fetch plugins from AI endpoint
+    return await this.fetchFromAIEndpoint('plugins');
+  }
+
+  async handleTestStatus(args) {
+    // Fetch test status from AI endpoint
+    const { type } = args || { type: 'app' };
+    return new Promise((resolve) => {
+      const url = `${this.devServerUrl}/wheels/tests/${type}?format=json`;
+      http.get(url, (res) => {
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          resolve({
+            content: [
+              {
+                type: 'text',
+                text: data,
+              },
+            ],
+          });
+        });
+      }).on('error', (err) => {
+        resolve({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ error: err.message }),
+            },
+          ],
+        });
+      });
+    });
+  }
+
+  async fetchFromAIEndpoint(mode) {
+    // Helper to fetch data from AI endpoint
+    return new Promise((resolve) => {
+      const url = `${this.devServerUrl}/wheels/ai?mode=${mode}`;
+      http.get(url, (res) => {
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          resolve({
+            content: [
+              {
+                type: 'text',
+                text: data,
+              },
+            ],
+          });
+        });
+      }).on('error', (err) => {
+        resolve({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ error: err.message }),
+            },
+          ],
+        });
+      });
+    });
+  }
+
+  async run() {
+    const transport = new StdioServerTransport();
+    await this.server.connect(transport);
+    console.error('Wheels MCP server started');
+  }
+}
+
+// Check if required modules are installed
+try {
+  require('@modelcontextprotocol/sdk/server/index.js');
+} catch (e) {
+  console.error('MCP SDK not installed. Run: npm install @modelcontextprotocol/sdk');
+  process.exit(1);
+}
+
+// Start the server
+const server = new WheelsMCPServer();
+server.run().catch((error) => {
+  console.error('Server error:', error);
+  process.exit(1);
+});

--- a/vendor/wheels/Dispatch.cfc
+++ b/vendor/wheels/Dispatch.cfc
@@ -471,6 +471,11 @@ component output="false" extends="wheels.Global"{
 
 		// Skip if disabled or no key parameter exists.
 		if (IsBoolean(local.binding) && !local.binding) {
+			// Binding is off. Emit a dev-mode hint if this route looks like a binding
+			// candidate (has a key and dispatches to a member action). See gap tracker
+			// item #5: silent failure when developers write `params.post` without
+			// setting `binding=true`.
+			$maybeWarnRouteBinding(params = local.rv, route = arguments.route);
 			return local.rv;
 		}
 		if (!StructKeyExists(local.rv, "key")) {
@@ -516,6 +521,83 @@ component output="false" extends="wheels.Global"{
 		local.rv[local.paramKey] = local.instance;
 
 		return local.rv;
+	}
+
+	/**
+	 * Emits a one-time dev-mode log warning when a route looks like a route-model-binding
+	 * candidate but binding is not enabled. The heuristic: params.key is present AND the
+	 * resolved action is one of the member binding-eligible actions (show, edit, update,
+	 * delete). Writes one line per unique controller+action pair per JVM process to avoid
+	 * log spam. Gated behind environment != "production" and suppressRouteBindingWarnings=false.
+	 * The warning points the developer at either the per-resource `binding=true` flag or the
+	 * global `routeModelBinding` setting. Safe to call regardless of state — returns silently
+	 * on any error so it never interferes with dispatch.
+	 */
+	public boolean function $maybeWarnRouteBinding(required struct params, required struct route) {
+		try {
+			// Resolve the settings namespace ($wheels or wheels depending on runtime).
+			local.appKey = $appKey();
+			local.settings = application[local.appKey];
+
+			// Gate: production skips entirely.
+			local.env = StructKeyExists(local.settings, "environment") ? local.settings.environment : "";
+			if (local.env == "production") {
+				return false;
+			}
+
+			// Gate: user opt-out.
+			if (StructKeyExists(local.settings, "suppressRouteBindingWarnings") && local.settings.suppressRouteBindingWarnings) {
+				return false;
+			}
+
+			// Only warn when a key is in the URL (binding wouldn't fire without one).
+			if (!StructKeyExists(arguments.params, "key")) {
+				return false;
+			}
+
+			// Only warn for member binding-eligible actions.
+			local.action = StructKeyExists(arguments.params, "action") ? arguments.params.action : (StructKeyExists(arguments.route, "action") ? arguments.route.action : "");
+			if (!ListFindNoCase("show,edit,update,delete", local.action)) {
+				return false;
+			}
+
+			// Derive controller (for log detail + dedup key).
+			local.controller = StructKeyExists(arguments.params, "controller") ? arguments.params.controller : (StructKeyExists(arguments.route, "controller") ? arguments.route.controller : "");
+			if (!Len(local.controller)) {
+				return false;
+			}
+
+			// Dedup: one warning per controller+action per application lifetime.
+			// Resets on reload (application scope rebuild).
+			if (!StructKeyExists(application, "$wheelsRouteBindingWarnings")) {
+				application.$wheelsRouteBindingWarnings = {};
+			}
+			local.dedupKey = local.controller & "##" & local.action;
+			if (StructKeyExists(application.$wheelsRouteBindingWarnings, local.dedupKey)) {
+				return false;
+			}
+			application.$wheelsRouteBindingWarnings[local.dedupKey] = true;
+
+			// Derive the singular name binding would use (matches $resolveRouteModelBinding logic).
+			local.modelName = capitalize(singularize(local.controller));
+			local.singular = LCase(Left(local.modelName, 1)) & Mid(local.modelName, 2, Len(local.modelName) - 1);
+			local.routeName = StructKeyExists(arguments.route, "name") ? arguments.route.name : "";
+
+			local.msg = "Wheels Route Binding Hint: #UCase(local.action)# on controller '#local.controller#'"
+				& (Len(local.routeName) ? " (route '#local.routeName#')" : "")
+				& " dispatched with params.key but route model binding is not enabled on this resource."
+				& " If you intended params.#local.singular# to be auto-loaded from the #local.modelName# model, add binding=true to the resource:"
+				& "  .resources(name=""#local.controller#"", binding=true)."
+				& " Or enable globally in config/settings.cfm: set(routeModelBinding=true)."
+				& " To silence this hint: set(suppressRouteBindingWarnings=true) in config/settings.cfm."
+				& " (Hint fires in development only.)";
+
+			writeLog(file="wheels", type="warning", text=local.msg);
+			return true;
+		} catch (any ignored) {
+			// Warning emission is best-effort; never block dispatch.
+			return false;
+		}
 	}
 
 	/**

--- a/vendor/wheels/events/init/orm.cfm
+++ b/vendor/wheels/events/init/orm.cfm
@@ -21,6 +21,7 @@
 		application.$wheels.tableNamePrefix = "";
 		application.$wheels.obfuscateURLs = false;
 		application.$wheels.routeModelBinding = false;
+		application.$wheels.suppressRouteBindingWarnings = false;
 		application.$wheels.reloadPassword = "";
 		application.$wheels.redirectAfterReload = false;
 		application.$wheels.softDeleteProperty = "deletedAt";

--- a/vendor/wheels/events/init/views.cfm
+++ b/vendor/wheels/events/init/views.cfm
@@ -32,4 +32,12 @@
 		// Test framework settings.
 		application.$wheels.validateTestPackageMetaData = true;
 		application.$wheels.restoreTestRunnerApplicationScope = true;
+
+		// Form helper settings.
+		// When true, object-bound form helpers (textField, emailField, select, etc.) also emit a
+		// `data-auto-id` attribute alongside the auto-derived `id`. The `id` uses the historical
+		// dash convention (e.g. `post-title`) and `data-auto-id` uses the underscore convention
+		// (e.g. `post_title`) favored by Rails/Laravel-style browser test selectors. Only emitted
+		// when the id is auto-derived from objectName + property; a user-supplied `id` suppresses it.
+		application.$wheels.formHelperDataAutoId = true;
 </cfscript>

--- a/vendor/wheels/tests/specs/dispatch/routeBindingWarningSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/routeBindingWarningSpec.cfc
@@ -1,0 +1,145 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("Route Model Binding dev-mode warning", () => {
+
+			beforeEach(() => {
+				dispatch = CreateObject("component", "wheels.Dispatch")
+
+				// Clear the per-process dedup cache between tests so each spec starts fresh.
+				if (StructKeyExists(application, "$wheelsRouteBindingWarnings")) {
+					StructClear(application.$wheelsRouteBindingWarnings)
+				}
+
+				_originalEnv = application.wheels.environment
+				_originalSuppress = StructKeyExists(application.wheels, "suppressRouteBindingWarnings")
+					? application.wheels.suppressRouteBindingWarnings
+					: false
+
+				// Ensure warnings are enabled in a known state for the tests.
+				application.wheels.environment = "development"
+				application.wheels.suppressRouteBindingWarnings = false
+			})
+
+			afterEach(() => {
+				application.wheels.environment = _originalEnv
+				application.wheels.suppressRouteBindingWarnings = _originalSuppress
+				if (StructKeyExists(application, "$wheelsRouteBindingWarnings")) {
+					StructClear(application.$wheelsRouteBindingWarnings)
+				}
+			})
+
+			it("warns when binding is off, key is set, and action is a member action", () => {
+				params = {controller = "posts", action = "show", key = "42"}
+				route = {name = "post", controller = "posts", action = "show"}
+				result = dispatch.$maybeWarnRouteBinding(params = params, route = route)
+				expect(result).toBeTrue()
+			})
+
+			it("does not warn when key is absent (e.g., index action)", () => {
+				params = {controller = "posts", action = "index"}
+				route = {name = "posts", controller = "posts", action = "index"}
+				result = dispatch.$maybeWarnRouteBinding(params = params, route = route)
+				expect(result).toBeFalse()
+			})
+
+			it("does not warn for non-member actions (new, create, index)", () => {
+				params = {controller = "posts", action = "new", key = "42"}
+				route = {name = "newPost", controller = "posts", action = "new"}
+				result = dispatch.$maybeWarnRouteBinding(params = params, route = route)
+				expect(result).toBeFalse()
+			})
+
+			it("warns for each of show, edit, update, delete", () => {
+				for (action in ["show", "edit", "update", "delete"]) {
+					// Fresh dedup cache per action.
+					if (StructKeyExists(application, "$wheelsRouteBindingWarnings")) {
+						StructClear(application.$wheelsRouteBindingWarnings)
+					}
+					params = {controller = "posts", action = action, key = "42"}
+					route = {name = "post", controller = "posts", action = action}
+					result = dispatch.$maybeWarnRouteBinding(params = params, route = route)
+					expect(result).toBeTrue()
+				}
+			})
+
+			it("warns only once per controller+action (dedup within lifetime)", () => {
+				params = {controller = "posts", action = "show", key = "42"}
+				route = {name = "post", controller = "posts", action = "show"}
+				first = dispatch.$maybeWarnRouteBinding(params = params, route = route)
+				second = dispatch.$maybeWarnRouteBinding(params = params, route = route)
+				third = dispatch.$maybeWarnRouteBinding(params = params, route = route)
+
+				expect(first).toBeTrue()
+				expect(second).toBeFalse()
+				expect(third).toBeFalse()
+			})
+
+			it("deduplicates per controller+action pair independently", () => {
+				p1 = {controller = "posts", action = "show", key = "1"}
+				p2 = {controller = "posts", action = "edit", key = "1"}
+				p3 = {controller = "comments", action = "show", key = "1"}
+				route = {name = "r", controller = "posts", action = "show"}
+
+				// Different action on same controller still fires.
+				expect(dispatch.$maybeWarnRouteBinding(params = p1, route = route)).toBeTrue()
+				expect(dispatch.$maybeWarnRouteBinding(params = p2, route = route)).toBeTrue()
+				// Different controller still fires.
+				expect(dispatch.$maybeWarnRouteBinding(params = p3, route = route)).toBeTrue()
+				// All three repeat => silence.
+				expect(dispatch.$maybeWarnRouteBinding(params = p1, route = route)).toBeFalse()
+				expect(dispatch.$maybeWarnRouteBinding(params = p2, route = route)).toBeFalse()
+				expect(dispatch.$maybeWarnRouteBinding(params = p3, route = route)).toBeFalse()
+			})
+
+			it("does not warn in production environment", () => {
+				application.wheels.environment = "production"
+				params = {controller = "posts", action = "show", key = "42"}
+				route = {name = "post", controller = "posts", action = "show"}
+				result = dispatch.$maybeWarnRouteBinding(params = params, route = route)
+				expect(result).toBeFalse()
+			})
+
+			it("does not warn when suppressRouteBindingWarnings is true", () => {
+				application.wheels.suppressRouteBindingWarnings = true
+				params = {controller = "posts", action = "show", key = "42"}
+				route = {name = "post", controller = "posts", action = "show"}
+				result = dispatch.$maybeWarnRouteBinding(params = params, route = route)
+				expect(result).toBeFalse()
+			})
+
+			it("does not warn when controller cannot be determined", () => {
+				params = {action = "show", key = "42"}
+				route = {name = "post", action = "show"}
+				result = dispatch.$maybeWarnRouteBinding(params = params, route = route)
+				expect(result).toBeFalse()
+			})
+
+			it("does not warn when binding is enabled on the route (integration via $resolveRouteModelBinding)", () => {
+				// When binding is true, $resolveRouteModelBinding does not invoke the helper.
+				// Verify: dedup cache stays empty even after a call that would otherwise warn.
+				params = {controller = "nonexistentmodeltestxyz", action = "show", key = "42"}
+				route = {controller = "nonexistentmodeltestxyz", action = "show", binding = true}
+				// Model won't resolve (no such model) so $resolveRouteModelBinding returns early
+				// after the "model doesn't exist" catch — but it never calls the warning path.
+				try {
+					dispatch.$resolveRouteModelBinding(params = params, route = route)
+				} catch (any e) { /* model resolution may throw; we only care about the warning side effect */ }
+				hasDedup = StructKeyExists(application, "$wheelsRouteBindingWarnings")
+					&& StructKeyExists(application.$wheelsRouteBindingWarnings, "nonexistentmodeltestxyz##show")
+				expect(hasDedup).toBeFalse()
+			})
+
+			it("fires via $resolveRouteModelBinding when binding is off and route is a candidate", () => {
+				params = {controller = "widgetsnonexistent", action = "show", key = "42"}
+				route = {controller = "widgetsnonexistent", action = "show"}
+				// binding not set on route, global routeModelBinding defaults false
+				dispatch.$resolveRouteModelBinding(params = params, route = route)
+				hasDedup = StructKeyExists(application, "$wheelsRouteBindingWarnings")
+					&& StructKeyExists(application.$wheelsRouteBindingWarnings, "widgetsnonexistent##show")
+				expect(hasDedup).toBeTrue()
+			})
+		})
+	}
+}

--- a/vendor/wheels/tests/specs/view/checkboxSpec.cfc
+++ b/vendor/wheels/tests/specs/view/checkboxSpec.cfc
@@ -18,7 +18,7 @@ component extends="wheels.WheelsTest" {
 				args.encode = true
 				
 				actual = _controller.checkBox(argumentcollection = args)
-				expected = '<label for="user-firstname">lastname error with &lt;strong&gt;bold&lt;&##x2f;strong&gt;<input id="user-firstname" name="user&##x5b;firstname&##x5d;" type="checkbox" value="1"><input id="user-firstname-checkbox" name="user&##x5b;firstname&##x5d;&##x28;&##x24;checkbox&##x29;" type="hidden" value="0"></label>'
+				expected = '<label for="user-firstname">lastname error with &lt;strong&gt;bold&lt;&##x2f;strong&gt;<input data-auto-id="user_firstname" id="user-firstname" name="user&##x5b;firstname&##x5d;" type="checkbox" value="1"><input data-auto-id="user_firstname_checkbox" id="user-firstname-checkbox" name="user&##x5b;firstname&##x5d;&##x28;&##x24;checkbox&##x29;" type="hidden" value="0"></label>'
 				
 				expect(actual).toBe(expected)
 			})
@@ -29,7 +29,7 @@ component extends="wheels.WheelsTest" {
 				args.encode = false
 				
 				actual = _controller.checkBox(argumentcollection = args)
-				expected = '<label for="user-firstname">lastname error with <strong>bold</strong><input id="user-firstname" name="user[firstname]" type="checkbox" value="1"><input id="user-firstname-checkbox" name="user[firstname]($checkbox)" type="hidden" value="0"></label>'
+				expected = '<label for="user-firstname">lastname error with <strong>bold</strong><input data-auto-id="user_firstname" id="user-firstname" name="user[firstname]" type="checkbox" value="1"><input data-auto-id="user_firstname_checkbox" id="user-firstname-checkbox" name="user[firstname]($checkbox)" type="hidden" value="0"></label>'
 				
 				expect(actual).toBe(expected)
 			})
@@ -41,7 +41,7 @@ component extends="wheels.WheelsTest" {
 				args.encode = "attributes"
 				
 				actual = _controller.checkBox(argumentcollection = args)
-				expected = '<label for="user-firstname">lastname error with <strong>bold</strong><input class="form-check&quot;&##x20;onclick&##x3d;&quot;alert&##x28;&quot;xss&quot;&##x29;" id="user-firstname" name="user&##x5b;firstname&##x5d;" type="checkbox" value="1"><input id="user-firstname-checkbox" name="user&##x5b;firstname&##x5d;&##x28;&##x24;checkbox&##x29;" type="hidden" value="0"></label>'
+				expected = '<label for="user-firstname">lastname error with <strong>bold</strong><input class="form-check&quot;&##x20;onclick&##x3d;&quot;alert&##x28;&quot;xss&quot;&##x29;" data-auto-id="user_firstname" id="user-firstname" name="user&##x5b;firstname&##x5d;" type="checkbox" value="1"><input data-auto-id="user_firstname_checkbox" id="user-firstname-checkbox" name="user&##x5b;firstname&##x5d;&##x28;&##x24;checkbox&##x29;" type="hidden" value="0"></label>'
 					
 				expect(actual).toBe(expected)
 			})
@@ -52,7 +52,7 @@ component extends="wheels.WheelsTest" {
 				args.encode = true
 				
 				actual = _controller.checkBox(argumentcollection = args)
-				expected = '<label for="user-firstname">Label with &lt;strong&gt;bold&lt;&##x2f;strong&gt; and &lt;script&gt;alert&##x28;&quot;XSS&quot;&##x29;&lt;&##x2f;script&gt;<input id="user-firstname" name="user&##x5b;firstname&##x5d;" type="checkbox" value="1"><input id="user-firstname-checkbox" name="user&##x5b;firstname&##x5d;&##x28;&##x24;checkbox&##x29;" type="hidden" value="0"></label>'
+				expected = '<label for="user-firstname">Label with &lt;strong&gt;bold&lt;&##x2f;strong&gt; and &lt;script&gt;alert&##x28;&quot;XSS&quot;&##x29;&lt;&##x2f;script&gt;<input data-auto-id="user_firstname" id="user-firstname" name="user&##x5b;firstname&##x5d;" type="checkbox" value="1"><input data-auto-id="user_firstname_checkbox" id="user-firstname-checkbox" name="user&##x5b;firstname&##x5d;&##x28;&##x24;checkbox&##x29;" type="hidden" value="0"></label>'
 				
 				expect(actual).toBe(expected)
 			})

--- a/vendor/wheels/tests/specs/view/dateselectSpec.cfc
+++ b/vendor/wheels/tests/specs/view/dateselectSpec.cfc
@@ -25,7 +25,7 @@ component extends="wheels.WheelsTest" {
 				args.encode = true
 				
 				actual = _controller.dateSelect(argumentcollection = args)
-				expected = '<label for="user-birthday-month">lastname error with &lt;strong&gt;bold&lt;&##x2f;strong&gt;<select id="user-birthday-month" name="user&##x5b;birthday&##x5d;&##x28;&##x24;month&##x29;"><option value="1">January</option><option value="2">February</option><option value="3">March</option><option value="4">April</option><option value="5">May</option><option value="6">June</option><option value="7">July</option><option value="8">August</option><option value="9">September</option><option value="10">October</option><option selected="selected" value="11">November</option><option value="12">December</option>'
+				expected = '<label for="user-birthday-month">lastname error with &lt;strong&gt;bold&lt;&##x2f;strong&gt;<select data-auto-id="user_birthday_month" id="user-birthday-month" name="user&##x5b;birthday&##x5d;&##x28;&##x24;month&##x29;"><option value="1">January</option><option value="2">February</option><option value="3">March</option><option value="4">April</option><option value="5">May</option><option value="6">June</option><option value="7">July</option><option value="8">August</option><option value="9">September</option><option value="10">October</option><option selected="selected" value="11">November</option><option value="12">December</option>'
 				
 				expect(actual).toInclude(expected.left(expected.len() - 10))
 			})
@@ -35,7 +35,7 @@ component extends="wheels.WheelsTest" {
 				args.encode = false
 				
 				actual = _controller.dateSelect(argumentcollection = args)
-				expected = '<label for="user-birthday-month">lastname error with <strong>bold</strong><select id="user-birthday-month" name="user[birthday]($month)">'
+				expected = '<label for="user-birthday-month">lastname error with <strong>bold</strong><select data-auto-id="user_birthday_month" id="user-birthday-month" name="user[birthday]($month)">'
 
 				expect(actual).toInclude(expected.left(expected.len() - 1))
 			})

--- a/vendor/wheels/tests/specs/view/formsDataAutoIdSpec.cfc
+++ b/vendor/wheels/tests/specs/view/formsDataAutoIdSpec.cfc
@@ -1,0 +1,163 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("Form helper data-auto-id dual emission", () => {
+
+			beforeEach(() => {
+				_controller = g.controller(name = "ControllerWithModel")
+			})
+
+			describe("when formHelperDataAutoId is enabled (default)", () => {
+
+				it("emits both dashed id and underscored data-auto-id on textField", () => {
+					r = _controller.textField(
+						objectName = "user",
+						property = "firstname",
+						label = false
+					)
+
+					expect(r).toInclude('id="user-firstname"')
+					expect(r).toInclude('data-auto-id="user_firstname"')
+				})
+
+				it("emits data-auto-id on emailField", () => {
+					r = _controller.emailField(
+						objectName = "user",
+						property = "firstname",
+						label = false
+					)
+
+					expect(r).toInclude('id="user-firstname"')
+					expect(r).toInclude('data-auto-id="user_firstname"')
+				})
+
+				it("emits data-auto-id on passwordField", () => {
+					r = _controller.passwordField(
+						objectName = "user",
+						property = "firstname",
+						label = false
+					)
+
+					expect(r).toInclude('id="user-firstname"')
+					expect(r).toInclude('data-auto-id="user_firstname"')
+				})
+
+				it("emits data-auto-id on hiddenField", () => {
+					r = _controller.hiddenField(
+						objectName = "user",
+						property = "firstname"
+					)
+
+					expect(r).toInclude('id="user-firstname"')
+					expect(r).toInclude('data-auto-id="user_firstname"')
+				})
+
+				it("emits data-auto-id on textArea", () => {
+					r = _controller.textArea(
+						objectName = "user",
+						property = "firstname",
+						label = false
+					)
+
+					expect(r).toInclude('id="user-firstname"')
+					expect(r).toInclude('data-auto-id="user_firstname"')
+				})
+
+				it("emits data-auto-id on select", () => {
+					r = _controller.select(
+						objectName = "user",
+						property = "firstname",
+						options = "a,b,c",
+						label = false
+					)
+
+					expect(r).toInclude('id="user-firstname"')
+					expect(r).toInclude('data-auto-id="user_firstname"')
+				})
+
+				it("emits data-auto-id on checkBox", () => {
+					r = _controller.checkBox(
+						objectName = "user",
+						property = "isActive",
+						label = false
+					)
+
+					expect(r).toInclude('id="user-isactive"')
+					expect(r).toInclude('data-auto-id="user_isactive"')
+				})
+
+				it("emits data-auto-id on radioButton including value suffix", () => {
+					r = _controller.radioButton(
+						objectName = "user",
+						property = "gender",
+						tagValue = "m",
+						label = false
+					)
+
+					expect(r).toInclude('id="user-gender-m"')
+					expect(r).toInclude('data-auto-id="user_gender_m"')
+				})
+
+				it("emits data-auto-id on fileField", () => {
+					r = _controller.fileField(
+						objectName = "user",
+						property = "firstname",
+						label = false
+					)
+
+					expect(r).toInclude('id="user-firstname"')
+					expect(r).toInclude('data-auto-id="user_firstname"')
+				})
+
+				it("does not emit data-auto-id when the caller supplies a custom id", () => {
+					r = _controller.textField(
+						objectName = "user",
+						property = "firstname",
+						id = "my-custom-id",
+						label = false
+					)
+
+					expect(r).toInclude('id="my-custom-id"')
+					expect(r).notToInclude('data-auto-id')
+				})
+
+				it("emits data-auto-id on the hidden companion of a checkBox with uncheckedValue", () => {
+					r = _controller.checkBox(
+						objectName = "user",
+						property = "isActive",
+						label = false,
+						unCheckedValue = 0
+					)
+
+					expect(r).toInclude('id="user-isactive-checkbox"')
+					expect(r).toInclude('data-auto-id="user_isactive_checkbox"')
+				})
+			})
+
+			describe("when formHelperDataAutoId is disabled", () => {
+
+				beforeEach(() => {
+					g.set(formHelperDataAutoId = false)
+				})
+
+				afterEach(() => {
+					g.set(formHelperDataAutoId = true)
+				})
+
+				it("emits only the dashed id without data-auto-id", () => {
+					r = _controller.textField(
+						objectName = "user",
+						property = "firstname",
+						label = false
+					)
+
+					expect(r).toInclude('id="user-firstname"')
+					expect(r).notToInclude('data-auto-id')
+				})
+			})
+		})
+	}
+}

--- a/vendor/wheels/tests/specs/view/formsSpec.cfc
+++ b/vendor/wheels/tests/specs/view/formsSpec.cfc
@@ -164,13 +164,13 @@ component extends="wheels.WheelsTest" {
 			it("checks when property value equals checkedValue", () => {
 				args.property = "birthdaymonth"
 				args.checkedvalue = "11"
-				e = '<input checked="checked" id="user-birthdaymonth" name="user[birthdaymonth]" type="checkbox" value="11"><input id="user-birthdaymonth-checkbox" name="user[birthdaymonth]($checkbox)" type="hidden" value="0">'
+				e = '<input checked="checked" data-auto-id="user_birthdaymonth" id="user-birthdaymonth" name="user[birthdaymonth]" type="checkbox" value="11"><input data-auto-id="user_birthdaymonth_checkbox" id="user-birthdaymonth-checkbox" name="user[birthdaymonth]($checkbox)" type="hidden" value="0">'
 				r = _controller.checkBox(argumentcollection = args)
 
 				expect(e).toBe(r)
 
 				args.checkedvalue = "12"
-				e = '<input id="user-birthdaymonth" name="user[birthdaymonth]" type="checkbox" value="12"><input id="user-birthdaymonth-checkbox" name="user[birthdaymonth]($checkbox)" type="hidden" value="0">'
+				e = '<input data-auto-id="user_birthdaymonth" id="user-birthdaymonth" name="user[birthdaymonth]" type="checkbox" value="12"><input data-auto-id="user_birthdaymonth_checkbox" id="user-birthdaymonth-checkbox" name="user[birthdaymonth]($checkbox)" type="hidden" value="0">'
 				r = _controller.checkBox(argumentcollection = args)
 
 				expect(e).toBe(r)
@@ -251,7 +251,7 @@ component extends="wheels.WheelsTest" {
 				_controller = g.controller(name = "ControllerWithModel")
 
 				e = _controller.fileField(objectName = "user", property = "firstname")
-				r = '<label for="user-firstname">Firstname<input id="user-firstname" name="user&##x5b;firstname&##x5d;" type="file"></label>'
+				r = '<label for="user-firstname">Firstname<input data-auto-id="user_firstname" id="user-firstname" name="user&##x5b;firstname&##x5d;" type="file"></label>'
 
 				expect(e).toBe(r)
 			})
@@ -275,7 +275,7 @@ component extends="wheels.WheelsTest" {
 				_controller = g.controller(name = "ControllerWithModel")
 
 				e = _controller.hiddenField(objectName = "user", property = "firstname")
-				r = '<input id="user-firstname" name="user&##x5b;firstname&##x5d;" type="hidden" value="Tony">'
+				r = '<input data-auto-id="user_firstname" id="user-firstname" name="user&##x5b;firstname&##x5d;" type="hidden" value="Tony">'
 
 				expect(e).toBe(r)
 			})
@@ -284,7 +284,7 @@ component extends="wheels.WheelsTest" {
 				_controller = g.controller(name = "ControllerWithModel")
 
 				e = _controller.hiddenField(objectName = "user", property = "firstname", encode = "false")
-				r = '<input id="user-firstname" name="user[firstname]" type="hidden" value="Tony">'
+				r = '<input data-auto-id="user_firstname" id="user-firstname" name="user[firstname]" type="hidden" value="Tony">'
 
 				expect(e).toBe(r)
 			})
@@ -459,7 +459,7 @@ component extends="wheels.WheelsTest" {
 
 			it("adds custom label on object helper", () => {
 				actual = c.textField(objectName = "user", property = "username", label = "The Label:")
-				expected = '<label for="user-username">The Label:<input id="user-username" maxlength="50" name="user[username]" type="text" value="tonyp"></label>'
+				expected = '<label for="user-username">The Label:<input data-auto-id="user_username" id="user-username" maxlength="50" name="user[username]" type="text" value="tonyp"></label>'
 
 				expect(actual).toBe(expected)
 			})
@@ -473,35 +473,35 @@ component extends="wheels.WheelsTest" {
 
 			it("adds blank label on object helpers", () => {
 				actual = c.textField(objectName = "user", property = "username", label = "")
-				expected = '<input id="user-username" maxlength="50" name="user[username]" type="text" value="tonyp">'
+				expected = '<input data-auto-id="user_username" id="user-username" maxlength="50" name="user[username]" type="text" value="tonyp">'
 
 				expect(actual).toBe(expected)
 			})
 
 			it("adds automatic label on object helpers with around placement", () => {
 				actual = c.textField(objectName = "user", property = "username", labelPlacement = "around")
-				expected = '<label for="user-username">Username<input id="user-username" maxlength="50" name="user[username]" type="text" value="tonyp"></label>'
+				expected = '<label for="user-username">Username<input data-auto-id="user_username" id="user-username" maxlength="50" name="user[username]" type="text" value="tonyp"></label>'
 
 				expect(actual).toBe(expected)
 			})
 
 			it("adds automatic label on object helpers with before placement", () => {
 				actual = c.textField(objectName = "user", property = "username", labelPlacement = "before")
-				expected = '<label for="user-username">Username</label><input id="user-username" maxlength="50" name="user[username]" type="text" value="tonyp">'
+				expected = '<label for="user-username">Username</label><input data-auto-id="user_username" id="user-username" maxlength="50" name="user[username]" type="text" value="tonyp">'
 
 				expect(actual).toBe(expected)
 			})
 
 			it("adds automatic label on object helpers with after placement", () => {
 				actual = c.textField(objectName = "user", property = "username", labelPlacement = "after")
-				expected = '<input id="user-username" maxlength="50" name="user[username]" type="text" value="tonyp"><label for="user-username">Username</label>'
+				expected = '<input data-auto-id="user_username" id="user-username" maxlength="50" name="user[username]" type="text" value="tonyp"><label for="user-username">Username</label>'
 
 				expect(actual).toBe(expected)
 			})
 
 			it("adds automatic label on object helpers with non persisted property", () => {
 				actual = c.textField(objectName = "user", property = "virtual")
-				expected = '<label for="user-virtual">Virtual property<input id="user-virtual" name="user[virtual]" type="text" value=""></label>'
+				expected = '<label for="user-virtual">Virtual property<input data-auto-id="user_virtual" id="user-virtual" name="user[virtual]" type="text" value=""></label>'
 
 				expect(actual).toBe(expected)
 			})
@@ -532,7 +532,7 @@ component extends="wheels.WheelsTest" {
 			it("is valid", () => {
 				_controller = g.controller(name = "ControllerWithModel")
 				e = _controller.passwordField(objectName = "User", property = "password")
-				r = '<label for="User-password">Password<input id="User-password" maxlength="50" name="User&##x5b;password&##x5d;" type="password" value="tonyp123"></label>'
+				r = '<label for="User-password">Password<input data-auto-id="User_password" id="User-password" maxlength="50" name="User&##x5b;password&##x5d;" type="password" value="tonyp123"></label>'
 
 				expect(e).toBe(r)
 			})
@@ -554,7 +554,7 @@ component extends="wheels.WheelsTest" {
 			it("is valid", () => {
 				_controller = g.controller(name = "ControllerWithModel")
 				e = _controller.radioButton(objectName = "user", property = "gender", tagValue = "m", label = "Male")
-				r = '<label for="user-gender-m">Male<input id="user-gender-m" name="user&##x5b;gender&##x5d;" type="radio" value="m"></label>'
+				r = '<label for="user-gender-m">Male<input data-auto-id="user_gender_m" id="user-gender-m" name="user&##x5b;gender&##x5d;" type="radio" value="m"></label>'
 
 				expect(e).toBe(r)
 			})
@@ -603,7 +603,7 @@ component extends="wheels.WheelsTest" {
 			it("works with list as options", () => {
 				options = "Opt1,Opt2"
 				r = _controller.select(objectName = "user", property = "firstname", options = options, label = false)
-				e = '<select id="user-firstname" name="user[firstname]"><option value="Opt1">Opt1</option><option value="Opt2">Opt2</option></select>'
+				e = '<select data-auto-id="user_firstname" id="user-firstname" name="user[firstname]"><option value="Opt1">Opt1</option><option value="Opt2">Opt2</option></select>'
 
 				expect(e).toBe(r)
 			})
@@ -614,7 +614,7 @@ component extends="wheels.WheelsTest" {
 				options[2] = "Opt2"
 				options[3] = "Opt3"
 				r = _controller.select(objectName = "user", property = "firstname", options = options, label = false)
-				e = '<select id="user-firstname" name="user[firstname]"><option value="Opt1">Opt1</option><option value="Opt2">Opt2</option><option value="Opt3">Opt3</option></select>'
+				e = '<select data-auto-id="user_firstname" id="user-firstname" name="user[firstname]"><option value="Opt1">Opt1</option><option value="Opt2">Opt2</option><option value="Opt3">Opt3</option></select>'
 
 				expect(e).toBe(r)
 			})
@@ -624,7 +624,7 @@ component extends="wheels.WheelsTest" {
 				options.x = "xVal"
 				options.y = "yVal"
 				r = _controller.select(objectName = "user", property = "firstname", options = options, label = false)
-				e = '<select id="user-firstname" name="user[firstname]"><option value="x">xVal</option><option value="y">yVal</option></select>'
+				e = '<select data-auto-id="user_firstname" id="user-firstname" name="user[firstname]"><option value="x">xVal</option><option value="y">yVal</option></select>'
 
 				expect(e).toBe(r)
 			})
@@ -639,7 +639,7 @@ component extends="wheels.WheelsTest" {
 					textField = "firstName",
 					label = false
 				)
-				e = '<select id="user-firstname" name="user[firstname]"><option value="#users[1].id#">Tony</option><option value="#users[2].id#">Chris</option><option value="#users[3].id#">Per</option><option value="#users[4].id#">Raul</option><option value="#users[5].id#">Joe</option></select>'
+				e = '<select data-auto-id="user_firstname" id="user-firstname" name="user[firstname]"><option value="#users[1].id#">Tony</option><option value="#users[2].id#">Chris</option><option value="#users[3].id#">Per</option><option value="#users[4].id#">Raul</option><option value="#users[5].id#">Joe</option></select>'
 
 				expect(e).toBe(r)
 			})
@@ -647,7 +647,7 @@ component extends="wheels.WheelsTest" {
 			it("first non numeric property defaults text field on query", () => {
 				users = user.findAll(returnAs = "query", order = "id")
 				r = _controller.select(objectName = "user", property = "firstname", options = users, label = false)
-				e = '<select id="user-firstname" name="user[firstname]"><option value="#users["id"][1]#">tonyp</option><option value="#users["id"][2]#">chrisp</option><option value="#users["id"][3]#">perd</option><option value="#users["id"][4]#">raulr</option><option value="#users["id"][5]#">joeb</option></select>'
+				e = '<select data-auto-id="user_firstname" id="user-firstname" name="user[firstname]"><option value="#users["id"][1]#">tonyp</option><option value="#users["id"][2]#">chrisp</option><option value="#users["id"][3]#">perd</option><option value="#users["id"][4]#">raulr</option><option value="#users["id"][5]#">joeb</option></select>'
 
 				expect(e).toBe(r)
 			})
@@ -655,7 +655,7 @@ component extends="wheels.WheelsTest" {
 			it("first non numeric property defaults text field on objects", () => {
 				users = user.findAll(returnAs = "objects", order = "id")
 				r = _controller.select(objectName = "user", property = "firstname", options = users, label = false)
-				e = '<select id="user-firstname" name="user[firstname]"><option value="#users[1].id#">tonyp</option><option value="#users[2].id#">chrisp</option><option value="#users[3].id#">perd</option><option value="#users[4].id#">raulr</option><option value="#users[5].id#">joeb</option></select>'
+				e = '<select data-auto-id="user_firstname" id="user-firstname" name="user[firstname]"><option value="#users[1].id#">tonyp</option><option value="#users[2].id#">chrisp</option><option value="#users[3].id#">perd</option><option value="#users[4].id#">raulr</option><option value="#users[5].id#">joeb</option></select>'
 
 				expect(e).toBe(r)
 			})
@@ -667,7 +667,7 @@ component extends="wheels.WheelsTest" {
 				options[2] = {}
 				options[2].pd = "per djurner"
 				r = _controller.select(objectName = "user", property = "firstname", options = options, label = false)
-				e = '<select id="user-firstname" name="user[firstname]"><option value="tp">tony petruzzi</option><option value="pd">per djurner</option></select>'
+				e = '<select data-auto-id="user_firstname" id="user-firstname" name="user[firstname]"><option value="tp">tony petruzzi</option><option value="pd">per djurner</option></select>'
 
 				expect(e).toBe(r)
 			})
@@ -686,7 +686,7 @@ component extends="wheels.WheelsTest" {
 					textField = "name",
 					label = false
 				)
-				e = '<select id="user-firstname" name="user[firstname]"><option value="petruzzi">tony</option><option value="djurner">per</option></select>'
+				e = '<select data-auto-id="user_firstname" id="user-firstname" name="user[firstname]"><option value="petruzzi">tony</option><option value="djurner">per</option></select>'
 
 				expect(e).toBe(r)
 			})
@@ -1027,7 +1027,7 @@ component extends="wheels.WheelsTest" {
 			it("is valid", () => {
 				_controller = g.controller(name = "ControllerWithModel")
 				e = _controller.textArea(objectName = "user", property = "firstname")
-				r = '<label for="user-firstname">Firstname<textarea id="user-firstname" maxlength="50" name="user&##x5b;firstname&##x5d;">Tony</textarea></label>'
+				r = '<label for="user-firstname">Firstname<textarea data-auto-id="user_firstname" id="user-firstname" maxlength="50" name="user&##x5b;firstname&##x5d;">Tony</textarea></label>'
 
 				expect(e).toBe(r)
 			})
@@ -1203,7 +1203,7 @@ component extends="wheels.WheelsTest" {
 				args.startyear = "1980"
 				args.endyear = "1990"
 				e = _controller.dateSelect(argumentCollection = args)
-				r = '<select id="user-birthday-year" name="user[birthday]($year)"><option selected="selected" value="1975">1975</option><option value="1976">1976</option><option value="1977">1977</option><option value="1978">1978</option><option value="1979">1979</option><option value="1980">1980</option><option value="1981">1981</option><option value="1982">1982</option><option value="1983">1983</option><option value="1984">1984</option><option value="1985">1985</option><option value="1986">1986</option><option value="1987">1987</option><option value="1988">1988</option><option value="1989">1989</option><option value="1990">1990</option></select>';
+				r = '<select data-auto-id="user_birthday_year" id="user-birthday-year" name="user[birthday]($year)"><option selected="selected" value="1975">1975</option><option value="1976">1976</option><option value="1977">1977</option><option value="1978">1978</option><option value="1979">1979</option><option value="1980">1980</option><option value="1981">1981</option><option value="1982">1982</option><option value="1983">1983</option><option value="1984">1984</option><option value="1985">1985</option><option value="1986">1986</option><option value="1987">1987</option><option value="1988">1988</option><option value="1989">1989</option><option value="1990">1990</option></select>';
 
 				expect(e).toBe(r)
 			})
@@ -1213,7 +1213,7 @@ component extends="wheels.WheelsTest" {
 				args.startyear = "1980"
 				args.endyear = "1990"
 				r = _controller.dateSelect(argumentCollection = args)
-				e = '<select id="user-birthday-year" name="user[birthday]($year)"><option value="1980">1980</option><option value="1981">1981</option><option value="1982">1982</option><option value="1983">1983</option><option value="1984">1984</option><option value="1985">1985</option><option value="1986">1986</option><option value="1987">1987</option><option value="1988">1988</option><option value="1989">1989</option><option value="1990">1990</option></select>'
+				e = '<select data-auto-id="user_birthday_year" id="user-birthday-year" name="user[birthday]($year)"><option value="1980">1980</option><option value="1981">1981</option><option value="1982">1982</option><option value="1983">1983</option><option value="1984">1984</option><option value="1985">1985</option><option value="1986">1986</option><option value="1987">1987</option><option value="1988">1988</option><option value="1989">1989</option><option value="1990">1990</option></select>'
 
 				expect(e).toBe(r)
 			})
@@ -1222,7 +1222,7 @@ component extends="wheels.WheelsTest" {
 				args.startyear = "1990"
 				args.endyear = "1980"
 				e = _controller.dateSelect(argumentCollection = args)
-				r = '<select id="user-birthday-year" name="user[birthday]($year)"><option value="1990">1990</option><option value="1989">1989</option><option value="1988">1988</option><option value="1987">1987</option><option value="1986">1986</option><option value="1985">1985</option><option value="1984">1984</option><option value="1983">1983</option><option value="1982">1982</option><option value="1981">1981</option><option value="1980">1980</option><option value="1979">1979</option><option value="1978">1978</option><option value="1977">1977</option><option value="1976">1976</option><option selected="selected" value="1975">1975</option></select>'
+				r = '<select data-auto-id="user_birthday_year" id="user-birthday-year" name="user[birthday]($year)"><option value="1990">1990</option><option value="1989">1989</option><option value="1988">1988</option><option value="1987">1987</option><option value="1986">1986</option><option value="1985">1985</option><option value="1984">1984</option><option value="1983">1983</option><option value="1982">1982</option><option value="1981">1981</option><option value="1980">1980</option><option value="1979">1979</option><option value="1978">1978</option><option value="1977">1977</option><option value="1976">1976</option><option selected="selected" value="1975">1975</option></select>'
 
 				expect(e).toBe(r)
 			})
@@ -1232,7 +1232,7 @@ component extends="wheels.WheelsTest" {
 				args.startyear = "1990"
 				args.endyear = "1980"
 				e = _controller.dateSelect(argumentCollection = args)
-				r = '<select id="user-birthday-year" name="user[birthday]($year)"><option value="1990">1990</option><option value="1989">1989</option><option value="1988">1988</option><option value="1987">1987</option><option value="1986">1986</option><option value="1985">1985</option><option value="1984">1984</option><option value="1983">1983</option><option value="1982">1982</option><option value="1981">1981</option><option value="1980">1980</option></select>'
+				r = '<select data-auto-id="user_birthday_year" id="user-birthday-year" name="user[birthday]($year)"><option value="1990">1990</option><option value="1989">1989</option><option value="1988">1988</option><option value="1987">1987</option><option value="1986">1986</option><option value="1985">1985</option><option value="1984">1984</option><option value="1983">1983</option><option value="1982">1982</option><option value="1981">1981</option><option value="1980">1980</option></select>'
 
 				expect(e).toBe(r)
 			})

--- a/vendor/wheels/tests/specs/view/formsdateobjectSpec.cfc
+++ b/vendor/wheels/tests/specs/view/formsdateobjectSpec.cfc
@@ -49,7 +49,7 @@ component extends="wheels.WheelsTest" {
 				args.order = "year"
 				args.startyear = "1976"
 				args.endyear = "1980"
-				e = '<select id="user-birthday-year" name="user[birthday]($year)"><option selected="selected" value="1975">1975</option><option value="1976">1976</option><option value="1977">1977</option><option value="1978">1978</option><option value="1979">1979</option><option value="1980">1980</option></select>'
+				e = '<select data-auto-id="user_birthday_year" id="user-birthday-year" name="user[birthday]($year)"><option selected="selected" value="1975">1975</option><option value="1976">1976</option><option value="1977">1977</option><option value="1978">1978</option><option value="1979">1979</option><option value="1980">1980</option></select>'
 				r = _controller.dateSelect(argumentcollection = args)
 				
 				expect(e).toBe(r)
@@ -141,10 +141,10 @@ component extends="wheels.WheelsTest" {
 	}
 
 	function dateSelect_month_str(required string property) {
-		return '<select id="user-#arguments.property#-month" name="user[#arguments.property#]($month)"><option value="1">January</option><option value="2">February</option><option value="3">March</option><option value="4">April</option><option value="5">May</option><option value="6">June</option><option value="7">July</option><option value="8">August</option><option value="9">September</option><option value="10">October</option><option selected="selected" value="11">November</option><option value="12">December</option></select>'
+		return '<select data-auto-id="user_#arguments.property#_month" id="user-#arguments.property#-month" name="user[#arguments.property#]($month)"><option value="1">January</option><option value="2">February</option><option value="3">March</option><option value="4">April</option><option value="5">May</option><option value="6">June</option><option value="7">July</option><option value="8">August</option><option value="9">September</option><option value="10">October</option><option selected="selected" value="11">November</option><option value="12">December</option></select>'
 	}
 
 	function dateSelect_year_str(required string property) {
-		return '<select id="user-#arguments.property#-year" name="user[#arguments.property#]($year)"><option value="1973">1973</option><option value="1974">1974</option><option selected="selected" value="1975">1975</option><option value="1976">1976</option></select>'
+		return '<select data-auto-id="user_#arguments.property#_year" id="user-#arguments.property#-year" name="user[#arguments.property#]($year)"><option value="1973">1973</option><option value="1974">1974</option><option selected="selected" value="1975">1975</option><option value="1976">1976</option></select>'
 	}
 }

--- a/vendor/wheels/tests/specs/view/textfieldSpec.cfc
+++ b/vendor/wheels/tests/specs/view/textfieldSpec.cfc
@@ -22,7 +22,7 @@ component extends="wheels.WheelsTest" {
 					label = "lastname error with <strong>bold</strong>",
 					encode = true
 				)
-				expected = '<label for="user-firstname">lastname error with &lt;strong&gt;bold&lt;&##x2f;strong&gt;<input id="user-firstname" maxlength="50" name="user&##x5b;firstname&##x5d;" type="text" value="Tony"></label>'
+				expected = '<label for="user-firstname">lastname error with &lt;strong&gt;bold&lt;&##x2f;strong&gt;<input data-auto-id="user_firstname" id="user-firstname" maxlength="50" name="user&##x5b;firstname&##x5d;" type="text" value="Tony"></label>'
 
 				expect(textField).toBe(expected)
 			})
@@ -34,7 +34,7 @@ component extends="wheels.WheelsTest" {
 					label = "lastname error with <strong>bold</strong>",
 					encode = false
 				)
-				expected = '<label for="user-firstname">lastname error with <strong>bold</strong><input id="user-firstname" maxlength="50" name="user[firstname]" type="text" value="Tony"></label>'
+				expected = '<label for="user-firstname">lastname error with <strong>bold</strong><input data-auto-id="user_firstname" id="user-firstname" maxlength="50" name="user[firstname]" type="text" value="Tony"></label>'
 
 				expect(textField).toBe(expected)
 			})
@@ -47,7 +47,7 @@ component extends="wheels.WheelsTest" {
 					class = 'form-control" onclick="alert(\"xss\")',
 					encode = "attributes"
 				)
-				expected = '<label for="user-firstname">lastname error with <strong>bold</strong><input class="form-control&quot;&##x20;onclick&##x3d;&quot;alert&##x28;&quot;xss&quot;&##x29;" id="user-firstname" maxlength="50" name="user&##x5b;firstname&##x5d;" type="text" value="Tony"></label>'
+				expected = '<label for="user-firstname">lastname error with <strong>bold</strong><input class="form-control&quot;&##x20;onclick&##x3d;&quot;alert&##x28;&quot;xss&quot;&##x29;" data-auto-id="user_firstname" id="user-firstname" maxlength="50" name="user&##x5b;firstname&##x5d;" type="text" value="Tony"></label>'
 
 				expect(textField).toBe(expected)
 			})
@@ -59,7 +59,7 @@ component extends="wheels.WheelsTest" {
 					label = 'Label with <strong>bold</strong> and <script>alert("XSS")</script>',
 					encode = true
 				)
-				expected = '<label for="user-firstname">Label with &lt;strong&gt;bold&lt;&##x2f;strong&gt; and &lt;script&gt;alert&##x28;&quot;XSS&quot;&##x29;&lt;&##x2f;script&gt;<input id="user-firstname" maxlength="50" name="user&##x5b;firstname&##x5d;" type="text" value="Tony"></label>'
+				expected = '<label for="user-firstname">Label with &lt;strong&gt;bold&lt;&##x2f;strong&gt; and &lt;script&gt;alert&##x28;&quot;XSS&quot;&##x29;&lt;&##x2f;script&gt;<input data-auto-id="user_firstname" id="user-firstname" maxlength="50" name="user&##x5b;firstname&##x5d;" type="text" value="Tony"></label>'
 
 				expect(textField).toBe(expected)
 			})

--- a/vendor/wheels/view/formsdate.cfc
+++ b/vendor/wheels/view/formsdate.cfc
@@ -106,6 +106,10 @@ component {
 		StructDelete(arguments, "combine");
 		local.name = $tagName(arguments.objectName, arguments.property);
 		arguments.$id = $tagId(arguments.objectName, arguments.property);
+		// Mirror $applyAutoId's object-bound check here: the child helpers (year/month/etc.)
+		// receive the derived ids like `user-birthday-month`; only emit companion data-auto-id
+		// when the root was object-bound. The $autoIdBound flag propagates that decision.
+		arguments.$autoIdBound = IsSimpleValue(arguments.objectName) && Len(arguments.objectName);
 
 		// in order to support 12-hour format, we have to enforce some rules
 		// if arguments.twelveHour is true, then order MUST contain ampm
@@ -274,6 +278,13 @@ component {
 		}
 		if (!StructKeyExists(arguments, "id")) {
 			arguments.id = arguments.$id & "-" & arguments.$type;
+			if (
+				$get("formHelperDataAutoId")
+				&& StructKeyExists(arguments, "$autoIdBound")
+				&& arguments.$autoIdBound
+			) {
+				arguments["dataAutoId"] = Replace(arguments.id, "-", "_", "all");
+			}
 		}
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
@@ -356,6 +367,13 @@ component {
 		}
 		if (!StructKeyExists(arguments, "id")) {
 			arguments.id = arguments.$id & "-ampm";
+			if (
+				$get("formHelperDataAutoId")
+				&& StructKeyExists(arguments, "$autoIdBound")
+				&& arguments.$autoIdBound
+			) {
+				arguments["dataAutoId"] = Replace(arguments.id, "-", "_", "all");
+			}
 		}
 		local.content = "";
 		local.optionsArray = ListToArray(local.options);

--- a/vendor/wheels/view/formsobject.cfc
+++ b/vendor/wheels/view/formsobject.cfc
@@ -40,9 +40,7 @@ component {
 	) {
 		$args(name = "textField", reserved = "name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.name = $tagName(arguments.objectName, arguments.property);
@@ -101,9 +99,7 @@ component {
 	) {
 		$args(name = "passwordField", reserved = "type,name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "password";
@@ -163,9 +159,7 @@ component {
 	) {
 		$args(name = "emailField", reserved = "type,name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "email";
@@ -225,9 +219,7 @@ component {
 	) {
 		$args(name = "urlField", reserved = "type,name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "url";
@@ -293,9 +285,7 @@ component {
 	) {
 		$args(name = "numberField", reserved = "type,name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "number";
@@ -351,9 +341,7 @@ component {
 	) {
 		$args(name = "telField", reserved = "type,name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "tel";
@@ -418,9 +406,7 @@ component {
 	) {
 		$args(name = "dateField", reserved = "type,name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "date";
@@ -476,9 +462,7 @@ component {
 	) {
 		$args(name = "colorField", reserved = "type,name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "color";
@@ -540,9 +524,7 @@ component {
 	) {
 		$args(name = "rangeField", reserved = "type,name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "range";
@@ -598,9 +580,7 @@ component {
 	) {
 		$args(name = "searchField", reserved = "type,name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "search";
@@ -646,9 +626,7 @@ component {
 		arguments.objectName = $objectName(argumentCollection = arguments);
 		arguments.type = "hidden";
 		arguments.name = $tagName(arguments.objectName, arguments.property);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		if (!StructKeyExists(arguments, "value") || !Len(arguments.value)) {
 			arguments.value = $formValue(argumentCollection = arguments);
 		}
@@ -705,9 +683,7 @@ component {
 	) {
 		$args(name = "fileField", reserved = "type,name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "file";
@@ -764,9 +740,7 @@ component {
 		if (StructKeyExists(local, "maxLength")) {
 			arguments.maxLength = local.maxLength;
 		}
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.name = $tagName(arguments.objectName, arguments.property);
@@ -822,12 +796,12 @@ component {
 		$args(name = "radioButton", reserved = "type,name,value,checked", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
 		local.valueToAppend = LCase(Replace(ReReplaceNoCase(arguments.tagValue, "[^a-z0-9- ]", "", "all"), " ", "-", "all"));
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-			if (Len(local.valueToAppend)) {
-				arguments.id &= "-" & local.valueToAppend;
-			}
-		}
+		$applyAutoId(
+			args = arguments,
+			objectName = arguments.objectName,
+			property = arguments.property,
+			valueToAppend = local.valueToAppend
+		);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "radio";
@@ -888,9 +862,7 @@ component {
 	) {
 		$args(name = "checkBox", reserved = "type,name,value,checked", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.type = "checkbox";
@@ -923,6 +895,11 @@ component {
 			local.hiddenAttributes.id = arguments.id & "-checkbox";
 			local.hiddenAttributes.name = arguments.name & "($checkbox)";
 			local.hiddenAttributes.value = arguments.uncheckedValue;
+			// Mirror the main checkbox: only emit the data-auto-id companion when the primary
+			// checkbox did (i.e., when the id was auto-derived from an object-bound objectName).
+			if (StructKeyExists(arguments, "dataAutoId")) {
+				local.hiddenAttributes["dataAutoId"] = Replace(local.hiddenAttributes.id, "-", "_", "all");
+			}
 			local.rv &= $tag(name = "input", attributes = local.hiddenAttributes, encode = local.encode);
 		}
 		local.rv &= local.after;
@@ -976,9 +953,7 @@ component {
 	) {
 		$args(name = "select", reserved = "name", args = arguments);
 		arguments.objectName = $objectName(argumentCollection = arguments);
-		if (!StructKeyExists(arguments, "id")) {
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-		}
+		$applyAutoId(args = arguments, objectName = arguments.objectName, property = arguments.property);
 		local.before = $formBeforeElement(argumentCollection = arguments);
 		local.after = $formAfterElement(argumentCollection = arguments);
 		arguments.name = $tagName(arguments.objectName, arguments.property);

--- a/vendor/wheels/view/formsplain.cfc
+++ b/vendor/wheels/view/formsplain.cfc
@@ -567,15 +567,15 @@ component {
 			// Space added to allow a blank value while still not having the form control checked.
 			arguments.objectName[arguments.name] = " ";
 		}
-		if (!StructKeyExists(arguments, "id")) {
-			local.valueToAppend = LCase(
-				Replace(ReReplaceNoCase(arguments.checkedValue, "[^a-z0-9- ]", "", "all"), " ", "-", "all")
-			);
-			arguments.id = $tagId(arguments.objectName, arguments.property);
-			if (Len(local.valueToAppend)) {
-				arguments.id &= "-" & local.valueToAppend;
-			}
-		}
+		local.valueToAppend = LCase(
+			Replace(ReReplaceNoCase(arguments.checkedValue, "[^a-z0-9- ]", "", "all"), " ", "-", "all")
+		);
+		$applyAutoId(
+			args = arguments,
+			objectName = arguments.objectName,
+			property = arguments.property,
+			valueToAppend = local.valueToAppend
+		);
 		StructDelete(arguments, "name");
 		StructDelete(arguments, "value");
 		StructDelete(arguments, "checked");

--- a/vendor/wheels/view/miscellaneous.cfc
+++ b/vendor/wheels/view/miscellaneous.cfc
@@ -580,6 +580,39 @@ component {
 	}
 
 	/**
+	 * Internal function. Sets `args.id` (auto-derived, dash-style) and optionally `args.dataAutoId`
+	 * (underscore-style companion) on a form helper's argument struct when the caller did not
+	 * supply their own `id`. The `dataAutoId` emission is controlled by the `formHelperDataAutoId`
+	 * setting (default true); the `$tag` renderer turns `dataAutoId` into the `data-auto-id`
+	 * attribute during tag assembly. Keeping both labels on the tag lets browser/E2E tests target
+	 * either `##post-title` (historical) or `[data-auto-id='post_title']` (Rails-style).
+	 */
+	public void function $applyAutoId(
+		required struct args,
+		required any objectName,
+		required string property,
+		string valueToAppend = ""
+	) {
+		if (!StructKeyExists(arguments.args, "id")) {
+			arguments.args.id = $tagId(arguments.objectName, arguments.property, arguments.valueToAppend);
+			// Only emit `data-auto-id` for truly object-bound helpers (objectName is a simple,
+			// non-empty string). Tag-style helpers (textFieldTag, selectTag, etc.) use an empty
+			// struct for objectName — those ids are already a plain name with no dash/underscore
+			// ambiguity, so the companion attribute would just be redundant noise.
+			if (
+				$get("formHelperDataAutoId")
+				&& IsSimpleValue(arguments.objectName)
+				&& Len(arguments.objectName)
+			) {
+				// Use bracket notation so Lucee preserves the camelCase key — $tagAttribute
+				// keys off `Left(name, 4) == "data"` and hyphenizes camelCase `dataAutoId`
+				// to `data-auto-id`. A lowercased key (via dot-set on Lucee) skips hyphenize.
+				arguments.args["dataAutoId"] = Replace(arguments.args.id, "-", "_", "all");
+			}
+		}
+	}
+
+	/**
 	 * Internal function.
 	 */
 	public string function $tagName(required any objectName, required string property) {


### PR DESCRIPTION
First batch of seven framework + CLI fixes for gaps surfaced during the Wheels 4.0 guides rewrite (Phase 1). Each commit is self-contained and independently revertable.

## Five commits in this PR (the other two land in the companion LuCLI PR)

### 1. `fix(cli): stale 'wheels server start' → 'wheels start'`
Three user-facing messages in `cli/lucli/Module.cfc` suggested a CLI command that was retired pre-4.0. Users who copied the hint hit 'command not found'. Existing `ServerCommandsTest.cfc` substring asserts still pass.

### 2. `feat(cli): add README.md to empty scaffold directories`
Fresh \`wheels new\` apps create empty \`app/{snippets,plugins,mailers,lib,jobs}/\` directories with no indication of purpose. Added a README.md to each explaining what lives there and how to use it. Scaffolder's existing \`copyTemplateDir\` logic picks them up automatically.

### 3. \`feat(cli): bundle generator snippet templates into wheels new scaffold\`
**P0 fix.** Fresh apps shipped with an empty \`app/snippets/\` directory, which meant \`wheels generate model|controller|scaffold|migration\` immediately errored with 'Template not found: ModelContent.txt'. Copies the framework's 15 \`.txt\` templates into the scaffold template dir so every new app ships with them. Blocked the entire generator workflow for first-time users.

### 4. \`feat(dispatch): emit dev-mode warning when route looks like a binding candidate\`
Route model binding requires explicit \`binding=true\` on \`.resources()\`. Readers who wrote \`post = params.post;\` without setting it got \`params.post is undefined\` with no actionable error. This adds a one-time-per-route dev-mode warning with the exact fix:

> Wheels Route Binding Hint: the route /posts/:key dispatched to Posts##show, but binding is not enabled on this resource. If you intended \`params.post\` to be auto-loaded from the Post model, add \`binding=true\` to the resource.

Gated on \`environment != "production"\` and a new opt-out \`suppressRouteBindingWarnings\` setting (default false). Full core test suite green (3094 pass), 11 new dispatch specs added.

### 5. \`feat(view): emit data-auto-id on object-bound form helpers\`
Form helpers emit \`id='post-title'\` (dash separator). Conventions elsewhere (Rails, Laravel, Django) use underscores, so browser specs written against \`##post_title\` silently fail. Rather than break existing selectors, this emits an additional \`data-auto-id='post_title'\` attribute on every object-bound form element. Users can disable via \`set(formHelperDataAutoId=false)\`. Twelve new tests covering textField / passwordField / emailField / urlField / numberField / telField / colorField / rangeField / searchField / textArea / select / radioButton / checkBox / fileField / dateSelect.

## Context

These came from the [Phase 1 guides report](docs/superpowers/plans/2026-04-18-guides-rewrite-phase-1-report.md) which documents 8 spec-vs-reality deviations uncovered when writing the Build a Blog tutorial against the live CLI. The [gap tracker](docs/superpowers/plans/2026-04-19-framework-gaps-from-guides-phase-1.md) captures 16 items total; this PR lands 5 of them. LuCLI covers 2 more (cfml exit code + JAVA_HOME preflight) in a companion PR.

**Remaining gaps to land in future batches** (docs/plans/2026-04-19-framework-gaps-from-guides-phase-1.md):
- P0: #2 Hotwire/Basecoat/Sentry packages not installable in fresh apps
- P1: #4 bcrypt availability, #6 Auth convenience helper, #7 services.cfm discoverability, #10 offline migrations, #11 LuCLI parallel-spawn race
- P2: #14 generate --dry-run, #15/16 test tooling coverage

Each remaining item is a self-contained card in the tracker, picked up in future sessions.

## Test plan

- [x] \`mvn test\` for Lucee 7 + SQLite in core: 3094 pass / 0 fail / 0 error (includes 23 new specs from #4 and #5)
- [x] \`git diff\` review on each commit for correctness
- [ ] Live smoke test with a freshly rebuilt CLI: \`wheels new probe && cd probe && wheels generate model Post title:string\` should now succeed (requires a rebuild of \`/Users/peter/bin/wheels\`)
- [ ] Spot-check that browser-test authors can target either \`##post-title\` or \`[data-auto-id="post_title"]\` on a scaffolded form