### PR TITLE
docs(docs): add 301 redirects for retired cli-reference urls (#2179)

### DIFF
--- a/web/sites/guides/astro.config.mjs
+++ b/web/sites/guides/astro.config.mjs
@@ -64,6 +64,21 @@ function buildSidebarForVersion(version) {
 
 export default defineConfig({
 	site: 'https://guides.wheels.dev',
+	redirects: {
+		// Phase 0 preview at /v4-0-0-snapshot/cli-reference/ was retired in
+		// PR #2169 and replaced by the 103-page tree at
+		// /v4-0-0-snapshot/command-line-tools/. Preserve any external
+		// bookmarks or backlinks accumulated during the preview window.
+		// See issue #2179.
+		//
+		// Note: Astro's static `redirects` map does not support [...spread]
+		// sources without a backing page that can supply getStaticPaths,
+		// so deep-link catch-alls (e.g. /cli-reference/foo/bar) fall through
+		// to the site's 404 page rather than redirecting. Only the two
+		// documented Phase 0 URLs are redirected.
+		'/v4-0-0-snapshot/cli-reference': '/v4-0-0-snapshot/command-line-tools/',
+		'/v4-0-0-snapshot/cli-reference/info': '/v4-0-0-snapshot/command-line-tools/',
+	},
 	integrations: [
 		starlight({
 			title: 'Wheels Guides',


### PR DESCRIPTION
## Summary

Adds Astro static `redirects` map to `web/sites/guides/astro.config.mjs` so the Phase 0 preview paths at `/v4-0-0-snapshot/cli-reference/` (retired in #2169) redirect to the replacement tree at `/v4-0-0-snapshot/command-line-tools/` instead of 404'ing.

Two concrete redirects:
- `/v4-0-0-snapshot/cli-reference` → `/v4-0-0-snapshot/command-line-tools/`
- `/v4-0-0-snapshot/cli-reference/info` → `/v4-0-0-snapshot/command-line-tools/`

### Scope note — wildcard dropped

The triage plan called for a third `[...slug]` wildcard. Astro 5's static `redirects` map does **not** support `[...spread]` sources without a backing page that supplies `getStaticPaths` — `astro build` fails with `GetStaticPathsRequired` when a spread-source redirect has no source file. The wildcard was removed; only the two documented Phase 0 URLs (`index.mdx` and `info.mdx`) are redirected. Deep-link URLs under `/cli-reference/*` (if any exist in the wild) will hit the site's standard 404 page rather than redirecting.

### Status code note

Astro emits **308 Permanent Redirect** on the dev server (wire-level) and **meta-refresh HTML with canonical link** in the static build output (which Cloudflare Pages serves as HTTP 200 with refresh tag). Both are SEO-equivalent for a permanent redirect. If strict wire-level 301s are ever required, a parallel `public/_redirects` file with Cloudflare-native syntax can be added later.

Closes #2179

## Test plan

- [x] `pnpm --filter @wheels-dev/site-guides build` — compiles cleanly, 415 pages built, no warnings related to redirects
- [x] `ls dist/v4-0-0-snapshot/cli-reference/` — confirms `index.html` and `info/index.html` exist with meta-refresh + canonical to `/command-line-tools/`
- [x] `curl -sI http://localhost:4321/v4-0-0-snapshot/cli-reference` on `astro dev` → `HTTP/1.1 308 Permanent Redirect`, `location: /v4-0-0-snapshot/command-line-tools/`
- [x] `curl -sI http://localhost:4321/v4-0-0-snapshot/cli-reference/info` on `astro dev` → `HTTP/1.1 308 Permanent Redirect`, `location: /v4-0-0-snapshot/command-line-tools/`
- [x] `curl -sI http://localhost:4321/v4-0-0-snapshot/command-line-tools/` → `HTTP/1.1 200 OK` (regression check)
- [ ] After deploy, verify Cloudflare Pages preview serves the same three URLs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)