### PR TITLE
docs(docs): rename wheels code references to wheels generate snippets (#2173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 - **Breaking:** CSRF cookie now sets `SameSite` attribute (#2035)
 - **Breaking:** RateLimiter `trustProxy` default changed from `true` to `false` (#2024)
 - **Breaking:** RateLimiter proxy strategy default changed to `last` (#2088)
-- **Breaking:** `wheels snippets` CLI command renamed to `wheels code` (#1852)
+- **Breaking:** `wheels snippets` CLI command renamed to `wheels generate snippets` (#1852)
 - **Breaking:** Test base class namespace renamed: new tests extend `wheels.WheelsTest` (old `wheels.Test` preserved during 4.0 as a deprecation path) (#1889)
 - **Breaking:** Tests directory `tests/specs/functions/` renamed to `tests/specs/functional/` (#1872)
 - **Breaking:** `application.wirebox` renamed to `application.wheelsdi` (#1888)

--- a/docs/releases/blog-skeletons/02-upgrading-from-3x.md
+++ b/docs/releases/blog-skeletons/02-upgrading-from-3x.md
@@ -34,7 +34,7 @@ Use a consistent 4-part micro-template per item: **What changed / How to detect 
 2. **HSTS default-on in production** ([#2081](https://github.com/wheels-dev/wheels/pull/2081)).
 3. **CSRF key required in production; JWT algorithm validation** ([#2079](https://github.com/wheels-dev/wheels/pull/2079)).
 4. **`allowEnvironmentSwitchViaUrl` default false in prod; reload password required** ([#2076](https://github.com/wheels-dev/wheels/pull/2076), [#2082](https://github.com/wheels-dev/wheels/pull/2082)).
-5. **`wheels snippets` → `wheels code`** ([#1852](https://github.com/wheels-dev/wheels/pull/1852)).
+5. **`wheels snippets` → `wheels generate snippets`** ([#1852](https://github.com/wheels-dev/wheels/pull/1852)).
 6. **Test base class: `wheels.Test` → `wheels.WheelsTest`** ([#1889](https://github.com/wheels-dev/wheels/pull/1889)).
 7. **Tests directory rename: `tests/specs/functions/` → `tests/specs/functional/`** ([#1872](https://github.com/wheels-dev/wheels/pull/1872)).
 8. **Legacy RocketUnit removed from core** ([#1925](https://github.com/wheels-dev/wheels/pull/1925)) — existing RocketUnit specs still run; WheelsTest BDD mandatory for new.

--- a/docs/releases/wheels-3.0-vs-4.0.md
+++ b/docs/releases/wheels-3.0-vs-4.0.md
@@ -133,7 +133,7 @@ A category-by-category comparison showing how Wheels 4.0 closed framework-maturi
 | Dev inner-loop | Docker-required for tests | Zero-Docker LuCLI + SQLite (`tools/test-local.sh`) | **New** ([#2063](https://github.com/wheels-dev/wheels/pull/2063)) |
 | CI engine matrix | 42 jobs across engines × DBs | 8 jobs via engine-grouped testing | **Streamlined** ([#1939](https://github.com/wheels-dev/wheels/pull/1939)) |
 | CI pipeline | Docker-based | LuCLI-native Lucee 7 + SQLite | **Changed** ([#2032](https://github.com/wheels-dev/wheels/pull/2032)) |
-| `wheels snippets` command | Existed | Renamed to `wheels code` | **Breaking** ([#1852](https://github.com/wheels-dev/wheels/pull/1852)) |
+| `wheels snippets` command | Existed | Renamed to `wheels generate snippets` | **Breaking** ([#1852](https://github.com/wheels-dev/wheels/pull/1852)) |
 | LuCLI tier-1 commands | ~~absent~~ | Ported as a LuCLI module; WheelsTest suite | **New** ([#2092](https://github.com/wheels-dev/wheels/pull/2092), [#2093](https://github.com/wheels-dev/wheels/pull/2093)) |
 | LuCLI phase 3-4 | ~~absent~~ | Scaffold, seed, in-process services | **New** ([#2065](https://github.com/wheels-dev/wheels/pull/2065)) |
 | Scaffolded-app boot | ~~broken post-flatten~~ | Fixed | **Fixed** ([#2096](https://github.com/wheels-dev/wheels/pull/2096)) |

--- a/docs/releases/wheels-4.0-audit.md
+++ b/docs/releases/wheels-4.0-audit.md
@@ -122,7 +122,7 @@
 
 **CLI UX & generators:**
 
-- **`wheels snippets` → `wheels code` command rename** (#1852) — breaking; aligns with the "code snippets" concept.
+- **`wheels snippets` → `wheels generate snippets` command rename** (#1852) — breaking; aligns with the "code snippets" concept.
 - **Scaffold, seed, in-process services** (#2065) — Phase 3-4 of LuCLI migration. In-process service invocation removes external process overhead for generators.
 - **Playwright CLI commands** (#2013, #2021) — configuration, test helpers.
 - **Oracle admin privilege check for DB creation** (#1843).
@@ -229,7 +229,7 @@ Dependabot bumps (dev/CI infrastructure — not user-facing): #1898 (basic-ftp),
 
 Items that require migration notes for users upgrading from 3.x. These should have top billing in the upgrade guide and blog posts.
 
-1. **`wheels snippets` command renamed to `wheels code`** (#1852) — CLI breaking. Scripts/aliases calling `wheels snippets` must update.
+1. **`wheels snippets` command renamed to `wheels generate snippets`** (#1852) — CLI breaking. Scripts/aliases calling `wheels snippets` must update.
 2. **CFWheels → Wheels rebrand in active code** (#2064) — callers referencing old namespaces (e.g., `cfwheels.*`) must update. Most user code unaffected; internal reference.
 3. **`testbox` → `wheelstest` namespace** (#1889) — test CFCs should extend `wheels.WheelsTest` (old `wheels.Test` continues to work but is legacy).
 4. **Tests directory `tests/specs/functions/` → `tests/specs/functional/`** (#1872).

--- a/docs/superpowers/plans/2026-04-16-wheels-4.0-upgrade-guide.md
+++ b/docs/superpowers/plans/2026-04-16-wheels-4.0-upgrade-guide.md
@@ -105,7 +105,7 @@ If every row in this table looks fine for your app, your upgrade is probably str
 | 4 | CSRF cookie `SameSite=Lax` default | Fine for most apps; pass `SameSite=None` only for cross-site flows |
 | 5 | RateLimiter `trustProxy=false` default | Pass `trustProxy=true, proxyHopCount=N` behind a proxy |
 | 6 | RateLimiter proxy strategy `last` default | Fine for most proxy setups; `first` only if you own the full chain |
-| 7 | `wheels snippets` → `wheels code` CLI rename | Grep your scripts and CI configs for `wheels snippets` |
+| 7 | `wheels snippets` → `wheels generate snippets` CLI rename | Grep your scripts and CI configs for `wheels snippets` |
 | 8 | Test base `wheels.Test` → `wheels.WheelsTest` | Required for new tests only; old base still works for existing tests |
 | 9 | `tests/specs/functions/` → `tests/specs/functional/` (framework) | Apps that mirrored the old layout can rename for consistency |
 | 10 | `application.wirebox` → `application.wheelsdi` | Prefer the `service()` global helper instead of direct scope access |
@@ -358,13 +358,13 @@ Expected: 6
 
 ```markdown
 
-### 7. CLI: `wheels snippets` → `wheels code`
+### 7. CLI: `wheels snippets` → `wheels generate snippets`
 
 **PR:** [#1852](https://github.com/wheels-dev/wheels/pull/1852)
 
 **What changed**
 
-The `wheels snippets` CLI command is renamed to `wheels code`. Shell scripts, CI pipelines, deploy hooks, and personal aliases calling `wheels snippets` must be updated.
+The `wheels snippets` CLI command moved under the `generate` dispatcher as `wheels generate snippets`. Shell scripts, CI pipelines, deploy hooks, and personal aliases calling `wheels snippets` must be updated.
 
 **How to detect**
 
@@ -378,12 +378,12 @@ Replace every occurrence:
 
 ```bash
 # Before
-wheels snippets list
-wheels snippets add MyTemplate
+wheels snippets auth
+wheels snippets soft-delete
 
 # After
-wheels code list
-wheels code add MyTemplate
+wheels generate snippets auth
+wheels generate snippets soft-delete
 ```
 
 **Opt-out**
@@ -728,7 +728,7 @@ covering the 10 Breaking changes in 4.0 plus migration paths:
     * 6 security-hardening default flips (CORS, env-switch, HSTS,
       CSRF SameSite, RateLimiter trustProxy, RateLimiter proxy
       strategy)
-    * 1 CLI rename (wheels snippets → wheels code)
+    * 1 CLI rename (wheels snippets → wheels generate snippets)
     * 3 namespace / directory renames (wheels.Test → WheelsTest,
       tests/specs/functions/ → functional/, application.wirebox →
       application.wheelsdi)
@@ -789,7 +789,7 @@ Plus a one-line callout added to the top of the existing `upgrading.md` linking 
 | 4 | CSRF cookie SameSite=Lax | #2035 |
 | 5 | RateLimiter trustProxy default | #2024 |
 | 6 | RateLimiter proxy strategy default | #2088 |
-| 7 | wheels snippets → wheels code | #1852 |
+| 7 | wheels snippets → wheels generate snippets | #1852 |
 | 8 | wheels.Test → wheels.WheelsTest | #1889 |
 | 9 | tests/specs/functions/ → functional/ | #1872 |
 | 10 | application.wirebox → application.wheelsdi | #1888 |

--- a/docs/superpowers/specs/2026-04-16-wheels-4.0-upgrade-guide-design.md
+++ b/docs/superpowers/specs/2026-04-16-wheels-4.0-upgrade-guide-design.md
@@ -10,7 +10,7 @@
 
 ## Problem
 
-Wheels 4.0 introduces 10 Breaking changes in the CHANGELOG: 6 security-hardening default flips, 1 CLI rename (`wheels snippets` → `wheels code`), and 3 namespace / directory renames. Apps upgrading from 3.x need a single authoritative document that:
+Wheels 4.0 introduces 10 Breaking changes in the CHANGELOG: 6 security-hardening default flips, 1 CLI rename (`wheels snippets` → `wheels generate snippets`), and 3 namespace / directory renames. Apps upgrading from 3.x need a single authoritative document that:
 
 1. Enumerates every breaking change with **what changed, how to detect, how to fix, and opt-out**.
 2. Describes the Legacy Compatibility Adapter ([#2015](https://github.com/wheels-dev/wheels/pull/2015)) as the soft-landing option.
@@ -85,7 +85,7 @@ docs/src/introduction/upgrading-to-4.0.md
    6.4. CSRF cookie SameSite default (#2035)
    6.5. RateLimiter trustProxy default (#2024)
    6.6. RateLimiter proxy strategy default (#2088)
-   6.7. CLI: wheels snippets → wheels code (#1852)
+   6.7. CLI: wheels snippets → wheels generate snippets (#1852)
    6.8. Test base class namespace (#1889)
    6.9. Tests directory rename (#1872)
    6.10. application.wirebox → application.wheelsdi (#1888)

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/upgrading/3x-to-4x.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/upgrading/3x-to-4x.mdx
@@ -110,9 +110,9 @@ Rate limiter also now fails closed on lock timeout (#2069) rather than fail-open
 
 Cross-site `POST`s from third-party frames that relied on the missing attribute will break. Same-site app flows are unaffected.
 
-### 7. `wheels snippets` renamed to `wheels code`
+### 7. `wheels snippets` renamed to `wheels generate snippets`
 
-**CHANGELOG:** `Breaking: wheels snippets CLI command renamed to wheels code` (#1852).
+**CHANGELOG:** `Breaking: wheels snippets CLI command renamed to wheels generate snippets` (#1852).
 
 Update any scripts, CI jobs, or IDE integrations that shell out to `wheels snippets`. The flag surface is otherwise unchanged.
 


### PR DESCRIPTION
## Summary

- CHANGELOG and several downstream docs claimed `wheels snippets` was renamed to `wheels code`, but the shipped 4.0 command is `wheels generate snippets` (a subcommand of the `generate` dispatcher in `cli/lucli/Module.cfc`). `wheels code` does not exist.
- Pure documentation drift — corrected all references in CHANGELOG, the user-facing 3x-to-4x upgrade guide, release collateral, and internal planning/spec docs.
- Also fixed fabricated `wheels code list` / `wheels code add MyTemplate` examples in the internal upgrade-guide plan to match the real surface (`wheels generate snippets <pattern>`).

Closes #2173

## Test plan

- [x] `grep -rn "wheels code" .` returns zero hits
- [ ] Verify rendered docs site shows corrected command in the 3x-to-4x upgrade section
- [ ] `wheels generate snippets` lists available patterns (sanity check on local install)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>