### PR TITLE
docs(controller): update @with docstring to list 'exception' as canonical default

### DIFF
--- a/vendor/wheels/controller/csrf.cfc
+++ b/vendor/wheels/controller/csrf.cfc
@@ -7,7 +7,7 @@ component {
 	 * [section: Controller]
 	 * [category: Configuration Functions]
 	 *
-	 * @with How to handle invalid authenticity token checks. Valid values are `error` (throws a `Wheels.InvalidAuthenticityToken` error), `abort` (aborts the request silently and sends a blank response to the client), and `ignore` (ignores the check and lets the request proceed).
+	 * @with How to handle invalid authenticity token checks. Valid values are `exception` (the default — throws a `Wheels.InvalidAuthenticityToken` error), `abort` (aborts the request silently and sends a blank response to the client), and `ignore` (ignores the check and lets the request proceed).
 	 * @only List of actions that this check should only run on. Leave blank for all.
 	 * @except List of actions that this check should be omitted from running on. Leave blank for no exceptions.
 	 */


### PR DESCRIPTION
## Summary

\`vendor/wheels/controller/csrf.cfc:10\` docstring listed \`error\` as the throw-on-invalid-token value, but the function signature (\`string with = \"exception\"\`) on line 14 uses \`\"exception\"\` as the default. Updated the docstring to name \`exception\` as the canonical default value (aligns with \`deployment/security-hardening.mdx\`).

Closes #2175

## Testing

Docstring-only change. Runtime dispatch only handles \`abort\`/\`ignore\` by name; everything else (both \`exception\` and \`error\`) falls to the throw path, so behavior is unchanged.