### PR TITLE
fix(model): resolve cockroachdb bulk-ops and locking test failures (#2106)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -609,7 +609,7 @@ curl -s "http://localhost:62023/wheels/core/tests?db=mysql&format=json" | \
 - **`private` mixin functions not integrated**: `$integrateComponents()` only copies `public` methods into model/controller objects. ALL helper functions in mixin CFCs (`vendor/wheels/model/*.cfc`, view helpers, etc.) MUST use `public` access. Use `$` prefix for internal scope instead of `private` keyword. BoxLang handles this differently, so `private` may pass BoxLang tests but fail Lucee/Adobe.
 
 ### CI soft-fail databases
-CockroachDB is marked as soft-fail in `.github/workflows/tests.yml` — failures are logged as warnings but don't block the build. The `SOFT_FAIL_DBS` variable controls this. Remove a database from the list once its tests are fixed.
+`SOFT_FAIL_DBS` in `.github/workflows/compat-matrix.yml` (lines 389, 519) is currently empty (`""`) — **all databases, including CockroachDB, are hard-gated in CI**. To mark a database as soft-fail (failures logged as warnings but not blocking the build), add it to `SOFT_FAIL_DBS` in both locations. Remove a database from the list once its tests are fixed.
 
 ### Cleanup
 ```bash

--- a/vendor/wheels/databaseAdapters/CockroachDB/CockroachDBModel.cfc
+++ b/vendor/wheels/databaseAdapters/CockroachDB/CockroachDBModel.cfc
@@ -65,6 +65,11 @@ component extends="wheels.databaseAdapters.PostgreSQL.PostgreSQLModel" output=fa
 	 * Override query setup to append RETURNING clause to INSERTs.
 	 * CockroachDB does not support pg_get_serial_sequence()/currval(),
 	 * so the RETURNING clause is the correct way to retrieve generated keys.
+	 *
+	 * Skip the RETURNING append on bulk / upsert paths: bulk.cfc's insertAll
+	 * and upsertAll call $querySetup without $primaryKey (default empty), and
+	 * upsert statements already include ON CONFLICT clauses. In both cases,
+	 * appending `RETURNING ` produces syntactically invalid SQL.
 	 */
 	public struct function $querySetup(
 		required array sql,
@@ -74,7 +79,18 @@ component extends="wheels.databaseAdapters.PostgreSQL.PostgreSQLModel" output=fa
 		string $primaryKey = ""
 	) {
 		if (Left(arguments.sql[1], 11) == "INSERT INTO") {
-			ArrayAppend(arguments.sql, "RETURNING #arguments.$primaryKey#");
+			local.shouldAppendReturning = Len(Trim(arguments.$primaryKey)) > 0;
+			if (local.shouldAppendReturning) {
+				for (local.chunk in arguments.sql) {
+					if (IsSimpleValue(local.chunk) && ReFindNoCase("ON[[:space:]]+CONFLICT", local.chunk)) {
+						local.shouldAppendReturning = false;
+						break;
+					}
+				}
+			}
+			if (local.shouldAppendReturning) {
+				ArrayAppend(arguments.sql, "RETURNING #arguments.$primaryKey#");
+			}
 		}
 		$convertMaxRowsToLimit(args = arguments);
 		$removeColumnAliasesInOrderClause(args = arguments);

--- a/vendor/wheels/tests/specs/model/lockingSpec.cfc
+++ b/vendor/wheels/tests/specs/model/lockingSpec.cfc
@@ -3,10 +3,12 @@ component extends="wheels.WheelsTest" {
 	function run() {
 
 		g = application.wo
+		var _isCockroachDB = CreateObject("component", "wheels.migrator.Migration").init().adapter.adapterName() == "CockroachDB";
 
 		describe("Tests that withAdvisoryLock", () => {
 
 			it("executes callback and returns result", () => {
+				if (_isCockroachDB) return;
 				local.result = g.model("author").withAdvisoryLock(name="test_lock_1", callback=function() {
 					return 42;
 				});
@@ -14,6 +16,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("releases lock even when callback throws an exception", () => {
+				if (_isCockroachDB) return;
 				local.exceptionThrown = false;
 				try {
 					g.model("author").withAdvisoryLock(name="test_lock_2", callback=function() {
@@ -32,6 +35,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("accepts a custom timeout argument", () => {
+				if (_isCockroachDB) return;
 				local.result = g.model("author").withAdvisoryLock(name="test_lock_timeout", timeout=5, callback=function() {
 					return "locked";
 				});
@@ -39,6 +43,7 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("safely handles lock names with single quotes", () => {
+				if (_isCockroachDB) return;
 				// Regression guard: verify lock names are parameterized, not interpolated.
 				// On SQLite this is a no-op, but the call must not throw a SQL syntax error
 				// regardless of adapter. With proper parameterization, "O'Brien" is fine.


### PR DESCRIPTION
## Summary

Closes #2106. Fixes 10 CockroachDB-only core-test failures, split across two distinct bugs.

### Bug 1 — `RETURNING <EOF>` in bulk INSERT / UPSERT paths (6 failures in `bulkOperationsSpec`)

`CockroachDBModel.$querySetup` unconditionally appended `RETURNING #arguments.$primaryKey#` to every statement starting with `INSERT INTO`. But `vendor/wheels/model/bulk.cfc`'s `insertAll` and `upsertAll` invoke `$querySetup` **without** passing `$primaryKey` (default `""`), so emitted SQL ended in a bare `RETURNING ` — CockroachDB raises `at or near "EOF": syntax error`. UPSERT statements already contain `ON CONFLICT (…) DO UPDATE …`, so appending `RETURNING` there is also incorrect.

Fix: in `$querySetup`, skip the `ArrayAppend` when either (a) `$primaryKey` is empty / whitespace, or (b) any SQL chunk matches `ON CONFLICT` (case-insensitive). Single-row INSERT + `$identitySelect` behavior is preserved — that path always passes a populated `$primaryKey`.

Does **not** touch `PostgreSQLModel.cfc` — that was PR #2204's territory (vanilla Postgres identity fix).

### Bug 2 — `lockingSpec` missing CockroachDB skip-shim (4 failures)

`CockroachDBModel.$acquireAdvisoryLock` correctly throws `Wheels.AdvisoryLockNotSupported` (parity with Oracle/H2). The spec was missing the `_isCockroachDB` guard that 8 sibling specs (e.g. `transactionsSpec`, `crudSpec`, `callbacksSpec`) already declare. Added the shim to `run()` and `if (_isCockroachDB) return;` to each `withAdvisoryLock` test. `forUpdate` describes are untouched — CockroachDB supports `SELECT … FOR UPDATE`.

### Docs correction (second commit)

CLAUDE.md's "CI soft-fail databases" paragraph claimed CockroachDB was soft-fail; in reality `SOFT_FAIL_DBS=""` at `.github/workflows/compat-matrix.yml:389,519`, so CockroachDB is hard-gated. Updated the doc to match.

## Test plan

- [x] Local SQLite run via `bash tools/test-local.sh` — 3250 passed, 0 fail, 0 error (no regression on the dominant dev-loop path).
- [ ] CI `compat-matrix.yml` run against the real CockroachDB matrix column — this is the check that actually validates Bug 1's fix end-to-end, since CockroachDB is not reachable from the LuCLI-only local setup.
- [ ] Cross-engine matrix (Lucee 6/7, Adobe 2023/2025, BoxLang) × (sqlite, mysql, postgres, h2, sqlserver, cockroachdb) — expected green after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)