### PR TITLE
docs(docs): add wheels deploy guides and CLI reference (starlight-native mdx)

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/boot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/boot.mdx
@@ -1,0 +1,35 @@
+---
+title: "wheels deploy accessory boot"
+description: First-time install and run of a named accessory container.
+type: reference
+sidebar:
+  label: "boot"
+  order: 1
+---
+
+`docker run` the named accessory container on its pinned host(s).
+
+## Synopsis
+
+```
+wheels deploy accessory boot --name=<name|all> [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Behavior
+
+For each targeted accessory, emits `docker run` with the image, env, volumes, and `files:` uploads declared in `deploy.yml`. Container named `<service>-<accessory>`.
+
+## Example
+
+```bash
+wheels deploy accessory boot --name=db
+wheels deploy accessory boot --name=all
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/details.mdx
@@ -1,0 +1,30 @@
+---
+title: "wheels deploy accessory details"
+description: docker ps filtered to the named accessory container.
+type: reference
+sidebar:
+  label: "details"
+  order: 6
+---
+
+`docker ps --filter name=<service>-<name>` on each of the accessory's hosts. Confirms it's up and shows uptime.
+
+## Synopsis
+
+```
+wheels deploy accessory details --name=<name|all> [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Example
+
+```bash
+wheels deploy accessory details --name=db
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/index.mdx
@@ -1,0 +1,37 @@
+---
+title: "wheels deploy accessory"
+description: Sidecar container lifecycle — mirrors app verbs, scoped to a named accessory.
+type: reference
+sidebar:
+  label: "accessory"
+  order: 40
+---
+
+Sidecar container lifecycle. Every accessory verb takes a `--name` (or `all` for fan-out) and targets the pinned host(s) for that accessory.
+
+## Verbs
+
+| Verb | Purpose |
+|------|---------|
+| [`boot`](/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/boot/) | First-time install + run. |
+| [`reboot`](/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/reboot/) | Stop, remove, re-install. |
+| [`start`](/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/start/) | `docker start`. |
+| [`stop`](/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/stop/) | `docker stop`. |
+| [`restart`](/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/restart/) | `docker restart`. |
+| [`details`](/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/details/) | `docker ps --filter`. |
+| [`logs`](/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/logs/) | Tail accessory logs. |
+| [`remove`](/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/remove/) | Stop + remove the container. |
+
+## Common flags
+
+| Flag | Description |
+|------|-------------|
+| `--name=<name>` | **Required.** Accessory name, or `all` to fan out. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+Missing `--name` throws `DeployAccessoryCli.MissingName`.
+
+## Relationship to `wheels deploy`
+
+Accessory verbs are **not** part of the rolling app deploy. `wheels deploy` leaves accessories alone — that's deliberate, so routine rollouts can't accidentally bounce your database. See [Accessories](/v4-0-0-snapshot/deployment/accessories/).

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/logs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/logs.mdx
@@ -1,0 +1,33 @@
+---
+title: "wheels deploy accessory logs"
+description: Tail the named accessory's container logs.
+type: reference
+sidebar:
+  label: "logs"
+  order: 7
+---
+
+`docker logs` on the named accessory, on every host it's pinned to.
+
+## Synopsis
+
+```
+wheels deploy accessory logs --name=<name|all> [--tail=<N>] [--follow] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `--tail=<N>` | Trailing lines per host. Default 100. |
+| `--follow` | Stream logs continuously. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Example
+
+```bash
+wheels deploy accessory logs --name=db --tail=500
+wheels deploy accessory logs --name=redis --follow
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/reboot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/reboot.mdx
@@ -1,0 +1,34 @@
+---
+title: "wheels deploy accessory reboot"
+description: Stop, remove, and re-run the named accessory container.
+type: reference
+sidebar:
+  label: "reboot"
+  order: 2
+---
+
+Stop, remove, and re-run the named accessory container. Useful after bumping the image tag in `deploy.yml`.
+
+## Synopsis
+
+```
+wheels deploy accessory reboot --name=<name|all> [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Behavior
+
+Per accessory: `docker stop <service>-<name>`, `docker rm <service>-<name>`, then the same `docker run` as [`accessory boot`](/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/boot/). Downtime lasts until the new container passes its health check (if declared).
+
+## Example
+
+```bash
+wheels deploy accessory reboot --name=redis
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/remove.mdx
@@ -1,0 +1,36 @@
+---
+title: "wheels deploy accessory remove"
+description: Stop and remove the named accessory container. Volumes persist.
+type: reference
+sidebar:
+  label: "remove"
+  order: 8
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Stop and remove the named accessory container. Does not touch attached volumes.
+
+<Aside type="caution">
+Volumes persist after `accessory remove`. Data survives. If you want a truly clean slate, follow up with `docker volume rm` on the host.
+</Aside>
+
+## Synopsis
+
+```
+wheels deploy accessory remove --name=<name|all> [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Example
+
+```bash
+wheels deploy accessory remove --name=redis
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/restart.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/restart.mdx
@@ -1,0 +1,30 @@
+---
+title: "wheels deploy accessory restart"
+description: docker restart the named accessory container.
+type: reference
+sidebar:
+  label: "restart"
+  order: 5
+---
+
+`docker restart <service>-<name>`. Briefly interrupts the accessory.
+
+## Synopsis
+
+```
+wheels deploy accessory restart --name=<name|all> [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Example
+
+```bash
+wheels deploy accessory restart --name=redis
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/start.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/start.mdx
@@ -1,0 +1,30 @@
+---
+title: "wheels deploy accessory start"
+description: docker start the named accessory container.
+type: reference
+sidebar:
+  label: "start"
+  order: 3
+---
+
+`docker start <service>-<name>` on the accessory's pinned host(s). Fails if the container doesn't exist — use [`accessory boot`](/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/boot/) for first-time install.
+
+## Synopsis
+
+```
+wheels deploy accessory start --name=<name|all> [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Example
+
+```bash
+wheels deploy accessory start --name=db
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/stop.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/stop.mdx
@@ -1,0 +1,30 @@
+---
+title: "wheels deploy accessory stop"
+description: docker stop the named accessory container.
+type: reference
+sidebar:
+  label: "stop"
+  order: 4
+---
+
+`docker stop <service>-<name>`. Container remains on disk — use [`accessory remove`](/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/remove/) to delete.
+
+## Synopsis
+
+```
+wheels deploy accessory stop --name=<name|all> [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Example
+
+```bash
+wheels deploy accessory stop --name=db
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/boot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/boot.mdx
@@ -1,0 +1,47 @@
+---
+title: "wheels deploy app boot"
+description: Run new app containers for the given version on every host in every role.
+type: reference
+sidebar:
+  label: "boot"
+  order: 1
+---
+
+`docker run` new containers for the given version, on every host in every role.
+
+## Synopsis
+
+```
+wheels deploy app boot --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | **Required.** Version to boot. Throws `DeployAppCli.MissingVersion` if absent. |
+| `--role=<name>` | Limit to one role. Default: every role. |
+| `--destination=<name>` | Overlay `deploy.<name>.yml`. |
+| `--dry-run` | Print the `docker run` commands without executing. |
+
+## Behavior
+
+For each host in each role, emits:
+
+```
+docker run --detach --restart unless-stopped \
+  --name <service>-<role>-<version> \
+  --network kamal \
+  --label service=<service> --label role=<role> --label destination=<dest> --label version=<v> \
+  -e KEY=VALUE ... \
+  <image>:<version>
+```
+
+`boot` does **not** ask the proxy to cut traffic — that's what `wheels deploy` does. Use `boot` for a stand-alone container bring-up; use `wheels deploy` for a full zero-downtime rollout.
+
+## Example
+
+```bash
+wheels deploy app boot --version=abc1234
+wheels deploy app boot --version=abc1234 --role=job
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/containers.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/containers.mdx
@@ -1,0 +1,37 @@
+---
+title: "wheels deploy app containers"
+description: docker ps filtered by the service label — lists every version's container on every host.
+type: reference
+sidebar:
+  label: "containers"
+  order: 5
+---
+
+`docker ps` filtered by the service label. Shows every container for the service on every host, across every version. Useful for confirming retained containers before a rollback.
+
+## Synopsis
+
+```
+wheels deploy app containers [--role=<name>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--role=<name>` | Limit to one role. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the command without executing. |
+
+Unlike most `app` verbs, `--version` is **not** required — this verb enumerates every version.
+
+## Behavior
+
+Emits `docker ps --filter label=service=<service>` on every host in the targeted role(s). Running *and* stopped containers are returned.
+
+## Example
+
+```bash
+wheels deploy app containers
+wheels deploy app containers --role=web
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/details.mdx
@@ -1,0 +1,37 @@
+---
+title: "wheels deploy app details"
+description: docker inspect for the app containers at the given version.
+type: reference
+sidebar:
+  label: "details"
+  order: 4
+---
+
+`docker inspect --format={{.State.Status}}` for the named container version on every host. Shows running / exited / paused state.
+
+## Synopsis
+
+```
+wheels deploy app details --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | **Required.** |
+| `--role=<name>` | Limit to one role. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Emits `docker inspect --format={{.State.Status}} <service>-<role>-<version>` per host per role. Output is prefixed by host.
+
+For a broader sweep that shows every service-labelled container regardless of version, use [`app containers`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/containers/) instead.
+
+## Example
+
+```bash
+wheels deploy app details --version=abc1234
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/images.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/images.mdx
@@ -1,0 +1,38 @@
+---
+title: "wheels deploy app images"
+description: docker images for the configured app image — shows every pulled version on every host.
+type: reference
+sidebar:
+  label: "images"
+  order: 6
+---
+
+`docker images <image>` across every host. Lists every pulled tag of the app image, useful for confirming what's available to roll back to.
+
+## Synopsis
+
+```
+wheels deploy app images [--role=<name>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--role=<name>` | Limit to one role. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the command without executing. |
+
+`--version` is not required.
+
+## Behavior
+
+Emits `docker images <image>` on every host. Output includes image ID, tag, and created-at — the usual `docker images` columns.
+
+To reduce disk pressure from old images, run [`wheels deploy prune images`](/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/images/).
+
+## Example
+
+```bash
+wheels deploy app images
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/index.mdx
@@ -1,0 +1,34 @@
+---
+title: "wheels deploy app"
+description: App container lifecycle verbs — boot, start, stop, logs, containers, images, live, maintenance, remove.
+type: reference
+sidebar:
+  label: "app"
+  order: 20
+---
+
+App container lifecycle. Every verb targets containers labelled with the current service, optionally filtered by `--role`.
+
+## Verbs
+
+| Verb | Purpose |
+|------|---------|
+| [`boot`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/boot/) | `docker run` new containers for the given version. |
+| [`start`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/start/) | `docker start` existing stopped containers. |
+| [`stop`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/stop/) | `docker stop` running containers. |
+| [`details`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/details/) | `docker inspect` for the given version's containers. |
+| [`containers`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/containers/) | `docker ps` filtered by service label. |
+| [`images`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/images/) | `docker images` for the app image. |
+| [`logs`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/logs/) | `docker logs` across every host. |
+| [`live`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/live/) | Clear the maintenance marker file. |
+| [`maintenance`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/maintenance/) | Write the maintenance marker file. |
+| [`remove`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/remove/) | Stop + remove containers for the given version. |
+
+## Common flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | Required for boot/start/stop/details/live/maintenance/remove. |
+| `--role=<name>` | Limit to one role. Default: all roles. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/live.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/live.mdx
@@ -1,0 +1,41 @@
+---
+title: "wheels deploy app live"
+description: Clear the server-side maintenance marker file so traffic resumes.
+type: reference
+sidebar:
+  label: "live"
+  order: 8
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Clear the server-side maintenance marker, resuming traffic. Pair with [`app maintenance`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/maintenance/).
+
+## Synopsis
+
+```
+wheels deploy app live --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | **Required** by the same parser as the other app verbs. |
+| `--role=<name>` | Limit to one role. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Emits `rm -f /tmp/kamal-maintenance-<service>` on every host in the targeted role(s).
+
+<Aside type="note" title="Phase 2 simplification">
+The Phase 2 port uses a marker-file convention rather than `kamal-proxy`'s native maintenance mode. An app-level check against `/tmp/kamal-maintenance-<service>` is the current contract. A follow-up will swap in native proxy-level maintenance for true out-of-band blocking.
+</Aside>
+
+## Example
+
+```bash
+wheels deploy app live --version=abc1234
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/logs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/logs.mdx
@@ -1,0 +1,43 @@
+---
+title: "wheels deploy app logs"
+description: docker logs fanned out across every host. Tail, follow, and per-container filtering supported.
+type: reference
+sidebar:
+  label: "logs"
+  order: 7
+---
+
+`docker logs` fanned out across every host, prefixed by host. Follows and per-container targeting supported.
+
+## Synopsis
+
+```
+wheels deploy app logs [--tail=<N>] [--follow] [--container=<name>] [--role=<name>] [--destination=<name>]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--tail=<N>` | Trailing lines per host. Default 100. |
+| `--follow` | `docker logs --follow`. Leaves the connection open; Ctrl-C to stop. |
+| `--container=<name>` | Target one specific container name instead of every service-labelled container. |
+| `--role=<name>` | Limit to one role. |
+| `--destination=<name>` | Overlay destination config. |
+
+`--version` is not required.
+
+## Behavior
+
+Emits `docker logs --tail <N> [--follow] [<container>]` per host. Output is line-buffered and prefixed with `[<host>]`.
+
+Under `--follow`, the command fans out in parallel and stays running until interrupted.
+
+## Examples
+
+```bash
+wheels deploy app logs
+wheels deploy app logs --tail=500
+wheels deploy app logs --follow --role=web
+wheels deploy app logs --container=myapp-web-abc1234
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/maintenance.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/maintenance.mdx
@@ -1,0 +1,41 @@
+---
+title: "wheels deploy app maintenance"
+description: Write the server-side maintenance marker file so the app can return a maintenance response.
+type: reference
+sidebar:
+  label: "maintenance"
+  order: 9
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Write the server-side maintenance marker. Pair with [`app live`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/live/) to clear it.
+
+## Synopsis
+
+```
+wheels deploy app maintenance --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | **Required** by the same parser as the other app verbs. |
+| `--role=<name>` | Limit to one role. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Emits `touch /tmp/kamal-maintenance-<service>` on every host in the targeted role(s). Your app is responsible for checking for the marker and serving a maintenance response — this verb only writes the file.
+
+<Aside type="note" title="Phase 2 simplification">
+The Phase 2 port uses a marker-file convention rather than `kamal-proxy`'s native maintenance mode. A follow-up will swap in native proxy-level maintenance for true out-of-band blocking — the file-based approach here assumes app-level cooperation.
+</Aside>
+
+## Example
+
+```bash
+wheels deploy app maintenance --version=abc1234
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/remove.mdx
@@ -1,0 +1,43 @@
+---
+title: "wheels deploy app remove"
+description: Stop and remove app containers for the given version on every host.
+type: reference
+sidebar:
+  label: "remove"
+  order: 10
+---
+
+Stop and remove app containers for the given version. Scoped to one version — use [`wheels deploy remove`](/v4-0-0-snapshot/command-line-tools/commands/deploy/remove/) for a broader teardown.
+
+## Synopsis
+
+```
+wheels deploy app remove --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | **Required.** |
+| `--role=<name>` | Limit to one role. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Behavior
+
+For each host in each targeted role, chains:
+
+```
+docker stop <service>-<role>-<version> && docker rm <service>-<role>-<version>
+```
+
+Fails per-host if the container doesn't exist.
+
+Prefer [`wheels deploy prune`](/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/) for retention-policy-driven cleanup. `app remove` is surgical — it removes exactly the version you named.
+
+## Example
+
+```bash
+wheels deploy app remove --version=abc1234
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/start.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/start.mdx
@@ -1,0 +1,37 @@
+---
+title: "wheels deploy app start"
+description: docker start existing app containers for the given version.
+type: reference
+sidebar:
+  label: "start"
+  order: 2
+---
+
+`docker start` existing containers for the given version. Useful after a `stop`, or to resurrect a previously-pruned container.
+
+## Synopsis
+
+```
+wheels deploy app start --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | **Required.** Must match an existing container's version label. |
+| `--role=<name>` | Limit to one role. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Emits `docker start <service>-<role>-<version>` on every host in the targeted role(s). Fails per-host if the container doesn't exist.
+
+Does not touch the proxy. For traffic to flow to started containers, follow up with `wheels deploy rollback --version=<v>`.
+
+## Example
+
+```bash
+wheels deploy app start --version=abc1234
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/stop.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/app/stop.mdx
@@ -1,0 +1,37 @@
+---
+title: "wheels deploy app stop"
+description: docker stop the app containers for the given version.
+type: reference
+sidebar:
+  label: "stop"
+  order: 3
+---
+
+`docker stop` app containers for the given version. Containers remain on disk — use `app remove` to delete them.
+
+## Synopsis
+
+```
+wheels deploy app stop --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | **Required.** |
+| `--role=<name>` | Limit to one role. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Behavior
+
+Emits `docker stop <service>-<role>-<version>` on every host in the target role(s). The proxy is not notified — in-flight requests to the stopped container will fail until you cut traffic elsewhere or restart.
+
+For traffic-safe shutdown, use `wheels deploy rollback` to the previous version first.
+
+## Example
+
+```bash
+wheels deploy app stop --version=abc1234
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/audit.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/audit.mdx
@@ -1,0 +1,37 @@
+---
+title: "wheels deploy audit"
+description: Tail the on-host audit log — who deployed what, when.
+type: reference
+sidebar:
+  label: "audit"
+  order: 8
+---
+
+Tail the on-host audit log. Every deploy appends an entry with the actor, version, and timestamp to `/tmp/kamal-audit.log` on every host; `audit` reads the last N lines from each host and streams them back.
+
+## Synopsis
+
+```
+wheels deploy audit [--tail=<N>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--tail=<N>` | Number of trailing lines per host. Default 100. |
+| `--destination=<name>` | Overlay `deploy.<name>.yml`. |
+| `--dry-run` | Print the `tail` command that would run. |
+
+## Behavior
+
+Dispatches `tail -n <N> /tmp/kamal-audit.log` to every host in parallel, prefixes output by host. Entries are plain text — one event per line.
+
+The audit log is on ephemeral `/tmp`, so it doesn't survive host reboots. For durable audit, pipe the log into your observability stack via a hook — see [Hooks](/v4-0-0-snapshot/deployment/hooks/).
+
+## Example
+
+```bash
+wheels deploy audit
+wheels deploy audit --tail=500 --destination=production
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/create.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/create.mdx
@@ -1,0 +1,39 @@
+---
+title: "wheels deploy build create"
+description: Create a docker buildx builder for multi-arch or remote builds.
+type: reference
+sidebar:
+  label: "create"
+  order: 4
+---
+
+Create a `docker buildx` builder on the control machine. One-time setup for multi-arch builds and remote builds.
+
+## Synopsis
+
+```
+wheels deploy build create [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## When to run
+
+- Before the first multi-arch build (`builder.arch:` has more than one entry).
+- Before the first build against a remote builder (`builder.remote:` is set).
+- Single-arch local builds don't need `build create` — `docker build` alone suffices.
+
+## Behavior
+
+Emits `docker buildx create --use ...` with a name derived from the service. Idempotent — re-running uses the existing builder.
+
+## Example
+
+```bash
+wheels deploy build create
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/deliver.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/deliver.mdx
@@ -1,0 +1,38 @@
+---
+title: "wheels deploy build deliver"
+description: Build, push, and pull a new image. Combines push and pull in one command.
+type: reference
+sidebar:
+  label: "deliver"
+  order: 1
+---
+
+Build, push, and pull a new image. Equivalent to `push` followed by `pull`. Skips the rolling traffic switch that [`wheels deploy`](/v4-0-0-snapshot/command-line-tools/commands/deploy/deploy/) would add.
+
+## Synopsis
+
+```
+wheels deploy build deliver [--version=<v>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | Version label. Defaults to `git rev-parse --short HEAD`. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print both local + remote commands without executing. |
+
+## Behavior
+
+1. Runs locally: `docker build` → `docker push`.
+2. Runs remotely on every host: `docker pull`.
+
+No container is started — use [`wheels deploy`](/v4-0-0-snapshot/command-line-tools/commands/deploy/deploy/) for a full rollout.
+
+## Example
+
+```bash
+wheels deploy build deliver
+wheels deploy build deliver --version=v1.2.3
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/details.mdx
@@ -1,0 +1,33 @@
+---
+title: "wheels deploy build details"
+description: docker buildx inspect for the configured builder.
+type: reference
+sidebar:
+  label: "details"
+  order: 6
+---
+
+`docker buildx inspect` for the builder associated with this service.
+
+## Synopsis
+
+```
+wheels deploy build details [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Shows builder name, driver, endpoint, and supported platforms. Confirms multi-arch builds will land on the architectures you expect.
+
+## Example
+
+```bash
+wheels deploy build details
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/dev.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/dev.mdx
@@ -1,0 +1,34 @@
+---
+title: "wheels deploy build dev"
+description: Build a local dev-tagged image without pushing to a registry.
+type: reference
+sidebar:
+  label: "dev"
+  order: 7
+---
+
+Build the app image locally and tag it with `:dev`. No registry push; intended for local smoke testing.
+
+## Synopsis
+
+```
+wheels deploy build dev [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the `docker build` command without executing. |
+
+## Behavior
+
+Emits `docker build -t <image>:dev ...` on the control machine, using the same `builder.context`, `dockerfile`, and `args` as a regular push. No `docker push`. Useful when you want to verify the image builds before running `wheels deploy build push`.
+
+## Example
+
+```bash
+wheels deploy build dev
+docker run --rm -it <image>:dev   # spot-check locally
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/index.mdx
@@ -1,0 +1,30 @@
+---
+title: "wheels deploy build"
+description: Docker image lifecycle verbs — deliver, push, pull, create, remove, details, dev.
+type: reference
+sidebar:
+  label: "build"
+  order: 50
+---
+
+Docker image lifecycle. Most build verbs run **locally** on the control machine; only `pull` fans out to every host.
+
+## Verbs
+
+| Verb | Runs | Purpose |
+|------|------|---------|
+| [`deliver`](/v4-0-0-snapshot/command-line-tools/commands/deploy/build/deliver/) | local + remote | `push` then `pull`. |
+| [`push`](/v4-0-0-snapshot/command-line-tools/commands/deploy/build/push/) | local | Build and push image. |
+| [`pull`](/v4-0-0-snapshot/command-line-tools/commands/deploy/build/pull/) | remote | Pull image on every host. |
+| [`create`](/v4-0-0-snapshot/command-line-tools/commands/deploy/build/create/) | local | Set up a buildx builder. |
+| [`remove`](/v4-0-0-snapshot/command-line-tools/commands/deploy/build/remove/) | local | Tear down the buildx builder. |
+| [`details`](/v4-0-0-snapshot/command-line-tools/commands/deploy/build/details/) | local | Inspect the buildx builder. |
+| [`dev`](/v4-0-0-snapshot/command-line-tools/commands/deploy/build/dev/) | local | Build a dev-tagged image for local use. |
+
+## When to use these directly
+
+`wheels deploy` already calls `push` and `pull` as part of the rolling flow. Reach for `build` verbs directly when you want to:
+
+- Preview the exact `docker build` / `docker push` command that will run (`--dry-run`).
+- Build on CI and push without deploying.
+- Pull a fresh image onto every host without advancing versions.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/pull.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/pull.mdx
@@ -1,0 +1,36 @@
+---
+title: "wheels deploy build pull"
+description: docker pull the image on every host in parallel.
+type: reference
+sidebar:
+  label: "pull"
+  order: 3
+---
+
+`docker pull <image>:<version>` on every host in every role, in parallel.
+
+## Synopsis
+
+```
+wheels deploy build pull [--version=<v>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | Version to pull. Defaults to git short sha. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Fans out over SSH. Each host pulls independently; a slow host doesn't block the others.
+
+Assumes the image is already pushed — use [`build push`](/v4-0-0-snapshot/command-line-tools/commands/deploy/build/push/) first, or [`build deliver`](/v4-0-0-snapshot/command-line-tools/commands/deploy/build/deliver/) for both.
+
+## Example
+
+```bash
+wheels deploy build pull --version=abc1234
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/push.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/push.mdx
@@ -1,0 +1,39 @@
+---
+title: "wheels deploy build push"
+description: docker build + docker push on the control machine.
+type: reference
+sidebar:
+  label: "push"
+  order: 2
+---
+
+Build the image locally and push it to the configured registry. Runs on the control machine; no SSH, no remote hosts.
+
+## Synopsis
+
+```
+wheels deploy build push [--version=<v>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | Tag for the pushed image. Defaults to git short sha. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the `docker build` + `docker push` commands without executing. |
+
+## Behavior
+
+Uses the `builder:` block in `deploy.yml`:
+
+1. `docker build` with `context`, `dockerfile`, `args`, and `arch` from config.
+2. `docker push <image>:<version>`.
+
+If `builder.remote:` is set, the build happens on the remote builder over SSH instead of locally. Multi-arch builds require `docker buildx` (run [`build create`](/v4-0-0-snapshot/command-line-tools/commands/deploy/build/create/) once).
+
+## Example
+
+```bash
+wheels deploy build push
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/build/remove.mdx
@@ -1,0 +1,33 @@
+---
+title: "wheels deploy build remove"
+description: Tear down the docker buildx builder created by build create.
+type: reference
+sidebar:
+  label: "remove"
+  order: 5
+---
+
+Remove the `docker buildx` builder. Inverse of [`build create`](/v4-0-0-snapshot/command-line-tools/commands/deploy/build/create/).
+
+## Synopsis
+
+```
+wheels deploy build remove [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Emits `docker buildx rm <builder-name>` on the control machine. Re-creating is cheap; tear down when you've switched to a different build strategy or want a clean state.
+
+## Example
+
+```bash
+wheels deploy build remove
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/config.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/config.mdx
@@ -1,0 +1,52 @@
+---
+title: "wheels deploy config"
+description: Print the resolved deploy.yml as YAML — useful for verifying env interpolation and destination overlays.
+type: reference
+sidebar:
+  label: "config"
+  order: 5
+---
+
+Print the fully-resolved `deploy.yml` config as YAML. Mustache interpolation is expanded; destination overlays are merged. Makes no network calls.
+
+## Synopsis
+
+```
+wheels deploy config [--destination=<name>] [--config=<path>]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay `deploy.<name>.yml` before printing. |
+| `--config=<path>` | Override `config/deploy.yml`. |
+
+## Output
+
+Prints a YAML dump with four keys that matter at deploy time:
+
+```yaml
+service: myapp
+image: myorg/myapp
+servers:
+  web:
+    - 192.0.2.10
+registry:
+  server: ghcr.io
+  username: myorg
+```
+
+Full per-role options, env merging, and accessory blocks are not emitted in Phase 1 — `wheels deploy config` is a deliberate subset focused on what most users want to verify (which hosts, which image, which registry).
+
+## When to use
+
+- Verify `--destination` overlays apply the keys you expect.
+- Confirm `{{env.*}}` resolves to the right values.
+- Diff against `kamal config` during a migration from Ruby Kamal.
+
+## Example
+
+```bash
+wheels deploy config --destination=staging
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/deploy.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/deploy.mdx
@@ -1,0 +1,43 @@
+---
+title: "wheels deploy deploy"
+description: Rolling zero-downtime deploy. The everyday verb — builds, pushes, pulls, boots new containers, and asks kamal-proxy to cut traffic over.
+type: reference
+sidebar:
+  label: "deploy"
+  order: 1
+---
+
+The everyday deploy verb. Runs the full rolling flow: lock, build, push, pull, boot new containers, cut traffic, release lock.
+
+## Synopsis
+
+```
+wheels deploy [--version=<v>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | Version label for the new containers. Defaults to `git rev-parse --short HEAD`. |
+| `--destination=<name>` | Overlay `deploy.<name>.yml` and `.kamal/secrets.<name>`. |
+| `--dry-run` | Print the commands that would run, prefixed by host. No network. |
+| `--config=<path>` | Override `config/deploy.yml`. |
+
+## Behavior
+
+1. Fires `pre-deploy` hook on the control machine.
+2. Acquires a per-service lock on one host.
+3. Pulls the image on every host in parallel.
+4. Boots `kamal-proxy` if it isn't running.
+5. For each host sequentially: `docker run` new container, then `kamal-proxy deploy` to cut traffic.
+6. Releases the lock.
+7. Fires `post-deploy` hook (or `post-deploy-failure` if anything threw).
+
+## Examples
+
+```bash
+wheels deploy
+wheels deploy --version=v1.2.3
+wheels deploy --destination=staging --dry-run
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/details.mdx
@@ -1,0 +1,40 @@
+---
+title: "wheels deploy details"
+description: Aggregate app container, proxy, and accessory state across every host.
+type: reference
+sidebar:
+  label: "details"
+  order: 9
+---
+
+Aggregate state — app containers, proxy, and every accessory — across every host. The first stop when something looks off.
+
+## Synopsis
+
+```
+wheels deploy details [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay `deploy.<name>.yml`. |
+| `--dry-run` | Print the `docker ps` commands that would run. |
+
+## Behavior
+
+Per host, in parallel, runs three things:
+
+1. App `docker ps` filtered by `label=service=<service>` (same as [`wheels deploy app containers`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/containers/)).
+2. Proxy `docker ps` filtered to the `kamal-proxy` container (same as [`wheels deploy proxy details`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/details/)).
+3. For each accessory, a filtered `docker ps` on its pinned host.
+
+Output is prefixed by host, then by role.
+
+## Example
+
+```bash
+wheels deploy details
+wheels deploy details --destination=production
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/docs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/docs.mdx
@@ -1,0 +1,41 @@
+---
+title: "wheels deploy docs"
+description: Print embedded per-topic Markdown help shipped with the CLI binary.
+type: reference
+sidebar:
+  label: "docs"
+  order: 10
+---
+
+Print embedded per-topic help. `wheels deploy docs` lists the available sections; `wheels deploy docs <section>` prints that section's Markdown.
+
+## Synopsis
+
+```
+wheels deploy docs [<section>]
+```
+
+## Sections
+
+- `accessories` — sidecar containers
+- `builder` — Docker image build config
+- `env` — environment variable handling
+- `hooks` — `.kamal/hooks/` scripts
+- `proxy` — `kamal-proxy` configuration
+- `registry` — image registry setup
+- `servers` — the `servers:` block shapes
+- `ssh` — SSH connection config
+
+## Behavior
+
+Output is plain Markdown straight from the binary's bundled docs. Unknown section names throw `DeployMainCli.UnknownDocsSection`.
+
+These embedded docs are a terser, hands-on companion to the web guides. For the full treatment, see [Deployment & Operations](/v4-0-0-snapshot/deployment/).
+
+## Examples
+
+```bash
+wheels deploy docs
+wheels deploy docs proxy
+wheels deploy docs ssh
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/index.mdx
@@ -1,0 +1,90 @@
+---
+title: "wheels deploy"
+description: The wheels deploy verb surface — 25 top-level verbs plus nine subcommand groups, mirrored from Kamal 2.4.0.
+type: reference
+sidebar:
+  order: 11
+---
+
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+`wheels deploy` is the Kamal-compatible deploy orchestrator built into the Wheels CLI. Every verb runs locally on the control machine — there is no agent on the target hosts. Commands fan out over SSH, stream prefixed output back, and honor `--dry-run` uniformly.
+
+For the end-to-end walk, start at [Your First Deploy](/v4-0-0-snapshot/deployment/first-deploy/). For the configuration schema, see [deploy.yml Reference](/v4-0-0-snapshot/deployment/config-reference/). This page is the dry verb index.
+
+## Top-level verbs
+
+| Verb | Purpose |
+|------|---------|
+| [`wheels deploy`](/v4-0-0-snapshot/command-line-tools/commands/deploy/deploy/) | Rolling zero-downtime deploy. The everyday verb. |
+| [`wheels deploy setup`](/v4-0-0-snapshot/command-line-tools/commands/deploy/setup/) | First-run deploy — includes proxy and accessory boot. |
+| [`wheels deploy redeploy`](/v4-0-0-snapshot/command-line-tools/commands/deploy/redeploy/) | Re-run the deploy flow without version bump. |
+| [`wheels deploy rollback`](/v4-0-0-snapshot/command-line-tools/commands/deploy/rollback/) | Route traffic back to a previous version. |
+| [`wheels deploy config`](/v4-0-0-snapshot/command-line-tools/commands/deploy/config/) | Print the resolved `deploy.yml` config. |
+| [`wheels deploy init`](/v4-0-0-snapshot/command-line-tools/commands/deploy/init/) | Stamp out `deploy.yml` and `.kamal/secrets`. |
+| [`wheels deploy version`](/v4-0-0-snapshot/command-line-tools/commands/deploy/version/) | Show the mirrored Kamal and kamal-proxy versions. |
+| [`wheels deploy audit`](/v4-0-0-snapshot/command-line-tools/commands/deploy/audit/) | Tail the on-host audit log. |
+| [`wheels deploy details`](/v4-0-0-snapshot/command-line-tools/commands/deploy/details/) | Aggregate app + proxy + accessory state. |
+| [`wheels deploy docs`](/v4-0-0-snapshot/command-line-tools/commands/deploy/docs/) | Print embedded per-topic help. |
+| [`wheels deploy remove`](/v4-0-0-snapshot/command-line-tools/commands/deploy/remove/) | Destructive teardown. Requires `--confirm`. |
+
+## Subcommand groups
+
+<CardGrid>
+  <LinkCard
+    title="wheels deploy app"
+    href="/v4-0-0-snapshot/command-line-tools/commands/deploy/app/"
+    description="App container lifecycle: boot, start, stop, logs, containers, images, live, maintenance, remove."
+  />
+  <LinkCard
+    title="wheels deploy proxy"
+    href="/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/"
+    description="kamal-proxy singleton lifecycle: boot, reboot, start, stop, restart, details, logs, remove."
+  />
+  <LinkCard
+    title="wheels deploy accessory"
+    href="/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/"
+    description="Sidecar container lifecycle — mirrors app verbs, scoped to a named accessory."
+  />
+  <LinkCard
+    title="wheels deploy build"
+    href="/v4-0-0-snapshot/command-line-tools/commands/deploy/build/"
+    description="Docker image lifecycle: deliver, push, pull, create, remove, details, dev."
+  />
+  <LinkCard
+    title="wheels deploy registry"
+    href="/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/"
+    description="Registry authentication: setup, login, logout, remove."
+  />
+  <LinkCard
+    title="wheels deploy server"
+    href="/v4-0-0-snapshot/command-line-tools/commands/deploy/server/"
+    description="Host-level operations: exec, bootstrap."
+  />
+  <LinkCard
+    title="wheels deploy prune"
+    href="/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/"
+    description="Cleanup: all, images, containers."
+  />
+  <LinkCard
+    title="wheels deploy lock"
+    href="/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/"
+    description="Deploy-lock management: acquire, release, status."
+  />
+  <LinkCard
+    title="wheels deploy secrets"
+    href="/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/"
+    description="Secret-store integration: fetch, extract, print."
+  />
+</CardGrid>
+
+## Global flags
+
+Every `wheels deploy` verb accepts these:
+
+| Flag | Description |
+|------|-------------|
+| `--config=<path>` | Path to `deploy.yml`. Default `config/deploy.yml`. |
+| `--destination=<name>` | Overlay `deploy.<name>.yml` and `.kamal/secrets.<name>`. |
+| `--dry-run` | Print the commands that would run, prefixed by host. No network. |
+| `--version=<v>` | Version label (default: `git rev-parse --short HEAD`). |

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/init.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/init.mdx
@@ -1,0 +1,42 @@
+---
+title: "wheels deploy init"
+description: Stamp out a starter config/deploy.yml and .kamal/secrets. Run once at project start.
+type: reference
+sidebar:
+  label: "init"
+  order: 6
+---
+
+Scaffold the files `wheels deploy` reads: `config/deploy.yml` and `.kamal/secrets`. Also creates `.kamal/hooks/` (empty) for optional hook scripts.
+
+## Synopsis
+
+```
+wheels deploy init [--service=<name>] [--image=<path>] [--registry-username=<user>] [--force]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--service=<name>` | Service name to bake in. Defaults to the project directory basename. |
+| `--image=<path>` | Image path. Defaults to `<service>/web`. |
+| `--registry-username=<user>` | Registry username. Defaults to `changeme` — you'll edit it. |
+| `--force` | Overwrite existing files. Without this, an existing `config/deploy.yml` aborts with `DeployMainCli.InitAlreadyExists`. |
+
+## What it creates
+
+- `config/deploy.yml` — a starter manifest with `service`, `image`, `servers`, `registry`, `env` stubs.
+- `.kamal/secrets` — key/value placeholders for the registry password and any app secrets.
+- `.kamal/hooks/` — empty directory. Drop executable `pre-deploy`, `post-deploy`, or `post-deploy-failure` scripts here later.
+
+Add `.kamal/secrets*` to `.gitignore` before running.
+
+## Example
+
+```bash
+wheels deploy init
+wheels deploy init --service=myapp --image=ghcr.io/myorg/myapp --registry-username=myorg
+```
+
+After running, edit both files — see [Your First Deploy](/v4-0-0-snapshot/deployment/first-deploy/) for the walk-through.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/acquire.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/acquire.mdx
@@ -1,0 +1,34 @@
+---
+title: "wheels deploy lock acquire"
+description: Manually take the per-service deploy lock on one host.
+type: reference
+sidebar:
+  label: "acquire"
+  order: 1
+---
+
+Manually take the deploy lock. Useful when running an out-of-band maintenance task that you want to serialize against normal deploys.
+
+## Synopsis
+
+```
+wheels deploy lock acquire [--message=<string>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--message=<string>` | Free-form message stored in the lock file. Default `manual acquire`. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Emits the atomic lock-acquire command (`ln -s` against `/tmp/kamal_deploy_lock_<service>`) on any single host. Fails if the lock is already held — run [`lock status`](/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/status/) to see who holds it.
+
+## Example
+
+```bash
+wheels deploy lock acquire --message="db migration in progress"
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "wheels deploy lock"
+description: Deploy-lock management — acquire, release, status.
+type: reference
+sidebar:
+  label: "lock"
+  order: 90
+---
+
+Deploy-lock management. The rolling `wheels deploy` flow acquires and releases a per-service lock automatically; these verbs expose manual escape hatches.
+
+## Verbs
+
+| Verb | Purpose |
+|------|---------|
+| [`acquire`](/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/acquire/) | Manually take the lock. |
+| [`release`](/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/release/) | Manually release the lock. |
+| [`status`](/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/status/) | Report whether the lock is held and who holds it. |
+
+## The lock
+
+One file per service at `/tmp/kamal_deploy_lock_<service>`. Created by symlink for atomicity — if another deploy is running, the symlink creation fails and the verb errors. Released when `wheels deploy` exits (success or failure).
+
+A stale lock after a crashed deploy blocks new deploys — use `lock release` to clear it. Always run `lock status` first to confirm it isn't actually held by someone else.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/release.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/release.mdx
@@ -1,0 +1,40 @@
+---
+title: "wheels deploy lock release"
+description: Manually release the per-service deploy lock.
+type: reference
+sidebar:
+  label: "release"
+  order: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Manually release the deploy lock. Use when a crashed deploy left the lock stuck.
+
+<Aside type="caution">
+Releasing a lock held by an active deploy on another machine causes that deploy to fail when it tries to release a lock it no longer holds. Always run [`lock status`](/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/status/) first.
+</Aside>
+
+## Synopsis
+
+```
+wheels deploy lock release [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the command without executing. |
+
+## Behavior
+
+Removes `/tmp/kamal_deploy_lock_<service>` on a single host. Lock state is per-service, stored at one well-known path — any host sees the same lock.
+
+## Example
+
+```bash
+wheels deploy lock status        # confirm it's stale
+wheels deploy lock release
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/status.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/status.mdx
@@ -1,0 +1,35 @@
+---
+title: "wheels deploy lock status"
+description: Report whether the deploy lock is held and who holds it.
+type: reference
+sidebar:
+  label: "status"
+  order: 3
+---
+
+Report whether the per-service deploy lock is held. If held, prints the user and message that took it.
+
+## Synopsis
+
+```
+wheels deploy lock status [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the command without executing. |
+
+## Behavior
+
+Reads `/tmp/kamal_deploy_lock_<service>` on a single host. Unlocked: empty output. Locked: message and performer from the lock file.
+
+Always run this before `lock release` — it's the only safe way to tell a stale lock from an active one.
+
+## Example
+
+```bash
+wheels deploy lock status
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/boot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/boot.mdx
@@ -1,0 +1,45 @@
+---
+title: "wheels deploy proxy boot"
+description: First-time install of the kamal-proxy singleton on every host.
+type: reference
+sidebar:
+  label: "boot"
+  order: 1
+---
+
+Install and run the `kamal-proxy` singleton on every host. First-run verb — pair with [`setup`](/v4-0-0-snapshot/command-line-tools/commands/deploy/setup/) which calls this automatically.
+
+## Synopsis
+
+```
+wheels deploy proxy boot [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+For every host across every role (the proxy is a per-host singleton):
+
+```
+docker run -d --restart unless-stopped \
+  --name kamal-proxy \
+  --network kamal \
+  --publish 80:80 --publish 443:443 \
+  -v /home/<user>/.config/kamal-proxy:/config \
+  basecamp/kamal-proxy:v0.8.6 \
+  run
+```
+
+Fails fast if port 80 or 443 is occupied on any host.
+
+## Example
+
+```bash
+wheels deploy proxy boot
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/details.mdx
@@ -1,0 +1,29 @@
+---
+title: "wheels deploy proxy details"
+description: docker ps filtered to the kamal-proxy container on every host.
+type: reference
+sidebar:
+  label: "details"
+  order: 6
+---
+
+`docker ps --filter name=kamal-proxy` on every host. Confirms the proxy is up and reports uptime.
+
+## Synopsis
+
+```
+wheels deploy proxy details [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Example
+
+```bash
+wheels deploy proxy details
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/index.mdx
@@ -1,0 +1,27 @@
+---
+title: "wheels deploy proxy"
+description: kamal-proxy singleton lifecycle — boot, reboot, start, stop, restart, details, logs, remove.
+type: reference
+sidebar:
+  label: "proxy"
+  order: 30
+---
+
+The `kamal-proxy` container is a singleton per host. Every proxy verb iterates **all** hosts (across every role) and applies the same command.
+
+## Verbs
+
+| Verb | Purpose |
+|------|---------|
+| [`boot`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/boot/) | First-time install + run. |
+| [`reboot`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/reboot/) | Stop, remove, and re-install. |
+| [`start`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/start/) | `docker start` the existing proxy. |
+| [`stop`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/stop/) | `docker stop` the proxy. |
+| [`restart`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/restart/) | `docker restart` the proxy. |
+| [`details`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/details/) | `docker ps` filtered to `kamal-proxy`. |
+| [`logs`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/logs/) | Tail the proxy logs. |
+| [`remove`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/remove/) | Stop + remove the proxy container. |
+
+## Port collisions
+
+`kamal-proxy` binds :80 and :443 directly on the host. If nginx, Traefik, or any other process is already on those ports, `proxy boot` fails fast. Stop the conflicting service before booting the proxy.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/logs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/logs.mdx
@@ -1,0 +1,34 @@
+---
+title: "wheels deploy proxy logs"
+description: Tail kamal-proxy logs on every host. Access logs, health-check results, TLS issuance messages.
+type: reference
+sidebar:
+  label: "logs"
+  order: 7
+---
+
+Tail `kamal-proxy` logs on every host. Shows access logs, health-check results, traffic-cut-over events, and Let's Encrypt issuance messages.
+
+## Synopsis
+
+```
+wheels deploy proxy logs [--tail=<N>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--tail=<N>` | Trailing lines per host. Default 100. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Behavior
+
+Emits `docker logs --tail <N> kamal-proxy` on every host, prefixed by host.
+
+## Example
+
+```bash
+wheels deploy proxy logs --tail=500
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/reboot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/reboot.mdx
@@ -1,0 +1,35 @@
+---
+title: "wheels deploy proxy reboot"
+description: Stop, remove, and re-install the kamal-proxy container on every host.
+type: reference
+sidebar:
+  label: "reboot"
+  order: 2
+---
+
+Stop, remove, and re-install `kamal-proxy` on every host. Useful after bumping the pinned image tag.
+
+## Synopsis
+
+```
+wheels deploy proxy reboot [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Per host: `docker stop kamal-proxy && docker rm kamal-proxy`, then the same `docker run` as [`proxy boot`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/boot/).
+
+Traffic drops while the proxy is down. Plan for a brief outage or stagger reboots host-by-host.
+
+## Example
+
+```bash
+wheels deploy proxy reboot
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/remove.mdx
@@ -1,0 +1,35 @@
+---
+title: "wheels deploy proxy remove"
+description: Stop and remove the kamal-proxy container on every host. All traffic drops.
+type: reference
+sidebar:
+  label: "remove"
+  order: 8
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Stop and remove `kamal-proxy` on every host.
+
+<Aside type="danger">
+All inbound traffic stops. Re-run [`proxy boot`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/boot/) or [`wheels deploy setup`](/v4-0-0-snapshot/command-line-tools/commands/deploy/setup/) to restore.
+</Aside>
+
+## Synopsis
+
+```
+wheels deploy proxy remove [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Example
+
+```bash
+wheels deploy proxy remove
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/restart.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/restart.mdx
@@ -1,0 +1,29 @@
+---
+title: "wheels deploy proxy restart"
+description: docker restart the kamal-proxy container on every host.
+type: reference
+sidebar:
+  label: "restart"
+  order: 5
+---
+
+`docker restart kamal-proxy` on every host. Brief traffic interruption per host.
+
+## Synopsis
+
+```
+wheels deploy proxy restart [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Example
+
+```bash
+wheels deploy proxy restart
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/start.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/start.mdx
@@ -1,0 +1,29 @@
+---
+title: "wheels deploy proxy start"
+description: docker start the stopped kamal-proxy container.
+type: reference
+sidebar:
+  label: "start"
+  order: 3
+---
+
+`docker start kamal-proxy` on every host. Fails if the container doesn't exist — use [`proxy boot`](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/boot/) for first-time install.
+
+## Synopsis
+
+```
+wheels deploy proxy start [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Example
+
+```bash
+wheels deploy proxy start
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/stop.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/stop.mdx
@@ -1,0 +1,33 @@
+---
+title: "wheels deploy proxy stop"
+description: docker stop the kamal-proxy container on every host. Drops all traffic.
+type: reference
+sidebar:
+  label: "stop"
+  order: 4
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`docker stop kamal-proxy` on every host.
+
+<Aside type="caution">All inbound traffic is dropped while the proxy is stopped. Use with intent.</Aside>
+
+## Synopsis
+
+```
+wheels deploy proxy stop [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Example
+
+```bash
+wheels deploy proxy stop
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/all.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/all.mdx
@@ -1,0 +1,33 @@
+---
+title: "wheels deploy prune all"
+description: Prune both old containers and old images on every host.
+type: reference
+sidebar:
+  label: "all"
+  order: 1
+---
+
+Prune old containers and old images on every host, respecting `retain_containers:`.
+
+## Synopsis
+
+```
+wheels deploy prune all [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Runs [`prune containers`](/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/containers/) then [`prune images`](/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/images/) on every host. The current live container and everything in the retention window survives.
+
+## Example
+
+```bash
+wheels deploy prune all
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/containers.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/containers.mdx
@@ -1,0 +1,33 @@
+---
+title: "wheels deploy prune containers"
+description: Prune old containers beyond the retention window on every host.
+type: reference
+sidebar:
+  label: "containers"
+  order: 3
+---
+
+Prune old containers beyond `retain_containers:` on every host. The current live container and everything in the retention window survives.
+
+## Synopsis
+
+```
+wheels deploy prune containers [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Per host, walks the service-labelled container list, sorts by creation time, and `docker rm`s anything older than the retention window. Older versions become unrollbackable after this — check [`wheels deploy app containers`](/v4-0-0-snapshot/command-line-tools/commands/deploy/app/containers/) first if you might need them.
+
+## Example
+
+```bash
+wheels deploy prune containers
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/images.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/images.mdx
@@ -1,0 +1,33 @@
+---
+title: "wheels deploy prune images"
+description: Prune old images for the service on every host.
+type: reference
+sidebar:
+  label: "images"
+  order: 2
+---
+
+Prune old images of the service on every host. Leaves the current image and anything referenced by a retained container.
+
+## Synopsis
+
+```
+wheels deploy prune images [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Per host, emits a `docker image prune --filter` scoped to the service's image name. Images referenced by retained containers are safe.
+
+## Example
+
+```bash
+wheels deploy prune images
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/index.mdx
@@ -1,0 +1,28 @@
+---
+title: "wheels deploy prune"
+description: Clean up old containers and images — all, images, containers.
+type: reference
+sidebar:
+  label: "prune"
+  order: 80
+---
+
+Disk cleanup. Three verbs with increasing scope.
+
+## Verbs
+
+| Verb | Removes |
+|------|---------|
+| [`all`](/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/all/) | Old containers + old images. |
+| [`images`](/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/images/) | Old images only. |
+| [`containers`](/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/containers/) | Old containers only. |
+
+## Retention policy
+
+`retain_containers:` in `deploy.yml` (default 5) controls how many old containers per host are kept. Prune verbs never touch the current live container or anything within the retention window. Older items are fair game.
+
+## When to prune
+
+- After several successful deploys, disk pressure grows on each host.
+- Before a container-registry rotation, to make sure you aren't pinning stale base images.
+- Never as part of a regular deploy flow — `wheels deploy` already prunes at the end.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/redeploy.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/redeploy.mdx
@@ -1,0 +1,37 @@
+---
+title: "wheels deploy redeploy"
+description: Re-run the deploy flow against the same version. Useful when a host fell behind or you need to reassert state.
+type: reference
+sidebar:
+  label: "redeploy"
+  order: 2
+---
+
+Re-run the deploy flow. Equivalent to `wheels deploy` — boots, ships, cuts traffic — but semantically signals "no new code; just reassert state."
+
+## Synopsis
+
+```
+wheels deploy redeploy [--version=<v>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | Version to redeploy. Defaults to current git short sha. |
+| `--destination=<name>` | Overlay `deploy.<name>.yml` and `.kamal/secrets.<name>`. |
+| `--dry-run` | Print commands without executing. |
+
+## When to use
+
+- A host was added or recovered from downtime and you need to re-converge it.
+- An env value changed in `.kamal/secrets` — redeploy picks up the new value for running containers (they're replaced).
+- A hook needs to fire even though no code changed.
+
+## Examples
+
+```bash
+wheels deploy redeploy
+wheels deploy redeploy --version=abc1234
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/index.mdx
@@ -1,0 +1,23 @@
+---
+title: "wheels deploy registry"
+description: Registry authentication verbs — setup, login, logout, remove.
+type: reference
+sidebar:
+  label: "registry"
+  order: 60
+---
+
+Registry authentication on every host. `setup` and `remove` are aliases for `login` and `logout` respectively, kept for parity with Kamal.
+
+## Verbs
+
+| Verb | Purpose |
+|------|---------|
+| [`setup`](/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/setup/) | Alias for `login`. |
+| [`login`](/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/login/) | `docker login` on every host. |
+| [`logout`](/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/logout/) | `docker logout`. |
+| [`remove`](/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/remove/) | Alias for `logout`. |
+
+## Password resolution
+
+The `registry.password:` array in `deploy.yml` names secret keys. `wheels deploy` reads the first one via `SecretResolver` (which expands `$(...)` in `.kamal/secrets`) and pipes it into `docker login --password-stdin`. Passing `--password=<value>` on the CLI overrides the resolved secret.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/login.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/login.mdx
@@ -1,0 +1,42 @@
+---
+title: "wheels deploy registry login"
+description: docker login to the configured registry on every host.
+type: reference
+sidebar:
+  label: "login"
+  order: 2
+---
+
+`docker login` to the configured registry on every host.
+
+## Synopsis
+
+```
+wheels deploy registry login [--password=<value>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--password=<value>` | Pass the password literally. Overrides the resolved `registry.password[0]` secret. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Per host:
+
+```
+echo <password> | docker login <server> --username <username> --password-stdin
+```
+
+Password comes from `.kamal/secrets` via the first key in `registry.password:`, or from `--password` when provided.
+
+`wheels deploy` runs this automatically before a push. Call it directly if you want to pre-authenticate hosts outside the deploy flow.
+
+## Example
+
+```bash
+wheels deploy registry login
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/logout.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/logout.mdx
@@ -1,0 +1,33 @@
+---
+title: "wheels deploy registry logout"
+description: docker logout on every host.
+type: reference
+sidebar:
+  label: "logout"
+  order: 3
+---
+
+`docker logout <server>` on every host. Clears cached credentials.
+
+## Synopsis
+
+```
+wheels deploy registry logout [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print commands without executing. |
+
+## Behavior
+
+`wheels deploy remove --confirm` calls logout automatically during its teardown flow. Call it directly if you want to clear credentials without tearing down the service.
+
+## Example
+
+```bash
+wheels deploy registry logout
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/remove.mdx
@@ -1,0 +1,24 @@
+---
+title: "wheels deploy registry remove"
+description: Alias for registry logout.
+type: reference
+sidebar:
+  label: "remove"
+  order: 4
+---
+
+Alias for [`registry logout`](/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/logout/). Kept for parity with Kamal.
+
+## Synopsis
+
+```
+wheels deploy registry remove [--destination=<name>] [--dry-run]
+```
+
+Behavior identical to [`registry logout`](/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/logout/).
+
+## Example
+
+```bash
+wheels deploy registry remove
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/setup.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/setup.mdx
@@ -1,0 +1,24 @@
+---
+title: "wheels deploy registry setup"
+description: Alias for registry login. docker login on every host.
+type: reference
+sidebar:
+  label: "setup"
+  order: 1
+---
+
+Alias for [`registry login`](/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/login/). Kept for parity with Kamal's setup verb.
+
+## Synopsis
+
+```
+wheels deploy registry setup [--password=<value>] [--destination=<name>] [--dry-run]
+```
+
+Behavior identical to [`registry login`](/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/login/).
+
+## Example
+
+```bash
+wheels deploy registry setup
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/remove.mdx
@@ -1,0 +1,46 @@
+---
+title: "wheels deploy remove"
+description: Destructive teardown — stops every app and accessory container, removes the proxy, logs out of the registry. Requires --confirm.
+type: reference
+sidebar:
+  label: "remove"
+  order: 11
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Destructive teardown. Stops and removes every app container, proxy container, and accessory container, then logs out of the registry on every host.
+
+<Aside type="danger" title="Destructive">
+This removes running containers on every target host. Requires `--confirm`. There is no undo — re-run `wheels deploy setup` to bring the environment back.
+</Aside>
+
+## Synopsis
+
+```
+wheels deploy remove --confirm [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--confirm` | **Required.** Without it, the verb throws `DeployMainCli.RemoveNotConfirmed`. |
+| `--destination=<name>` | Scope the teardown to one destination. |
+| `--dry-run` | Print the `docker` commands that would run without executing. Always start here. |
+
+## Behavior
+
+1. For every host in every role: `docker ps -a --filter label=service=<service> ...|xargs docker rm -f`. Broad — removes app containers for every version, not just the current one.
+2. Remove `kamal-proxy` on every host.
+3. Remove every declared accessory container.
+4. `docker logout` of the registry on every host.
+
+Volumes attached to accessories persist (they're named) — `docker rm` doesn't take them with it. Follow up with `docker volume rm` manually if you want a truly clean slate.
+
+## Example
+
+```bash
+wheels deploy remove --confirm --dry-run     # always preview first
+wheels deploy remove --confirm --destination=staging
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/rollback.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/rollback.mdx
@@ -1,0 +1,39 @@
+---
+title: "wheels deploy rollback"
+description: Point kamal-proxy at a previous version's containers. Fast when the old containers haven't been pruned.
+type: reference
+sidebar:
+  label: "rollback"
+  order: 3
+---
+
+Revert traffic to a previously-deployed version. Finds the containers tagged with `--version` on every host, starts them, and asks `kamal-proxy` to switch traffic back.
+
+## Synopsis
+
+```
+wheels deploy rollback --version=<v> [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version=<v>` | **Required.** The version to roll back to. |
+| `--destination=<name>` | Overlay `deploy.<name>.yml`. |
+| `--dry-run` | Print the commands without executing. |
+
+Omitting `--version` throws `DeployMainCli.MissingVersion`.
+
+## Behavior
+
+For each role, for each host in sequence: `docker start <service>-<role>-<version>`, then `kamal-proxy deploy` to route fresh traffic to the resurrected container.
+
+Success requires the target containers to still exist on each host. `retain_containers:` in `deploy.yml` (default 5) controls how many old ones are kept; `wheels deploy prune` removes older ones. If a target container has been pruned, the `docker start` step fails — re-deploy from that sha instead.
+
+## Examples
+
+```bash
+wheels deploy rollback --version=abc1234
+wheels deploy rollback --version=v1.2.3 --destination=production
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/extract.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/extract.mdx
@@ -1,0 +1,34 @@
+---
+title: "wheels deploy secrets extract"
+description: Extract one key's value from a KEY=VALUE block.
+type: reference
+sidebar:
+  label: "extract"
+  order: 2
+---
+
+Extract one key's value from a `KEY=VALUE` block. Useful inside hooks or wrapper scripts that pipe from `wheels deploy secrets fetch`.
+
+## Synopsis
+
+```
+wheels deploy secrets extract --key=<name> --from=<block>
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--key=<name>` | Key to extract. |
+| `--from=<block>` | The `KEY=VALUE` newline-separated text to extract from. |
+
+## Behavior
+
+Scans `--from` line-by-line and returns the value for the first line whose key equals `--key`. Returns an empty string if the key isn't present.
+
+## Example
+
+```bash
+block=$(wheels deploy secrets fetch --adapter=op --from=op://Prod/App A B)
+a=$(wheels deploy secrets extract --key=A --from="$block")
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/fetch.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/fetch.mdx
@@ -1,0 +1,42 @@
+---
+title: "wheels deploy secrets fetch"
+description: Fetch named secrets from an adapter. Prints KEY=VALUE lines.
+type: reference
+sidebar:
+  label: "fetch"
+  order: 1
+---
+
+Fetch one or more named keys from a named adapter. Prints them as `KEY=VALUE` lines — the format `.kamal/secrets` accepts via `$(...)`.
+
+## Synopsis
+
+```
+wheels deploy secrets fetch --adapter=<name> [--account=<acct>] [--from=<scope>] <KEY>...
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--adapter=<name>` | **Required.** One of `op`, `1password`, `bw`, `bitwarden`, `aws`, `lpass`, `lastpass`, `doppler`. Unknown names throw `DeploySecretsCli.UnknownAdapter`. |
+| `--account=<acct>` | Adapter-specific account selector. |
+| `--from=<scope>` | Adapter-specific scope — e.g. `op://Vault/Item` for 1Password, a prefix path for Doppler. |
+| `<KEY>...` | One or more keys to fetch. Required; no keys throws `DeploySecretsCli.NoKeys`. |
+
+## Behavior
+
+Shells out to the adapter's CLI tool with the given scope. Returns a newline-separated `KEY=VALUE` block on success. The adapter CLI must be installed locally.
+
+## Examples
+
+```bash
+wheels deploy secrets fetch --adapter=op --from=op://Production/App DATABASE_URL
+wheels deploy secrets fetch --adapter=aws --from=prod/app DB_PASSWORD
+```
+
+Wrap inside `.kamal/secrets` for batched resolution:
+
+```bash title=".kamal/secrets (illustrative — do not type)"
+$(wheels deploy secrets fetch --adapter=op --from=op://Production/App DATABASE_URL WHEELS_MASTER_KEY)
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/index.mdx
@@ -1,0 +1,32 @@
+---
+title: "wheels deploy secrets"
+description: Secret-store integration — fetch, extract, print. Five built-in adapters.
+type: reference
+sidebar:
+  label: "secrets"
+  order: 100
+---
+
+Secret-store integration. Five built-in adapters (1Password, Bitwarden, AWS Secrets Manager, LastPass, Doppler), exposed behind three verbs.
+
+## Verbs
+
+| Verb | Purpose |
+|------|---------|
+| [`fetch`](/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/fetch/) | Pull keys from a named adapter. |
+| [`extract`](/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/extract/) | Extract one key from a `KEY=VALUE` block. |
+| [`print`](/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/print/) | Print the resolved `.kamal/secrets`. |
+
+## Adapter names
+
+Each adapter is registered under one or two aliases matching Kamal's CLI conventions.
+
+| Adapter | Aliases |
+|---------|---------|
+| 1Password | `op`, `1password` |
+| Bitwarden | `bw`, `bitwarden` |
+| AWS Secrets Manager | `aws` |
+| LastPass | `lpass`, `lastpass` |
+| Doppler | `doppler` |
+
+Adapters shell out to the corresponding CLI tool on the control machine. See [Secrets](/v4-0-0-snapshot/deployment/secrets/) for setup.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/print.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/print.mdx
@@ -1,0 +1,42 @@
+---
+title: "wheels deploy secrets print"
+description: Print the fully-resolved .kamal/secrets file as KEY=VALUE lines.
+type: reference
+sidebar:
+  label: "print"
+  order: 3
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Print the fully resolved `.kamal/secrets` file as `KEY=VALUE` lines. All `$(...)` subshells expand.
+
+<Aside type="caution">
+Output is plaintext secrets. Never paste this into logs, tickets, or shared terminals. Run in private.
+</Aside>
+
+## Synopsis
+
+```
+wheels deploy secrets print [--destination=<name>] [--project-root=<path>]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay `.kamal/secrets.<name>` on top of `.kamal/secrets`. |
+| `--project-root=<path>` | Override the project root. Defaults to the current directory. |
+
+## Behavior
+
+Uses the internal `SecretResolver` — the same resolver the deploy flow uses. Every `$(...)` subshell runs through `bash`. Missing secrets referenced in `deploy.yml` do not appear in the output; they'd fail the deploy separately.
+
+Useful to audit what the deploy flow will see before running it.
+
+## Example
+
+```bash
+wheels deploy secrets print
+wheels deploy secrets print --destination=production
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/server/bootstrap.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/server/bootstrap.mdx
@@ -1,0 +1,39 @@
+---
+title: "wheels deploy server bootstrap"
+description: Install Docker on a fresh host. Idempotent — safe to re-run.
+type: reference
+sidebar:
+  label: "bootstrap"
+  order: 2
+---
+
+Install Docker on every host. Idempotent — re-runs on already-installed hosts are no-ops.
+
+## Synopsis
+
+```
+wheels deploy server bootstrap [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the commands without executing. |
+
+## Behavior
+
+Per host:
+
+```
+which docker >/dev/null 2>&1 || curl -fsSL https://get.docker.com | sh
+```
+
+The convenience script runs as root (or via `sudo`). For production hardening, install Docker through your usual config management instead — this is a fast-start verb, not a production setup.
+
+## Example
+
+```bash
+wheels deploy server bootstrap
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/server/exec.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/server/exec.mdx
@@ -1,0 +1,38 @@
+---
+title: "wheels deploy server exec"
+description: Run an arbitrary command on every host (or one filtered host).
+type: reference
+sidebar:
+  label: "exec"
+  order: 1
+---
+
+Run a command on every host. Filter to one host with `--host=`.
+
+## Synopsis
+
+```
+wheels deploy server exec --cmd=<command> [--host=<host>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--cmd=<command>` | **Required.** Shell command to run remotely. Throws `DeployServerCli.MissingCommand` if absent. |
+| `--host=<host>` | Limit to one host. Must match a host declared in `deploy.yml` — throws `DeployServerCli.UnknownHost` otherwise. |
+| `--destination=<name>` | Overlay destination config. |
+| `--dry-run` | Print the command without executing. |
+
+## Behavior
+
+SSHes in parallel (or to one host) and runs `--cmd` verbatim. Output is prefixed by host.
+
+Useful for smoke-testing connectivity, reading environment details, or running one-off diagnostic commands without writing a hook.
+
+## Example
+
+```bash
+wheels deploy server exec --cmd="uptime"
+wheels deploy server exec --cmd="docker ps" --host=192.0.2.10
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/server/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/server/index.mdx
@@ -1,0 +1,17 @@
+---
+title: "wheels deploy server"
+description: Host-level operations — exec arbitrary commands, bootstrap Docker on a fresh host.
+type: reference
+sidebar:
+  label: "server"
+  order: 70
+---
+
+Host-level operations that don't fit in the app/proxy/accessory model.
+
+## Verbs
+
+| Verb | Purpose |
+|------|---------|
+| [`exec`](/v4-0-0-snapshot/command-line-tools/commands/deploy/server/exec/) | Run a command on every host (optionally filtered). |
+| [`bootstrap`](/v4-0-0-snapshot/command-line-tools/commands/deploy/server/bootstrap/) | Install Docker on a fresh host (idempotent). |

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/setup.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/setup.mdx
@@ -1,0 +1,37 @@
+---
+title: "wheels deploy setup"
+description: First-time deploy. Runs the full deploy flow plus proxy and accessory boot.
+type: reference
+sidebar:
+  label: "setup"
+  order: 4
+---
+
+The first-time deploy verb. Runs the full `wheels deploy` flow and also boots `kamal-proxy` and every declared accessory. Use it once per environment; after that, plain `wheels deploy` is enough.
+
+## Synopsis
+
+```
+wheels deploy setup [--version=<v>] [--destination=<name>] [--dry-run]
+```
+
+## Flags
+
+Same as [`wheels deploy`](/v4-0-0-snapshot/command-line-tools/commands/deploy/deploy/).
+
+## Behavior
+
+In Phase 2 the `setup` implementation reduces to the same flow as `wheels deploy`. The intent remains: on first run, the proxy container and any accessories boot as a side effect. On a fresh host, the first `wheels deploy setup` is slower than subsequent deploys because `docker pull` fetches every base image.
+
+Expected preconditions:
+
+- Docker is installed on every host. Run [`wheels deploy server bootstrap`](/v4-0-0-snapshot/command-line-tools/commands/deploy/server/bootstrap/) first if not.
+- Registry credentials resolve in `.kamal/secrets`.
+- `ssh.user` has passwordless `sudo` (or is `root`).
+
+## Examples
+
+```bash
+wheels deploy setup
+wheels deploy setup --destination=staging
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/version.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/commands/deploy/version.mdx
@@ -1,0 +1,36 @@
+---
+title: "wheels deploy version"
+description: Print the mirrored Kamal and kamal-proxy versions.
+type: reference
+sidebar:
+  label: "version"
+  order: 7
+---
+
+Print the Kamal version this port mirrors and the pinned `kamal-proxy` image tag.
+
+## Synopsis
+
+```
+wheels deploy version
+```
+
+## Flags
+
+None.
+
+## Output
+
+```
+wheels-deploy mirrors kamal 2.4.0 / kamal-proxy v0.8.6
+```
+
+The Kamal version tracks the Ruby source of truth each `wheels deploy` release is audited against. The `kamal-proxy` tag is pinned in the default `proxy.image` so every deploy picks up the same binary.
+
+Bumping either version is a release-time decision, not a runtime flag — see the release notes for the current Wheels CLI.
+
+## Example
+
+```bash
+wheels deploy version
+```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/accessories.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/accessories.mdx
@@ -1,0 +1,138 @@
+---
+title: Accessories
+description: Sidecar containers — databases, caches, queues — booted alongside your app but outside the rolling deploy flow.
+type: howto
+sidebar:
+  order: 9
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Accessories are long-lived support containers that your app depends on but that aren't part of the rolling application deploy. Think databases, caches, and search indices. `wheels deploy` boots them once, leaves them alone, and lets you manage their lifecycle independently of the app.
+
+**You'll learn:**
+
+- When to use an accessory versus an externally-managed service
+- How to declare a Redis or Postgres accessory in `deploy.yml`
+- The independent lifecycle verbs — `boot`, `reboot`, `start`, `stop`, `logs`, `remove`
+- How accessories fit into the on-server label and naming scheme
+
+<Aside type="note" title="You should already know">
+You've read [Your First Deploy](/v4-0-0-snapshot/deployment/first-deploy/) and understand the overall deploy flow.
+</Aside>
+
+## When to use an accessory
+
+Accessories are convenient, not magical. They're a good fit when:
+
+- You're running a single-instance service (one Redis, one Postgres) and managing it alongside the app is simpler than running a managed service.
+- Your staging or dev environment shouldn't pay for managed Redis / RDS.
+- You want the database and the app rebuilt together when you tear down an environment (`wheels deploy remove`).
+
+Use a managed service — not an accessory — when:
+
+- You need HA, automated failover, or point-in-time recovery.
+- The service has its own ops story your team already runs (RDS, ElastiCache, Opensearch Service).
+- You're on Kubernetes and the cluster already has operators for the thing.
+
+Accessories are pinned to one host by default. They're not a clustering or replication story.
+
+## Minimal — Redis
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+accessories:
+  redis:
+    image: redis:7
+    host: 192.0.2.20
+    port: 6379
+```
+
+`wheels deploy accessory boot redis` on first deploy. Produces a container named `<service>-redis` on the named host, published on 6379. From the app side, connect to `redis://192.0.2.20:6379`.
+
+## Postgres with volume, env, and an init file
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+accessories:
+  db:
+    image: postgres:16
+    host: 192.0.2.20
+    port: 5432
+    env:
+      clear:
+        POSTGRES_USER: app
+        POSTGRES_DB: myapp_production
+      secret:
+        - POSTGRES_PASSWORD
+    volumes:
+      - /data/pg:/var/lib/postgresql/data
+    files:
+      - config/init.sql:/docker-entrypoint-initdb.d/init.sql
+```
+
+- `env.secret:` pulls `POSTGRES_PASSWORD` from `.kamal/secrets` — never commit it to `deploy.yml`.
+- `volumes:` persists `/var/lib/postgresql/data` to the host so the database survives `docker rm`.
+- `files:` uploads local paths to the container filesystem at deploy time. Useful for initialization scripts, client certs, or any read-only payload the container needs.
+
+## Named containers and labels
+
+Accessory containers are named `<service>-<accessory>` — the example above yields `myapp-db` and `myapp-redis`. They carry the same `service=` label as your app containers, so `wheels deploy details` lists them alongside everything else.
+
+## Multi-host accessories
+
+Declare multiple hosts to run independent copies:
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+accessories:
+  redis:
+    image: redis:7
+    hosts:
+      - 192.0.2.20
+      - 192.0.2.21
+```
+
+Each host gets its own independent container. There is no clustering, no replication, no leader election — that's the accessory's job. If you need a Redis cluster, either configure it manually across the hosts or run it as a managed service.
+
+## Lifecycle verbs
+
+Every accessory has an independent lifecycle, scoped by name:
+
+```bash
+wheels deploy accessory boot db              # first-time install
+wheels deploy accessory reboot db            # stop + remove + boot
+wheels deploy accessory start db             # docker start
+wheels deploy accessory stop db              # docker stop
+wheels deploy accessory restart db           # docker restart
+wheels deploy accessory details db           # docker ps filtered
+wheels deploy accessory logs db --tail=100   # tail container logs
+wheels deploy accessory remove db            # stop + rm
+```
+
+Pass `all` instead of a specific name to fan out:
+
+```bash
+wheels deploy accessory boot all
+wheels deploy accessory stop all
+```
+
+`wheels deploy setup` boots every declared accessory as part of first-run. `wheels deploy remove` tears them down.
+
+## Accessories and `wheels deploy`
+
+Accessories are deliberately **not** part of the rolling `wheels deploy` flow. Running `wheels deploy` does not restart Redis, does not upgrade Postgres, and does not reboot anything under `accessories:`. That separation is the whole point — app deploys happen ten times a day, accessory changes happen rarely, and mixing the two is how you accidentally take the database down during a routine rollout.
+
+When you do want to change an accessory — a Redis version bump, a Postgres config reload — run the accessory verb explicitly.
+
+## Related guides
+
+<CardGrid>
+  <LinkCard
+    title="deploy.yml Reference"
+    href="/v4-0-0-snapshot/deployment/config-reference/"
+    description="The full schema, including the accessory block's options."
+  />
+  <LinkCard
+    title="Secrets"
+    href="/v4-0-0-snapshot/deployment/secrets/"
+    description="How .kamal/secrets feeds accessory env.secret lists."
+  />
+</CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/config-reference.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/config-reference.mdx
@@ -1,0 +1,406 @@
+---
+title: "deploy.yml Reference"
+description: Every top-level key in config/deploy.yml — what it configures, what the defaults are, and the shapes it accepts.
+type: reference
+sidebar:
+  order: 8
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This is the complete `deploy.yml` schema. `wheels deploy` loads `config/deploy.yml` on every invocation, validates it against this schema, and hands it to every subcommand. Unknown top-level keys fail fast with a line-scoped error; required keys that are missing fail with a pointer to the file.
+
+<Aside type="note" title="You should already know">
+You've read [Your First Deploy](/v4-0-0-snapshot/deployment/first-deploy/) and understand the shape of a working deploy. This page is the dry reference — no narrative, just the schema.
+</Aside>
+
+## Required keys
+
+Three keys are required. Omitting any of them stops the loader with `deploy.yml: missing required key: '<name>'`.
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `service` | string | Short, stable name. Drives container naming (`<service>-<role>-<version>`) and the Docker label that scopes every `wheels deploy` query. |
+| `image` | string | Registry path excluding the tag (e.g. `myorg/myapp`). `wheels deploy` appends a version. |
+| `servers` | array or map | One or more hosts. See [`servers`](#servers) below. |
+
+## All allowed top-level keys
+
+The loader rejects any top-level key not on this list. Case-insensitive.
+
+```
+service, image, servers, registry, builder, env, ssh, proxy, boot,
+healthcheck, hooks, accessories, volumes, labels, logging,
+retain_containers, minimum_version, asset_path, require_destination,
+allow_empty_roles, run_directory, readiness_delay
+```
+
+## `service`
+
+The name threaded through every container, label, and lock file on the server.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+service: myapp
+```
+
+Containers are named `<service>-<role>-<version>` (`myapp-web-abc1234`). Accessories are named `<service>-<accessory>` (`myapp-db`). The lock file is `/tmp/kamal_deploy_lock_<service>`. Keep it short and stable — renaming later means manually cleaning up every host.
+
+## `image`
+
+The registry path for the app image, excluding the tag.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+image: myorg/myapp           # Docker Hub
+image: ghcr.io/myorg/myapp   # GHCR — include the registry host
+```
+
+`wheels deploy` tags every build with a version (short git sha by default) and produces a pull target like `myorg/myapp:abc1234`. Pair with `registry.server` when the registry isn't Docker Hub.
+
+## `servers`
+
+The hosts Wheels deploys to. Three shapes, increasing in expressiveness.
+
+### Bare list (implicit `web` role)
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+servers:
+  - 192.0.2.10
+  - 192.0.2.11
+```
+
+Every host joins an implicit role named `web`. Simplest shape for single-role apps.
+
+### Named roles
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+servers:
+  web:
+    - 192.0.2.10
+  job:
+    - 192.0.2.11
+```
+
+Any number of roles. The `web` role is special — it's the only one the proxy routes public traffic to. Other roles (`job`, `worker`, `sidekiq`) are started and stopped like `web` but don't receive a `kamal-proxy deploy` call.
+
+### Roles with options
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+servers:
+  web:
+    hosts:
+      - 192.0.2.10
+    env:
+      clear:
+        WHEELS_MAX_THREADS: 8
+    options:
+      memory: 2gb
+      cpus: 2
+    labels:
+      my-label: value
+    cmd: /app/bin/web
+```
+
+- `hosts:` — required when using the map shape.
+- `env:` — merges over the top-level `env:`. See [`env`](#env).
+- `options:` — additional `docker run` flags (`memory`, `cpus`, `user`, `publish`, etc.).
+- `labels:` — extra labels attached to the container, on top of the four Wheels adds (`service`, `role`, `destination`, `version`).
+- `cmd:` — overrides the container entrypoint for this role. Useful when one image runs as `web` under one command and as `job` under another.
+
+Host strings accept `user@host`, `host:port`, and `user@host:port`. IPv6 literals must be bracketed (`[::1]:22`). Multiple colons without brackets are rejected.
+
+## `registry`
+
+Where images are pushed and pulled.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+registry:
+  server: ghcr.io            # optional — defaults to Docker Hub
+  username: myorg
+  password:
+    - KAMAL_REGISTRY_PASSWORD
+```
+
+- `server:` — hostname. Omit for Docker Hub.
+- `username:` — identity used for `docker login`. Literal string.
+- `password:` — array of secret keys. `wheels deploy` resolves the first key against `.kamal/secrets` and passes it to `docker login --password-stdin`.
+
+For ECR, set `username: AWS` and point `password:` at an env var that you populate via a `$(aws ecr get-login-password)` in `.kamal/secrets` — ECR tokens rotate every 12 hours.
+
+## `builder`
+
+How and where Docker images are built.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+builder:
+  context: .
+  dockerfile: Dockerfile
+  arch:
+    - amd64
+    - arm64
+  args:
+    WHEELS_VERSION: "4.0.0"
+  remote: ssh://deploy@builder.example.com
+```
+
+- `context:` — build context. Default `.`.
+- `dockerfile:` — path relative to context. Default `Dockerfile`.
+- `arch:` — target architectures. Single-arch defaults to whatever the host running the build is. Multi-arch requires `docker buildx` (which `wheels deploy build create` sets up for you).
+- `args:` — map of `--build-arg` values.
+- `remote:` — SSH URL of a remote builder. Faster than local QEMU emulation when you're on an arm64 Mac building amd64 images.
+
+## `env`
+
+Environment variables for app containers, split into `clear` (baked into `deploy.yml`, safe under git) and `secret` (resolved from `.kamal/secrets` at deploy time).
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+env:
+  clear:
+    WHEELS_ENV: production
+    WHEELS_LOG_TO_STDOUT: "1"
+  secret:
+    - DATABASE_URL
+    - WHEELS_RELOAD_PASSWORD
+```
+
+Per-role overrides merge over the top level.
+
+| Layer | Wins over |
+|-------|-----------|
+| role `clear` | role `secret`, top-level `clear`, top-level `secret` |
+| role `secret` | top-level `clear`, top-level `secret` |
+| top-level `clear` | top-level `secret` |
+| top-level `secret` | — |
+
+Changes to `env` take effect on next deploy only; running containers keep their original values.
+
+## `ssh`
+
+How `wheels deploy` connects to hosts.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+ssh:
+  user: deploy
+  port: 22
+  proxy: bastion.example.com
+  keys_only: false
+```
+
+- `user:` — SSH user. Defaults to the current local user. If not root, `wheels deploy` wraps root-requiring commands with `sudo -n`.
+- `port:` — TCP port. Default 22.
+- `proxy:` — bastion host. Maps to OpenSSH's `ProxyJump`; every connection first hops through this host.
+- `keys_only:` — if true, disables agent-based auth and requires explicit `keys:`.
+
+SSH config picks up your usual `~/.ssh/config`, `~/.ssh/known_hosts`, and `ssh-agent` — you don't re-declare that here.
+
+## `proxy`
+
+Configuration for `kamal-proxy`, the singleton reverse proxy on every host.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+proxy:
+  host: app.example.com
+  app_port: 3000
+  ssl: true
+  healthcheck:
+    path: /up
+    timeout: 30
+  forward_headers: true
+  buffering:
+    requests: true
+    responses: true
+```
+
+- `host:` — the public hostname. Used for TLS SNI and Let's Encrypt issuance.
+- `app_port:` — port the app listens on inside the container. Default 3000. Wheels apps typically bind whatever `wheels start` binds; make sure the `Dockerfile` EXPOSE matches.
+- `ssl:` — if true, `kamal-proxy` requests a Let's Encrypt cert for `host` on first boot. Set false if you terminate TLS in front of the proxy.
+- `healthcheck:` — new container must return 2xx at `healthcheck.path` within `healthcheck.timeout` seconds or the proxy refuses to cut traffic over.
+- `forward_headers:` — if true, `X-Forwarded-For`, `X-Forwarded-Proto`, and related headers pass through. Turn on when the app trusts them.
+- `buffering:` — enable request/response buffering. Useful for slow clients on fast backends.
+
+## `accessories`
+
+Sidecar containers — databases, caches, queues — that run alongside the app but aren't part of the rolling deploy. Booted once and left alone.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+accessories:
+  redis:
+    image: redis:7
+    host: 192.0.2.20
+    port: 6379
+  db:
+    image: postgres:16
+    host: 192.0.2.20
+    port: 5432
+    env:
+      clear:
+        POSTGRES_USER: app
+      secret:
+        - POSTGRES_PASSWORD
+    volumes:
+      - /data/pg:/var/lib/postgresql/data
+    files:
+      - config/init.sql:/docker-entrypoint-initdb.d/init.sql
+```
+
+See [Accessories](/v4-0-0-snapshot/deployment/accessories/) for the full walk-through.
+
+## `volumes`, `labels`
+
+Top-level defaults that every role inherits unless overridden.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+volumes:
+  - ./storage:/rails/storage
+
+labels:
+  environment: production
+```
+
+Role-level `volumes` and `labels` merge over these.
+
+## `hooks`
+
+Path override for the `.kamal/hooks/` directory. Rarely used; the default is fine.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+hooks:
+  path: .kamal/hooks
+```
+
+See [Hooks](/v4-0-0-snapshot/deployment/hooks/) for what the scripts look like.
+
+## `healthcheck`
+
+Legacy top-level healthcheck config (pre-kamal-proxy). New deploys should configure health checks under `proxy.healthcheck:` instead. Accepted for back-compat with Kamal's pre-2.0 config shape.
+
+## `boot`
+
+Controls the rolling boot sequence.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+boot:
+  limit: 25%
+  wait: 2
+```
+
+- `limit:` — how many hosts boot in parallel. Default 1 (strict sequential). Set to `25%` or an absolute number to parallelize.
+- `wait:` — seconds to pause between each host's completion and the next host's start. Default 0.
+
+## `logging`
+
+Docker logging driver and options. Passed through to `docker run --log-driver` / `--log-opt`.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+logging:
+  driver: json-file
+  options:
+    max-size: 10m
+    max-file: "3"
+```
+
+## `retain_containers`
+
+How many old containers to keep on each host for rollback. Default 5. Older ones are pruned during `wheels deploy prune all`.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+retain_containers: 10
+```
+
+## `minimum_version`
+
+Require the CLI to be at least this version. Causes a fail-fast error if the installed `wheels` CLI is older.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+minimum_version: "4.0.0"
+```
+
+## `asset_path`
+
+Path inside the container for long-lived static assets. Used by the asset-swap path for zero-downtime JS/CSS rotation.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+asset_path: /app/public/assets
+```
+
+## `require_destination`
+
+If true, every command must pass `--destination=<name>`. Guards against deploying the wrong environment by default.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+require_destination: true
+```
+
+## `allow_empty_roles`
+
+If true, a role with an empty `hosts:` list doesn't fail validation. Useful when a role is temporarily scaled to zero.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+allow_empty_roles: true
+```
+
+## `run_directory`
+
+Working directory inside the container. Default is the image's configured `WORKDIR`. Override when the image ships without one.
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+run_directory: /app
+```
+
+## `readiness_delay`
+
+Seconds to wait after `docker run` before asking the proxy to cut over. Default 0. Set when your app needs a head start before the health check starts succeeding (database migrations running in-container on boot, for example).
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+readiness_delay: 5
+```
+
+## Variable interpolation
+
+`deploy.yml` supports a restricted subset of Mustache. Three variables are exposed in the rendering context:
+
+| Variable | Value |
+|----------|-------|
+| `env.*` | Any environment variable or `.kamal/secrets` entry. |
+| `destination` | Current `--destination` flag, or empty. |
+| `hostname` | Local hostname of the machine running `wheels deploy`. |
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+service: {{env.APP_NAME}}
+image: {{env.REGISTRY}}/{{env.APP_NAME}}
+```
+
+No loops, conditionals, or method calls. If you need logic, resolve it in `.kamal/secrets` first and reference the result via `env.*`.
+
+<Aside type="caution" title="No ERB">
+Ruby Kamal supports `<%= ... %>` ERB inside `deploy.yml`. Wheels does not — we substitute a restricted Mustache. This is the single schema divergence. See [Migrating from Kamal](/v4-0-0-snapshot/deployment/migrating-from-kamal/) for conversion patterns.
+</Aside>
+
+## Destination overlays
+
+`--destination production` loads `config/deploy.yml` and then deep-merges `config/deploy.production.yml` on top. Arrays are replaced; maps merge recursively. Use overlays to split shared config from per-environment overrides:
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+service: myapp
+image: myorg/myapp
+
+servers:
+  web:
+    - 192.0.2.10
+```
+
+```yaml title="config/deploy.staging.yml (illustrative — do not type)"
+servers:
+  web:
+    - staging.example.com
+
+proxy:
+  host: staging.example.com
+```
+
+## Validation errors
+
+Three classes of error, all emitted as `deploy.yml: <message>`:
+
+- `missing required key: '<name>'` — one of `service`, `image`, `servers` is absent.
+- `unknown top-level key: '<name>'` — typo or unsupported key. Cross-check against the allowlist above.
+- `invalid host: '<string>'` — host string has more than one colon without IPv6 brackets.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/first-deploy.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/first-deploy.mdx
@@ -1,0 +1,221 @@
+---
+title: Your First Deploy
+description: A guided walk-through from wheels deploy init to a running production app. Assumes Linux, SSH, and Docker familiarity but no prior Kamal knowledge.
+type: tutorial
+sidebar:
+  order: 7
+---
+
+import { Aside, Steps, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+This page takes an existing Wheels app and ships it to one or more Linux servers. You'll generate config, edit it for your target, bootstrap Docker on a fresh host, and run your first rolling deploy. Nothing here assumes you've used Kamal before. The whole thing takes about 20 minutes if your servers are ready.
+
+**You'll learn:**
+
+- How `wheels deploy init` stamps out `config/deploy.yml` and `.kamal/secrets`
+- What to edit in `deploy.yml` before your first deploy
+- The difference between `wheels deploy setup` and `wheels deploy`
+- How to verify the rollout, tail logs, and roll back if something breaks
+
+<Aside type="note" title="Assumptions">
+  You have a Wheels app that already builds into a working Docker image. You have at least one Linux server you can reach over SSH as a user with passwordless `sudo`, or as root. Docker can be installed later with `wheels deploy server bootstrap` — you don't need it preinstalled. You have a container registry (Docker Hub, GHCR, ECR, or self-hosted) you can push to.
+</Aside>
+
+## Before you start
+
+Three quick checks before running anything:
+
+- **SSH works.** `ssh deploy@your-host "uname -a"` succeeds without a password prompt.
+- **Registry login works.** `docker login <registry>` succeeds locally.
+- **Your app has a `Dockerfile`.** It builds and runs locally (`docker build . && docker run <image>`). If not, write the `Dockerfile` first — `wheels deploy` doesn't generate one.
+
+## Walk-through
+
+<Steps>
+
+1. **Stamp out the config files.**
+
+   From your project root:
+
+   ```bash
+   wheels deploy init
+   ```
+
+   Creates two files:
+
+   - `config/deploy.yml` — the deploy manifest. Under git.
+   - `.kamal/secrets` — secret values. **Never under git.** Add `.kamal/secrets` to `.gitignore` immediately.
+
+   A `.kamal/hooks/` directory is also created for optional local hook scripts. It's empty and safe to leave that way.
+
+   The generated `deploy.yml` uses your project directory name as the service name and a `changeme` registry user. You'll edit both next.
+
+2. **Edit `config/deploy.yml` for your target.**
+
+   At minimum, fix four keys:
+
+   ```yaml title="config/deploy.yml"
+   service: myapp
+   image: myorg/myapp
+
+   servers:
+     web:
+       - 192.0.2.10
+
+   proxy:
+     host: app.example.com
+     ssl: true
+
+   registry:
+     username: myorg
+     password:
+       - KAMAL_REGISTRY_PASSWORD
+   ```
+
+   - `service` names the on-host containers (`myapp-web-abc1234`). Pick something short and stable.
+   - `image` is the registry path excluding the tag. `wheels deploy` appends a version (short git sha by default).
+   - `servers` lists the Linux hosts that run the `web` role. Add more roles (`job`, `worker`) if you have them.
+   - `proxy.host` is the public hostname. `ssl: true` auto-issues a Let's Encrypt cert. If you point `proxy.host` at a CDN or custom reverse proxy instead, set `ssl: false`.
+   - `registry.username` is the identity used for `docker login`. `password:` names one or more environment variables that resolve to the actual password — the password itself lives in `.kamal/secrets`.
+
+   See [deploy.yml Reference](/v4-0-0-snapshot/deployment/config-reference/) for every key.
+
+3. **Populate `.kamal/secrets`.**
+
+   The generated file has placeholder entries. Replace them with real values or with `$(...)` subshells that pull from your secret store:
+
+   ```bash title=".kamal/secrets"
+   # Registry — matches registry.password[0] in deploy.yml
+   KAMAL_REGISTRY_PASSWORD=$(op read op://Production/Registry/password)
+
+   # App-level secrets — referenced under env.secret in deploy.yml
+   DATABASE_URL=$(op read op://Production/App/database-url)
+   WHEELS_RELOAD_PASSWORD=$(op read op://Production/App/reload-password)
+   ```
+
+   The `$(...)` form runs through `bash` at deploy time — any command-line tool that prints to stdout works: `op`, `bw`, `aws secretsmanager get-secret-value`, `doppler secrets get`, or plain `cat config/master.key`.
+
+   See [Secrets](/v4-0-0-snapshot/deployment/secrets/) for the full adapter list.
+
+4. **Configure env in `deploy.yml`.**
+
+   Under `env:`, declare the environment variables your container needs:
+
+   ```yaml title="config/deploy.yml"
+   env:
+     clear:
+       WHEELS_ENV: production
+       WHEELS_DATASOURCE_CLASS: com.mysql.cj.jdbc.Driver
+     secret:
+       - DATABASE_URL
+       - WHEELS_RELOAD_PASSWORD
+   ```
+
+   `clear:` values are baked into `deploy.yml` and safe under git. `secret:` names pull from `.kamal/secrets`. At deploy time, `wheels deploy` translates both into `docker run -e` flags.
+
+5. **Bootstrap Docker on the host (first time only).**
+
+   If Docker is already installed on the target, skip this step. Otherwise:
+
+   ```bash
+   wheels deploy server bootstrap
+   ```
+
+   Runs `which docker || curl -fsSL https://get.docker.com | sh` on every host. Idempotent — safe to run on a host that already has Docker. Fails fast if SSH or `sudo` isn't configured correctly.
+
+6. **Run setup once.**
+
+   ```bash
+   wheels deploy setup
+   ```
+
+   `setup` is the first-run verb. It runs the full deploy flow *and* boots `kamal-proxy` and any accessories you've declared. On subsequent deploys you use `wheels deploy` (without `setup`) because the proxy and accessories are already running.
+
+   Expect a few minutes on the first run — Docker pulls the base images for `kamal-proxy`, any accessories, and your app. Output is prefixed with `[host]` so you can see what each server is doing in parallel.
+
+7. **Hit the app.**
+
+   Once `setup` completes cleanly, your app is live at `https://app.example.com`. Let's Encrypt provisioning takes 10-30 seconds the first time — if `curl -I https://app.example.com` returns a TLS error immediately, wait a moment and retry.
+
+   Check the container state:
+
+   ```bash
+   wheels deploy app details
+   ```
+
+   Prints `docker ps` output filtered by your service label, for every host. You should see one running container per host per role.
+
+8. **Make a change and redeploy.**
+
+   Commit a change, then:
+
+   ```bash
+   wheels deploy
+   ```
+
+   Same command, no `setup`. The rolling flow kicks in: new image builds, pushes, pulls to every host, then the proxy cuts traffic over host-by-host. Zero downtime — `kamal-proxy` drains in-flight requests to the old container before switching.
+
+   The version label is the short git sha by default. Override with `--version=<tag>` if you tag releases differently.
+
+</Steps>
+
+## Verifying the rollout
+
+A successful deploy leaves you with a handful of useful introspection commands:
+
+```bash
+wheels deploy details                     # everything — app, proxy, accessories
+wheels deploy app containers              # just app containers across hosts
+wheels deploy app logs --follow           # tail every app log, prefixed by host
+wheels deploy proxy logs                  # kamal-proxy access/error logs
+wheels deploy audit                       # on-host audit log (who deployed what)
+```
+
+If something looks wrong, `wheels deploy details` is always the first stop.
+
+## Rolling back
+
+Every deploy tags its container with the version label (git sha by default). To roll back, you point `wheels deploy rollback` at a previous version:
+
+```bash
+wheels deploy rollback --version=abc1234
+```
+
+Finds containers tagged `abc1234` on every host, starts them, and asks the proxy to switch traffic back. The old containers usually still exist on-host — `wheels deploy` doesn't prune aggressively — so rollback is fast. If you've pruned, the rollback fails at the "no such container" step; re-deploy from that sha instead.
+
+Scoped rollouts and rollbacks are supported via `--hosts=` and `--role=` flags, useful when you want to test a change on one host before fanning out.
+
+## Troubleshooting
+
+Three failure modes you'll hit at least once:
+
+**"passwordless sudo not configured on `<host>`"** — `wheels deploy` shells in as the SSH user and `sudo`s to root for Docker commands. Either add your SSH user to `/etc/sudoers.d/wheels-deploy` with `NOPASSWD:ALL`, or deploy as `root` directly by setting `ssh.user: root` in `deploy.yml`.
+
+**"image not found"** — the image hasn't pushed, or the registry credentials don't resolve. Run `wheels deploy build push --dry-run` to see the exact `docker push` command that would run, then check `.kamal/secrets` — a missing `$(op read ...)` is the usual culprit.
+
+**Proxy refuses to cut traffic over** — `kamal-proxy` health-checks new containers before switching. If `proxy.healthcheck.path` (`/up` by default) returns non-2xx within `proxy.healthcheck.timeout` (30s), the proxy keeps routing to the old container. Check `wheels deploy app logs --tail=200` on the new container — usually it's a missing env var or a failed database connection.
+
+## What to read next
+
+<CardGrid>
+  <LinkCard
+    title="deploy.yml Reference"
+    href="/v4-0-0-snapshot/deployment/config-reference/"
+    description="Every top-level key in deploy.yml, in detail."
+  />
+  <LinkCard
+    title="Secrets"
+    href="/v4-0-0-snapshot/deployment/secrets/"
+    description="The 5 adapters for pulling values out of your vault."
+  />
+  <LinkCard
+    title="Accessories"
+    href="/v4-0-0-snapshot/deployment/accessories/"
+    description="Pinning databases, caches, and search to your deploy flow."
+  />
+  <LinkCard
+    title="Hooks"
+    href="/v4-0-0-snapshot/deployment/hooks/"
+    description="Local shell scripts that fire around every deploy."
+  />
+</CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/hooks.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/hooks.mdx
@@ -1,0 +1,151 @@
+---
+title: Hooks
+description: Local shell scripts under .kamal/hooks/ that run on the control machine around every deploy — the KAMAL_ env contract, the three events, and how they integrate with the deploy flow.
+type: howto
+sidebar:
+  order: 11
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Hooks are plain shell scripts in `.kamal/hooks/` that `wheels deploy` runs locally at specific points in a deploy. They're the escape hatch for "run this thing around every deploy" — Slack notifications, smoke tests, database backups, cache warms. Every hook is optional; if the file doesn't exist, `wheels deploy` skips it without a warning.
+
+**You'll learn:**
+
+- The three supported hook events
+- The `KAMAL_*` environment variables every hook receives
+- How to write and install a hook
+- What happens when a hook fails
+
+<Aside type="note" title="You should already know">
+You've read [Your First Deploy](/v4-0-0-snapshot/deployment/first-deploy/). Hooks are useful once you've shipped at least once.
+</Aside>
+
+## The three events
+
+| Hook | Fires | Aborts? |
+|------|-------|---------|
+| `pre-deploy` | Before any host work starts. | Yes — non-zero exit aborts the deploy before anything on the servers changes. |
+| `post-deploy` | After a successful deploy. | Yes — non-zero exit fails the deploy after-the-fact, useful for smoke tests. |
+| `post-deploy-failure` | After a deploy that threw an error. | No — this is already a failure path; the exit code is logged but doesn't change what happens. |
+
+All three live under `.kamal/hooks/` and must be executable (`chmod +x`). They run on the control machine — the same machine running `wheels deploy` — not on the target hosts.
+
+## Environment variables every hook receives
+
+`wheels deploy` fires every hook with a `KAMAL_*` env block that matches Ruby Kamal's contract exactly. Keeping the prefix `KAMAL_` (not `WHEELS_`) means any hook written for Ruby Kamal works unchanged — you can port hooks between the two tools without editing.
+
+| Variable | When available | Value |
+|----------|---------------|-------|
+| `KAMAL_VERSION` | all events | Version being deployed (git short sha by default). |
+| `KAMAL_HOSTS` | all events | Comma-separated list of hosts in the deploy. |
+| `KAMAL_PERFORMER` | all events | Local user running `wheels deploy` (`$USER`). |
+| `KAMAL_ROLE` | all events | Role being deployed, or empty when the deploy spans roles. |
+| `KAMAL_DESTINATION` | all events | Value of `--destination`, or empty. |
+| `KAMAL_RUNTIME` | `post-deploy`, `post-deploy-failure` | Seconds elapsed since the deploy started. |
+| `KAMAL_ERROR` | `post-deploy-failure` only | Error message that stopped the deploy. |
+
+## Example — Slack notification on success
+
+```bash title=".kamal/hooks/post-deploy (illustrative — do not type)"
+#!/usr/bin/env bash
+set -euo pipefail
+
+curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+  -H 'Content-Type: application/json' \
+  -d "$(cat <<EOF
+{
+  "text": "Deployed \`${KAMAL_VERSION}\` to \`${KAMAL_HOSTS}\` in ${KAMAL_RUNTIME}s by ${KAMAL_PERFORMER}"
+}
+EOF
+)"
+```
+
+Remember to `chmod +x .kamal/hooks/post-deploy` before committing.
+
+## Example — Smoke test before deploy
+
+Abort the deploy if staging is broken:
+
+```bash title=".kamal/hooks/pre-deploy (illustrative — do not type)"
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! curl -sf --max-time 5 https://staging.example.com/up > /dev/null; then
+  echo "Staging is down; refusing to deploy" >&2
+  exit 1
+fi
+```
+
+The non-zero exit stops `wheels deploy` before it touches production.
+
+## Example — Page on failure
+
+```bash title=".kamal/hooks/post-deploy-failure (illustrative — do not type)"
+#!/usr/bin/env bash
+set -euo pipefail
+
+curl -sS -X POST https://events.pagerduty.com/v2/enqueue \
+  -H 'Content-Type: application/json' \
+  -d "$(cat <<EOF
+{
+  "routing_key": "${PAGERDUTY_KEY}",
+  "event_action": "trigger",
+  "payload": {
+    "summary": "Deploy of ${KAMAL_VERSION} failed: ${KAMAL_ERROR}",
+    "severity": "error",
+    "source": "wheels deploy"
+  }
+}
+EOF
+)"
+```
+
+## Output
+
+Hook stdout and stderr are merged and prefixed with `[hook:<name>]` in the deploy log:
+
+```
+[hook:pre-deploy] staging check passed
+[hook:post-deploy] slack notification sent
+```
+
+A non-zero exit from `pre-deploy` aborts the deploy before any server work. A non-zero exit from `post-deploy` marks the deploy as failed after-the-fact — the containers are already rolled over, so this is useful for integration smoke tests that gate "did the deploy actually work" rather than "can I start the new container."
+
+`post-deploy-failure` never changes the exit code; it runs best-effort on an already-failed path.
+
+## Debugging hooks
+
+Hooks run in the project root directory (where `deploy.yml` lives). `$USER` is the user who invoked `wheels deploy`. Everything else is your environment.
+
+To see exactly what env vars your hook receives, drop this in during development:
+
+```bash title=".kamal/hooks/post-deploy (illustrative — do not type)"
+#!/usr/bin/env bash
+env | grep ^KAMAL_
+```
+
+To run a hook manually with the expected env:
+
+```bash
+KAMAL_VERSION=abc1234 \
+KAMAL_HOSTS=192.0.2.10 \
+KAMAL_RUNTIME=42 \
+KAMAL_PERFORMER=$USER \
+./.kamal/hooks/post-deploy
+```
+
+## Related guides
+
+<CardGrid>
+  <LinkCard
+    title="Secrets"
+    href="/v4-0-0-snapshot/deployment/secrets/"
+    description="Hooks can shell out to wheels deploy secrets fetch."
+  />
+  <LinkCard
+    title="Migrating from Kamal"
+    href="/v4-0-0-snapshot/deployment/migrating-from-kamal/"
+    description="Hook env stays KAMAL_* on purpose — keeps Ruby Kamal hooks portable."
+  />
+</CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/index.mdx
@@ -1,101 +1,130 @@
 ---
 title: Deployment & Operations
-description: How Wheels apps reach production — the two supported models, what the framework provides, and what you provide.
-type: section
+description: How Wheels apps reach production — the built-in wheels deploy orchestrator, when to use it vs. other paths, and the line between what the framework ships and what you provide.
+type: howto
 sidebar:
   order: 6
 ---
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-A Wheels app in production is a Java webapp running on a CFML engine. That one fact determines everything that follows — your deployment target is anything that can host a JVM process and terminate HTTP in front of it. This page is the map for the Deployment & Operations section. It covers the two models Wheels supports today, the line between what the framework gives you and what you own, and where each detail page lives.
+A Wheels app in production is a Java webapp running on a CFML engine. That one fact determines everything that follows — your deployment target is anything that can host a JVM process and terminate HTTP in front of it. What's new in 4.0 is that you don't have to assemble the glue yourself: `wheels deploy` ships a first-party, zero-downtime rolling deploy orchestrator that takes your app from laptop to production Linux hosts in one command.
 
 **You'll learn:**
 
-- The two deployment models Wheels supports today and how to choose between them
+- What `wheels deploy` is, and the lineage it inherits from Basecamp's Kamal
+- When to use `wheels deploy` versus a plain `docker compose` or VM-based path
+- How zero-downtime rollover works through `kamal-proxy`
 - Exactly what the framework ships versus what production infrastructure you provide
-- The current state of the `wheels deploy` CLI and how to deploy without it
 
-## The two models
+## What `wheels deploy` is
 
-Every Wheels deployment the authors have seen in the wild fits one of two shapes. Pick the one that matches your team's operational maturity, not the one that looks modern.
+`wheels deploy` is a port of [Kamal](https://kamal-deploy.org/), Basecamp's container-based deployer, into the Wheels CLI. It orchestrates from your laptop or CI runner over plain SSH — there is no agent on the target hosts. Commands like `wheels deploy`, `wheels deploy rollback`, and `wheels deploy app logs` fan out to your servers, drive `docker` remotely, and stream prefixed output back so you can see what each host is doing.
 
-| | Containerized (Docker) | Traditional (VM / bare metal) |
-|---|---|---|
-| **Artifact** | OCI image containing Lucee + your app | Directory of app code plus an installed engine |
-| **Runtime** | Container runtime (Docker, Podman, Kubernetes) | systemd service running CommandBox or a servlet container |
-| **Updates** | Build image, push to registry, roll out new image | Pull code, restart service |
-| **Dev/prod parity** | High — same image in both environments | Lower — dev and prod diverge on engine version, JVM flags, OS libs |
-| **Ops burden** | Registry, orchestrator or Compose, image hygiene | Config management (Ansible/Puppet/Chef), package pinning |
+The port is byte-compatible with Ruby Kamal on the server side. Container names, labels, Docker network, lock-file paths, and the `.kamal/` directory layout all match exactly — a host managed by Ruby Kamal can be taken over by `wheels deploy` during evaluation, and vice versa. You don't need Ruby, a gem install, or a second CLI. The mirrored Kamal version is 2.4.0; the `kamal-proxy` image is pinned at v0.8.6.
 
-### Pick containerized when
+There is exactly one deliberate schema divergence: `deploy.yml` does not support ERB. Where Ruby Kamal writes `<%= ENV["APP_NAME"] %>`, Wheels writes `{{env.APP_NAME}}`. Everything else is identical. See [Migrating from Kamal](/v4-0-0-snapshot/deployment/migrating-from-kamal/) for the full story.
 
-- Your team already runs containers for other services. The existing registry, orchestration, and observability stack applies unchanged.
-- You want one artifact you can run identically on a laptop, in CI, and in production.
-- You're comfortable operating a registry and either an orchestrator or a Compose-based host.
+## When to reach for `wheels deploy`
 
-### Pick traditional when
+`wheels deploy` targets the common production shape — one to a few dozen Linux servers, one or more Docker images, a handful of sidecar services (a database, a cache), and a requirement for zero-downtime rollover. If that's your target, it is the shortest path.
 
-- You have existing VM or bare-metal infrastructure with mature config management, and adding a container layer adds cost without reducing risk.
-- Compliance, audit, or network topology constraints make containers harder than they're worth.
-- Your team is small and one long-lived host per environment is simpler than an orchestrator.
+Reach for something else when:
 
-Both models are first-class. The detail pages go deep on each.
+- **Your deploy target is Kubernetes.** `wheels deploy` talks to `docker` remotely, not to a Kubernetes API. Use your normal k8s pipeline; the [Docker Deployment](/v4-0-0-snapshot/deployment/docker-deployment/) page covers image hygiene for that world.
+- **You're deploying locally with Docker Compose only.** For single-host, developer-centric Compose setups, [Docker Deployment](/v4-0-0-snapshot/deployment/docker-deployment/) covers the Compose path end-to-end. `wheels deploy` adds value once you have two or more servers to coordinate.
+- **Your target is a VM without containers.** If you run CommandBox or a standalone servlet container under systemd, stay on that path — [VM and Bare-metal Deployment](/v4-0-0-snapshot/deployment/vm-deployment/) covers it. `wheels deploy` is Docker-only on the server side; it does not grow a systemd mode.
+- **Your servers run Windows.** Kamal doesn't support Windows servers and `wheels deploy` inherits that limitation. Windows developer workstations are best-effort.
+
+If none of those apply, start with [Your First Deploy](/v4-0-0-snapshot/deployment/first-deploy/).
+
+## Zero-downtime rollover
+
+Every `wheels deploy` invocation follows the same sequence:
+
+1. Acquire a per-service lock on one host so two operators don't trip over each other.
+2. Build and push the new image to your registry.
+3. Pull the image on every target host in parallel.
+4. Boot `kamal-proxy` if it isn't already running (it's a singleton per host).
+5. For each host in sequence: start the new container, then ask `kamal-proxy` to switch traffic. The proxy drains in-flight requests from the old container and routes fresh ones to the new one. If health checks on the new container fail, the proxy refuses to cut over and the old container stays authoritative.
+6. Release the lock.
+
+The load-bearing hand-off is `kamal-proxy deploy <service> --target <container>:<port>`. That's a Go binary — not a Ruby one — and it runs on your hosts as a long-lived container. `wheels deploy` produces the `docker exec` that invokes it; `kamal-proxy` itself does the actual traffic switch. See [Proxy](/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/) for the operational surface.
+
+<Aside type="note" title="Phase status">
+The 4.0 port is feature-complete for the Kamal 2.4.0 surface — all 25 top-level verbs, the full `app`/`proxy`/`accessory`/`build`/`registry`/`secrets`/`server`/`prune`/`lock` subcommand tree, and 5 secret-store adapters (1Password, Bitwarden, AWS Secrets Manager, LastPass, Doppler). The `app live`/`app maintenance` verbs use a server-side marker-file approach rather than `kamal-proxy`'s native maintenance mode — a follow-up will swap that in.
+</Aside>
 
 ## What Wheels provides vs. what you provide
 
-The framework is deliberately narrow about production. Wheels gives you a CFML app that boots on any supported engine, configures itself from environment variables, and exposes health and observability hooks. Everything outside the JVM process is yours.
+The framework is narrow about production. Wheels gives you a CFML app that boots on any supported engine, configures itself from environment variables, and exposes observability hooks. `wheels deploy` packages, ships, and rolls out that app. Everything else is still yours.
 
 **Wheels provides:**
 
-- A CFML application that runs on Lucee 5/6/7, Adobe ColdFusion 2018/2021/2023/2025, or BoxLang. The 4.0 reference engine for core tests is Lucee 7 on Java 21.
+- A CFML application that runs on Lucee 6/7 or Adobe ColdFusion 2023/2025. The 4.0 reference engine for core tests is Lucee 7 on Java 21.
+- `wheels deploy` — orchestration, dry-run, rollback, accessories, secrets adapters, hooks. See [Your First Deploy](/v4-0-0-snapshot/deployment/first-deploy/).
 - Environment-aware configuration (`config/environment.cfm`, `config/environments/*.cfm`) that selects behavior by `WHEELS_ENV`.
-- Secrets loaded from `.env` (dev) or process environment (prod) via `config/settings.cfm`.
-- A migrator (`wheels dbmigrate`) and seeder (`wheels seed`) that run against your production database on deploy.
+- A migrator (`wheels dbmigrate`) and seeder (`wheels seed`) that run inside the deployed container against your production database.
 - Built-in middleware for request IDs, security headers, CORS, and rate limiting — wired in `config/settings.cfm`.
-- A reload endpoint (`?reload=true&password=...`) and health-check surface your orchestrator or load balancer can poll.
+- A reload endpoint (`?reload=true&password=...`) and a health-check surface `kamal-proxy` polls.
 
 **You provide:**
 
-- The container or VM. Wheels does not ship a canonical base image or bake-a-VM recipe.
-- The CFML engine install and its JVM. A typical production Wheels container runs Lucee 7 on Java 21; a typical VM install uses the same engine under CommandBox or a standalone servlet container.
-- A reverse proxy (nginx, Caddy, Traefik, HAProxy, ALB) to terminate TLS and forward plain HTTP to the engine.
-- TLS certificates and their renewal. Wheels has an `HTTPS detection` helper but does not issue or rotate certificates.
-- Secrets management. The app reads from environment variables; how those variables get populated (1Password Connect, Vault, SSM Parameter Store, Docker secrets, plain `.env` files) is your call.
-- The database, its backups, and its failover story. Migrations run against whatever `WHEELS_DATASOURCE_*` points at — the framework does not provision databases.
-- Logs, metrics, and traces. See [Observability & Logging](/v4-0-0-snapshot/deployment/observability-and-logging/) for the hooks Wheels exposes.
-
-<Aside type="note">
-  This split is deliberate. Wheels runs inside every kind of production environment teams already have — locking the framework to one opinionated stack would exclude most of them. The detail pages show concrete setups for the common cases.
-</Aside>
-
-## The `wheels deploy` CLI
-
-There is no `wheels deploy` command in 4.0 today. Deployment is currently assembled from the pieces your infrastructure gives you — a Dockerfile and a `docker compose` or Kubernetes manifest, or an Ansible playbook and a systemd unit.
-
-A first-party `wheels deploy` is in active development. The design ports the [Kamal](https://kamal-deploy.org/) deploy model — single-binary, zero-downtime rolling deploys from a laptop, with the orchestration state kept on the target hosts — onto the Wheels CLI surface. It targets Docker-based deployments first, and treats the reverse proxy, TLS via Let's Encrypt, and rolling container replacement as built-in rather than user-provided.
-
-{/* TODO(phase-2c): swap this paragraph for a link to the wheels deploy PR/issue once opened */}
-
-Until it ships, everything on the detail pages assumes you are assembling deployment yourself.
+- The Linux hosts. Bare VMs, cloud instances, it doesn't matter — Docker is the only hard requirement. `wheels deploy server bootstrap` installs Docker on a fresh host.
+- The Docker image. Wheels doesn't ship a canonical base image; your `Dockerfile` lives in your app repo.
+- The container registry. Docker Hub, GHCR, ECR, or self-hosted — `wheels deploy` logs in, pushes, and pulls; the registry itself is yours to operate.
+- TLS certificates. `kamal-proxy` will request Let's Encrypt certs automatically when `proxy.ssl: true`, but if you need wildcards, custom CAs, or static certs, you configure the proxy.
+- Secrets storage. `.kamal/secrets` resolves `$(op read ...)`, `$(aws secretsmanager ...)`, and equivalents — the vault itself is yours.
+- The database, its backups, and its failover story. Accessories can host one if you want Wheels to manage it, or you can point at an existing managed database.
+- Logs, metrics, and traces. See [Observability & Logging](/v4-0-0-snapshot/deployment/observability-and-logging/).
 
 ## Where to go next
 
 <CardGrid>
   <LinkCard
+    title="Your First Deploy"
+    href="/v4-0-0-snapshot/deployment/first-deploy/"
+    description="A guided walk from wheels deploy init to running app, assuming no prior Kamal knowledge."
+  />
+  <LinkCard
+    title="deploy.yml Reference"
+    href="/v4-0-0-snapshot/deployment/config-reference/"
+    description="Every top-level key in deploy.yml, what it does, and when to reach for it."
+  />
+  <LinkCard
+    title="Accessories"
+    href="/v4-0-0-snapshot/deployment/accessories/"
+    description="Sidecar containers for databases, caches, and search. Booted once and left alone."
+  />
+  <LinkCard
+    title="Secrets"
+    href="/v4-0-0-snapshot/deployment/secrets/"
+    description="The .kamal/secrets file, $(...) command substitution, and the 5 built-in adapters."
+  />
+  <LinkCard
+    title="Hooks"
+    href="/v4-0-0-snapshot/deployment/hooks/"
+    description="Shell scripts under .kamal/hooks/ that run locally around every deploy."
+  />
+  <LinkCard
+    title="Migrating from Kamal"
+    href="/v4-0-0-snapshot/deployment/migrating-from-kamal/"
+    description="For teams coming from Ruby Kamal — what's compatible, what's not, and the one schema divergence."
+  />
+  <LinkCard
     title="Production Configuration"
     href="/v4-0-0-snapshot/deployment/production-config/"
-    description="Environment files, secrets, reload passwords, and the settings that differ between dev and prod."
+    description="Environment files, secrets, reload passwords, and settings that differ between dev and prod."
   />
   <LinkCard
     title="Docker Deployment"
     href="/v4-0-0-snapshot/deployment/docker-deployment/"
-    description="Dockerfile layout, a working Compose setup, registry workflow, and rolling image updates."
+    description="Dockerfile layout, image hygiene, and the Compose path for smaller setups."
   />
   <LinkCard
-    title="VM Deployment"
+    title="VM & Bare-metal Deployment"
     href="/v4-0-0-snapshot/deployment/vm-deployment/"
-    description="systemd units, Ansible-style provisioning, reverse proxy configuration, and deploy scripts."
+    description="systemd units, reverse proxy configuration, and deploy scripts for non-container setups."
   />
   <LinkCard
     title="Security Hardening"
@@ -106,5 +135,10 @@ Until it ships, everything on the detail pages assumes you are assembling deploy
     title="Observability & Logging"
     href="/v4-0-0-snapshot/deployment/observability-and-logging/"
     description="Request IDs, structured logs, health checks, error tracking, and metrics hooks."
+  />
+  <LinkCard
+    title="CLI Reference"
+    href="/v4-0-0-snapshot/command-line-tools/commands/deploy/"
+    description="Every wheels deploy verb — flags, examples, behavior."
   />
 </CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/migrating-from-kamal.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/migrating-from-kamal.mdx
@@ -1,0 +1,154 @@
+---
+title: Migrating from Kamal
+description: For teams coming from Ruby Kamal — what wheels deploy inherits verbatim, the one deliberate schema divergence, and a concrete switch-over checklist.
+type: howto
+sidebar:
+  order: 12
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+This page is for teams already running Ruby Kamal who want to replace `kamal` with `wheels deploy`. The short version: your `config/deploy.yml`, `.kamal/secrets`, and `.kamal/hooks/*` work unchanged with one exception — ERB inside `deploy.yml`. Keep reading for the full story.
+
+**You'll learn:**
+
+- What `wheels deploy` keeps byte-compatible with Ruby Kamal
+- The one deliberate schema divergence (ERB → Mustache) and how to convert
+- The coexistence guarantee — running both tools against the same host during evaluation
+- A concrete switch-over checklist
+
+<Aside type="caution" title="ERB is not supported">
+`deploy.yml` in Ruby Kamal supports embedded ERB. `wheels deploy` does not. This is the only schema-level incompatibility. If you use ERB anywhere in your deploy config, you will need to convert it to Mustache. See [The one divergence](#the-one-divergence) below.
+</Aside>
+
+## What's byte-compatible
+
+The on-server state managed by `wheels deploy` and Ruby Kamal is identical by design. Everything in this list matches the Kamal 2.4.0 contract exactly.
+
+| Concern | Value |
+|---------|-------|
+| Container name | `<service>-<role>-<version>` (e.g. `myapp-web-abc1234`) |
+| Container labels | `service=`, `role=`, `destination=`, `version=` |
+| Docker network | `kamal` |
+| Proxy image | `basecamp/kamal-proxy:v0.8.6` |
+| Proxy config dir | `/home/<user>/.config/kamal-proxy/` |
+| Lock file path | `/tmp/kamal_deploy_lock_<service>` |
+| Audit log | `/tmp/kamal-audit.log` |
+| Hook directory | `.kamal/hooks/` |
+| Hook env prefix | `KAMAL_*` (not `WHEELS_*`) |
+| Secret file | `.kamal/secrets`, `.kamal/secrets.<destination>` |
+
+Why keep the `KAMAL_*` prefix? Because every hook anyone has ever written for Ruby Kamal uses it. Renaming would break every user's existing scripts for zero benefit.
+
+Why keep the `.kamal/` directory name? Because you can sit on both tools during evaluation — `kamal deploy` and `wheels deploy` read the same secrets and the same hooks. Switch back and forth freely; nothing on the server changes.
+
+## The one divergence
+
+Ruby Kamal allows ERB inside `deploy.yml`:
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+# Ruby Kamal — NOT SUPPORTED in wheels deploy
+service: <%= ENV["APP_NAME"] %>
+image: <%= ENV["REGISTRY"] %>/<%= ENV["APP_NAME"] %>
+```
+
+ERB is a Ruby template language — it calls into Ruby code at render time. We can't render ERB from a CFML CLI without embedding a Ruby runtime, which defeats the purpose of the port.
+
+`wheels deploy` replaces ERB with a restricted Mustache context:
+
+```yaml title="config/deploy.yml (illustrative — do not type)"
+service: {{env.APP_NAME}}
+image: {{env.REGISTRY}}/{{env.APP_NAME}}
+```
+
+Three variables are available in the rendering context:
+
+| Variable | Value |
+|----------|-------|
+| `env.*` | Any environment variable or `.kamal/secrets` entry. |
+| `destination` | Current `--destination` flag, or empty. |
+| `hostname` | Local hostname of the machine running `wheels deploy`. |
+
+No loops, no conditionals, no method calls. If your existing config uses ERB logic — `<%= "blue" if ENV["ROLE"] == "staging" %>` — move that logic into a shell wrapper or into `.kamal/secrets` first, and reference the resolved value via `{{env.*}}`.
+
+### Common ERB → Mustache conversions
+
+| Ruby Kamal ERB | `wheels deploy` Mustache |
+|----------------|--------------------------|
+| `<%= ENV["FOO"] %>` | `{{env.FOO}}` |
+| `<%= ENV.fetch("FOO", "bar") %>` | `{{env.FOO}}` (set `FOO=bar` in `.kamal/secrets` for the default) |
+| `<%= `git rev-parse --short HEAD`.chomp %>` | pass `--version=$(git rev-parse --short HEAD)` on the CLI, or set `VERSION` in `.kamal/secrets` and use `{{env.VERSION}}` |
+| `<%= ENV["STAGE"] == "prod" ? 1 : 0 %>` | Set the resolved value in `.kamal/secrets.production` or `.kamal/secrets.staging` — destination overlays replace in-file logic |
+
+## What changes in the CLI
+
+The verb surface mirrors Kamal's. Most invocations are identical save the leading verb:
+
+| Ruby Kamal | `wheels deploy` |
+|------------|-----------------|
+| `kamal setup` | `wheels deploy setup` |
+| `kamal deploy` | `wheels deploy` |
+| `kamal redeploy` | `wheels deploy redeploy` |
+| `kamal rollback VERSION` | `wheels deploy rollback --version=VERSION` |
+| `kamal config` | `wheels deploy config` |
+| `kamal app logs --follow` | `wheels deploy app logs --follow` |
+| `kamal proxy boot` | `wheels deploy proxy boot` |
+| `kamal accessory boot db` | `wheels deploy accessory boot db` |
+| `kamal secrets fetch --from op://...` | `wheels deploy secrets fetch --adapter=op --from=op://...` |
+| `kamal version` | `wheels deploy version` |
+
+Two CLI-level differences worth flagging:
+
+- **Flag style.** `wheels deploy` uses `--flag=value` everywhere. Positional args for a few verbs (`accessory boot <name>`, `rollback <version>` in Kamal) become named flags (`accessory boot --name=<name>`, `rollback --version=<version>`) for consistency across the CFML arg parser.
+- **`--dry-run` is everywhere.** Every `wheels deploy` verb accepts `--dry-run` and prints the commands it would have run, prefixed by host. This is wider coverage than Kamal's `KAMAL_DEBUG=1` logs.
+
+## The coexistence guarantee
+
+Because on-server state is byte-identical, you can run both tools against the same host during a transition:
+
+- Deploy with `kamal deploy` on Tuesday, `wheels deploy` on Wednesday, `kamal deploy` on Thursday. Nothing on the server notices.
+- Run `kamal config` and `wheels deploy config` side-by-side to compare resolved output. The wheels output is a subset of the Kamal output — it names fewer keys, but every key it names matches.
+- Locks, audit logs, and the `kamal-proxy` container are single-owner on the server; whichever tool holds the lock has it until release.
+
+This exists for evaluation, not long-term mixed use. Pick a tool per repo and stick with it.
+
+## Switch-over checklist
+
+Before removing `kamal` from your ecosystem:
+
+1. **Scan `deploy.yml` for ERB.** `grep -n '<%' config/deploy.yml`. Every match needs conversion.
+2. **Review `.kamal/secrets` for shell compatibility.** `wheels deploy` evaluates the file through `bash`; if you relied on `sh`-only behavior, nothing changes, but confirm.
+3. **Install the Wheels CLI on every control machine that runs deploys.** See [installing the CLI](/v4-0-0-snapshot/command-line-tools/installation/).
+4. **Run `wheels deploy config` and diff against `kamal config`.** Every field wheels emits should match kamal's. The reverse isn't true — wheels emits a subset during Phase 1.
+5. **Run `wheels deploy --dry-run`.** Every command it would run, printed with host prefixes. Confirm it matches what you expect.
+6. **Deploy a non-critical environment first.** Staging before production. Verify logs, health checks, rollback.
+7. **Update CI.** Replace any `bundle exec kamal ...` or `gem install kamal` lines with your Wheels CLI install command plus `wheels deploy ...`.
+8. **Remove `Gemfile` / `Gemfile.lock` Kamal entries.** Only after at least one successful production deploy with `wheels deploy`.
+
+## What's explicitly not supported
+
+These Ruby Kamal features have no `wheels deploy` equivalent and won't get one:
+
+- **Kamal plugins** (`Kamal::Commands` extension points in Ruby). The plugin API is Ruby-specific. Shell-script `.kamal/hooks/` are supported — that's the language-agnostic extension story.
+- **Arbitrary ERB in `deploy.yml`.** Covered above.
+- **Windows servers.** Kamal doesn't support them, and `wheels deploy` inherits that.
+
+## Related guides
+
+<CardGrid>
+  <LinkCard
+    title="deploy.yml Reference"
+    href="/v4-0-0-snapshot/deployment/config-reference/"
+    description="Every key in the schema, with the Mustache interpolation rules."
+  />
+  <LinkCard
+    title="Your First Deploy"
+    href="/v4-0-0-snapshot/deployment/first-deploy/"
+    description="The walkthrough to confirm wheels deploy works on your stack."
+  />
+  <LinkCard
+    title="Hooks"
+    href="/v4-0-0-snapshot/deployment/hooks/"
+    description="Your Ruby Kamal hooks port over unchanged — KAMAL_ env is preserved."
+  />
+</CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/secrets.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/secrets.mdx
@@ -1,0 +1,179 @@
+---
+title: Secrets
+description: The .kamal/secrets file, $(...) command substitution, and the five built-in adapters for 1Password, Bitwarden, AWS Secrets Manager, LastPass, and Doppler.
+type: howto
+sidebar:
+  order: 10
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+`.kamal/secrets` is the plain-text glue between your secret store and `deploy.yml`. It's read on the control machine at deploy time, values are resolved, and the resulting `KEY=VALUE` map is passed into containers as environment variables. The file itself is never under git — the whole point is that it's the bridge between "secrets that live in a vault" and "env vars that live in a container."
+
+**You'll learn:**
+
+- The format of `.kamal/secrets`
+- How `$(...)` subshell substitution pulls values from any CLI tool
+- The five built-in adapters for common vaults
+- How secrets flow from `.kamal/secrets` through `deploy.yml` into the container
+
+<Aside type="caution" title="Never commit .kamal/secrets">
+Add `.kamal/secrets*` to your `.gitignore` before writing a single value. The file is designed to hold plaintext or subshells that reveal plaintext at deploy time — both are equally dangerous under git.
+</Aside>
+
+## The file format
+
+`.kamal/secrets` is a shell-compatible file with `KEY=value` lines. Comments start with `#`. Blank lines are ignored.
+
+```bash title=".kamal/secrets (illustrative — do not type)"
+# Registry
+KAMAL_REGISTRY_PASSWORD=ghp_abc123...
+
+# App
+DATABASE_URL=postgres://user:pass@db.example.com/app
+WHEELS_RELOAD_PASSWORD=choose-something-long
+```
+
+The keys on the left are referenced from two places in `deploy.yml`:
+
+- `registry.password:` — an array of keys the registry login uses.
+- `env.secret:` — an array of keys passed into the app container as env vars.
+
+At deploy time, `wheels deploy` reads `.kamal/secrets`, resolves every `$(...)`, and looks up each name the app asked for. A secret named in `deploy.yml` but missing from `.kamal/secrets` fails the deploy with `unresolved secret: <key>`.
+
+## Destination-scoped secrets
+
+For multi-environment deploys, `.kamal/secrets.<destination>` is merged on top of `.kamal/secrets` when you pass `--destination`. Keys in the overlay win.
+
+```bash title=".kamal/secrets.production (illustrative — do not type)"
+DATABASE_URL=$(op read op://Production/App/database-url)
+```
+
+```bash title=".kamal/secrets.staging (illustrative — do not type)"
+DATABASE_URL=$(op read op://Staging/App/database-url)
+```
+
+## `$(...)` command substitution
+
+Inside `.kamal/secrets`, anything on the right-hand side is passed through `bash`, so the usual `$(command)` substitution works. This is how you pull live values from your secret store:
+
+```bash title=".kamal/secrets (illustrative — do not type)"
+# 1Password CLI
+DATABASE_URL=$(op read op://Production/App/database-url)
+
+# Bitwarden CLI
+DATABASE_URL=$(bw get password db-url)
+
+# AWS Secrets Manager
+DATABASE_URL=$(aws secretsmanager get-secret-value --secret-id prod/db-url --query SecretString --output text)
+
+# Doppler
+DATABASE_URL=$(doppler secrets get DATABASE_URL --plain)
+
+# Flat file on the control machine
+WHEELS_MASTER_KEY=$(cat ~/.wheels/master.key)
+```
+
+`$(...)` runs once per deploy on the machine running `wheels deploy`. The vault is the system of record; `.kamal/secrets` is a glue layer.
+
+## Built-in adapters
+
+Five named adapters are available behind the `wheels deploy secrets fetch` verb. They're a shorthand over the raw `$(...)` substitution — preferring whichever CLI tool you already use.
+
+| Adapter | Aliases | Backing tool |
+|---------|---------|--------------|
+| 1Password | `op`, `1password` | `op` CLI |
+| Bitwarden | `bw`, `bitwarden` | `bw` CLI |
+| AWS Secrets | `aws` | `aws secretsmanager` |
+| LastPass | `lastpass`, `lpass` | `lpass` CLI |
+| Doppler | `doppler` | `doppler` CLI |
+
+### `wheels deploy secrets fetch`
+
+Fetches a set of keys from an adapter and prints them as `KEY=VALUE` lines — the format `.kamal/secrets` accepts via `$(...)`.
+
+```bash
+wheels deploy secrets fetch --adapter=op --from=op://Production/App DATABASE_URL WHEELS_MASTER_KEY
+```
+
+Prints:
+
+```
+DATABASE_URL=postgres://...
+WHEELS_MASTER_KEY=abc123...
+```
+
+Common pattern: wrap a `fetch` call in `.kamal/secrets` to pull multiple keys at once without repeating `$(...)`:
+
+```bash title=".kamal/secrets (illustrative — do not type)"
+$(wheels deploy secrets fetch --adapter=op --from=op://Production/App DATABASE_URL WHEELS_MASTER_KEY)
+```
+
+### `wheels deploy secrets extract`
+
+Extracts a single key from a `KEY=VALUE` block. Useful inside hooks or wrapper scripts.
+
+```bash
+echo "A=1
+B=2" | wheels deploy secrets extract --key=B
+# prints: 2
+```
+
+### `wheels deploy secrets print`
+
+Prints your project's fully resolved `.kamal/secrets` as `KEY=VALUE` lines. All `$(...)` subshells expand; every referenced key is emitted.
+
+```bash
+wheels deploy secrets print
+```
+
+Useful for auditing what the deploy flow will actually see. Run it in private — the output is plaintext secrets.
+
+## How secrets flow at deploy time
+
+```
+vault (1Password / Bitwarden / AWS / LastPass / Doppler / flat files)
+  │
+  │  $(op read ...)   ← .kamal/secrets evaluates once, on the control machine
+  ▼
+.kamal/secrets (KEY=VALUE, in-memory only)
+  │
+  │  env.secret: and registry.password: in deploy.yml name the keys
+  ▼
+docker run ... -e DATABASE_URL=... -e WHEELS_MASTER_KEY=...
+  │
+  ▼
+app container
+```
+
+Two things never happen:
+
+- The plaintext `.kamal/secrets` file is never uploaded to the target hosts. Only the resolved `-e` values land there, via `docker run`.
+- The resolved `KEY=VALUE` map is not cached. Every deploy re-runs every `$(...)`. Your vault is the source of truth.
+
+## Rotating a secret
+
+1. Update the value in your vault.
+2. Run `wheels deploy` — the next deploy pulls the new value.
+
+Running containers keep their original env vars. Rotation is a deploy, not a live operation.
+
+## Related guides
+
+<CardGrid>
+  <LinkCard
+    title="deploy.yml env"
+    href="/v4-0-0-snapshot/deployment/config-reference/#env"
+    description="How env.clear and env.secret work together."
+  />
+  <LinkCard
+    title="Registry"
+    href="/v4-0-0-snapshot/deployment/config-reference/#registry"
+    description="Using secrets for docker login."
+  />
+  <LinkCard
+    title="Hooks"
+    href="/v4-0-0-snapshot/deployment/hooks/"
+    description="Shell scripts can read resolved secrets via wheels deploy secrets print."
+  />
+</CardGrid>

--- a/web/sites/guides/src/sidebars/v4-0-0-snapshot.json
+++ b/web/sites/guides/src/sidebars/v4-0-0-snapshot.json
@@ -93,6 +93,12 @@
     "label": "Deployment & Operations",
     "link": "/v4-0-0-snapshot/deployment/",
     "items": [
+      { "label": "Your First Deploy", "link": "/v4-0-0-snapshot/deployment/first-deploy/" },
+      { "label": "deploy.yml Reference", "link": "/v4-0-0-snapshot/deployment/config-reference/" },
+      { "label": "Accessories", "link": "/v4-0-0-snapshot/deployment/accessories/" },
+      { "label": "Secrets", "link": "/v4-0-0-snapshot/deployment/secrets/" },
+      { "label": "Hooks", "link": "/v4-0-0-snapshot/deployment/hooks/" },
+      { "label": "Migrating from Kamal", "link": "/v4-0-0-snapshot/deployment/migrating-from-kamal/" },
       { "label": "Production Configuration", "link": "/v4-0-0-snapshot/deployment/production-config/" },
       { "label": "Docker Deployment", "link": "/v4-0-0-snapshot/deployment/docker-deployment/" },
       { "label": "VM and Bare-metal Deployment", "link": "/v4-0-0-snapshot/deployment/vm-deployment/" },
@@ -131,6 +137,134 @@
           { "label": "System & Secrets", "link": "/v4-0-0-snapshot/command-line-tools/core-commands/system-and-secrets/" },
           { "label": "Modules & Deps", "link": "/v4-0-0-snapshot/command-line-tools/core-commands/modules-and-deps/" },
           { "label": "AI & Completion", "link": "/v4-0-0-snapshot/command-line-tools/core-commands/ai-and-completion/" }
+        ]
+      },
+      {
+        "label": "Deploy Commands",
+        "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/",
+        "items": [
+          { "label": "deploy", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/deploy/" },
+          { "label": "setup", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/setup/" },
+          { "label": "redeploy", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/redeploy/" },
+          { "label": "rollback", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/rollback/" },
+          { "label": "config", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/config/" },
+          { "label": "init", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/init/" },
+          { "label": "version", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/version/" },
+          { "label": "audit", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/audit/" },
+          { "label": "details", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/details/" },
+          { "label": "docs", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/docs/" },
+          { "label": "remove", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/remove/" },
+          {
+            "label": "app",
+            "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/app/",
+            "collapsed": true,
+            "items": [
+              { "label": "app boot", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/app/boot/" },
+              { "label": "app start", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/app/start/" },
+              { "label": "app stop", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/app/stop/" },
+              { "label": "app details", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/app/details/" },
+              { "label": "app containers", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/app/containers/" },
+              { "label": "app images", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/app/images/" },
+              { "label": "app logs", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/app/logs/" },
+              { "label": "app live", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/app/live/" },
+              { "label": "app maintenance", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/app/maintenance/" },
+              { "label": "app remove", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/app/remove/" }
+            ]
+          },
+          {
+            "label": "proxy",
+            "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/",
+            "collapsed": true,
+            "items": [
+              { "label": "proxy boot", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/boot/" },
+              { "label": "proxy reboot", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/reboot/" },
+              { "label": "proxy start", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/start/" },
+              { "label": "proxy stop", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/stop/" },
+              { "label": "proxy restart", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/restart/" },
+              { "label": "proxy details", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/details/" },
+              { "label": "proxy logs", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/logs/" },
+              { "label": "proxy remove", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/proxy/remove/" }
+            ]
+          },
+          {
+            "label": "accessory",
+            "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/",
+            "collapsed": true,
+            "items": [
+              { "label": "accessory boot", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/boot/" },
+              { "label": "accessory reboot", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/reboot/" },
+              { "label": "accessory start", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/start/" },
+              { "label": "accessory stop", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/stop/" },
+              { "label": "accessory restart", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/restart/" },
+              { "label": "accessory details", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/details/" },
+              { "label": "accessory logs", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/logs/" },
+              { "label": "accessory remove", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/accessory/remove/" }
+            ]
+          },
+          {
+            "label": "build",
+            "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/build/",
+            "collapsed": true,
+            "items": [
+              { "label": "build deliver", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/build/deliver/" },
+              { "label": "build push", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/build/push/" },
+              { "label": "build pull", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/build/pull/" },
+              { "label": "build create", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/build/create/" },
+              { "label": "build remove", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/build/remove/" },
+              { "label": "build details", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/build/details/" },
+              { "label": "build dev", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/build/dev/" }
+            ]
+          },
+          {
+            "label": "registry",
+            "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/",
+            "collapsed": true,
+            "items": [
+              { "label": "registry setup", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/setup/" },
+              { "label": "registry login", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/login/" },
+              { "label": "registry logout", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/logout/" },
+              { "label": "registry remove", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/registry/remove/" }
+            ]
+          },
+          {
+            "label": "server",
+            "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/server/",
+            "collapsed": true,
+            "items": [
+              { "label": "server exec", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/server/exec/" },
+              { "label": "server bootstrap", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/server/bootstrap/" }
+            ]
+          },
+          {
+            "label": "prune",
+            "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/",
+            "collapsed": true,
+            "items": [
+              { "label": "prune all", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/all/" },
+              { "label": "prune images", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/images/" },
+              { "label": "prune containers", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/prune/containers/" }
+            ]
+          },
+          {
+            "label": "lock",
+            "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/",
+            "collapsed": true,
+            "items": [
+              { "label": "lock acquire", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/acquire/" },
+              { "label": "lock release", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/release/" },
+              { "label": "lock status", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/lock/status/" }
+            ]
+          },
+          {
+            "label": "secrets",
+            "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/",
+            "collapsed": true,
+            "items": [
+              { "label": "secrets fetch", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/fetch/" },
+              { "label": "secrets extract", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/extract/" },
+              { "label": "secrets print", "link": "/v4-0-0-snapshot/command-line-tools/commands/deploy/secrets/print/" }
+            ]
+          }
         ]
       }
     ]


### PR DESCRIPTION
## Summary

Fills the deployment docs slot deliberately left empty when the v4 guides rewrite shipped ([#2169](https://github.com/wheels-dev/wheels/pull/2169)). The Kamal-based `wheels deploy` port ([#2187](https://github.com/wheels-dev/wheels/pull/2187)) is now documented for end users in Starlight-native MDX under `web/sites/guides/src/content/docs/v4-0-0-snapshot/`.

**Deployment guides** (7 files under `deployment/`):
- `index.mdx` rewrite — replaces the "no wheels deploy in 4.0 today" placeholder with a landing page covering the Kamal lineage, when to reach for the tool vs. alternatives, and the zero-downtime rollover story.
- `first-deploy.mdx` — guided tutorial from `wheels deploy init` → `wheels deploy` with Starlight `<Steps>`.
- `config-reference.mdx` — full `deploy.yml` schema. Every allowed top-level key was sourced directly from `cli/lucli/services/deploy/config/Validator.cfc` on this branch.
- `accessories.mdx`, `secrets.mdx`, `hooks.mdx` — topic-focused how-tos.
- `migrating-from-kamal.mdx` — the ERB-vs-Mustache divergence is called out in a `<Aside type="caution">` at the top.

**CLI reference** (69 files under `command-line-tools/commands/deploy/`):
- One page per verb across 10 groups (top-level + `app`/`proxy`/`accessory`/`build`/`registry`/`server`/`prune`/`lock`/`secrets`). Each page carries frontmatter, synopsis, flags table, behavior paragraph, and 1-2 examples. Behavior is sourced directly from the `*Cli.cfc` files on develop — e.g. the Phase 2 marker-file `app live`/`app maintenance` implementation is documented honestly rather than as full proxy-native maintenance.

**Sidebar** (`src/sidebars/v4-0-0-snapshot.json`):
- Deployment & Operations: 6 new items promoted to the top; existing `production-config`, `docker-deployment`, `vm-deployment`, `security-hardening`, `observability-and-logging` entries retained below unchanged.
- CLI Reference: new "Deploy Commands" subsection with collapsible per-verb-group leaves.

## Test plan

- [x] `cd web && pnpm --filter @wheels-dev/site-guides build` — green. 415 pages built; all 76 new pages render with correct sidebar position.
- [x] Sidebar JSON validates as JSON (`python3 -c "import json; json.load(open(...))"`).
- [x] Spot-checked frontmatter shape, Starlight component imports, and voice against existing pages (`start-here/tutorial/index.mdx`, `basics/models-and-the-orm.mdx`).
- [ ] Preview locally with `pnpm --filter @wheels-dev/site-guides dev` and click through the new sidebar sections.
- [ ] Verify migrating-from-kamal.mdx ERB-vs-Mustache callout reads loud enough.

## Notes

- Ruby Kamal on-server parity and the deliberate Mustache-for-ERB schema divergence follow the spec at `docs/superpowers/specs/2026-04-20-wheels-deploy-kamal-port-design.md`.
- Per `cli/CLAUDE.md:67` the commit does not include a Co-Authored-By trailer.