### PR TITLE
fix(cli): bundle codegen templates into wheels-module tar (#1944)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,12 @@ jobs:
       - name: Build Wheels Module Tarball
         run: |
           mkdir -p artifacts/wheels/${{ env.WHEELS_VERSION }}
+          # Bundle codegen templates into the module so Templates.cfc::resolveTemplateDir()
+          # finds them at moduleRoot/templates/codegen/ in installed distributions.
+          # Without this, every template-driven generator (model, controller, view,
+          # scaffold, helper, api-resource) fails or emits empty output. See #1944.
+          mkdir -p cli/lucli/templates/codegen
+          cp -R cli/src/templates/. cli/lucli/templates/codegen/
           tar czf artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-${{ env.WHEELS_VERSION }}.tar.gz -C cli/lucli .
           cd cli/lucli && zip -r ../../artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-${{ env.WHEELS_VERSION }}.zip . && cd ../..
           cd artifacts/wheels/${{ env.WHEELS_VERSION }}


### PR DESCRIPTION
## Summary

- Copy `cli/src/templates/` into `cli/lucli/templates/codegen/` in the `Build Wheels Module Tarball` step of `release.yml`, so `Templates.cfc::resolveTemplateDir()` finds them at `moduleRoot/templates/codegen/` in installed distributions.
- Fixes [#1944](https://github.com/wheels-dev/wheels/issues/1944). The three stretch generators (`api-resource`, `helper`, `snippets`) were already wired in source; the reason they appeared broken in installed Wheels was this missing packaging step, which also silently stripped output from `model`, `controller`, `view`, and `scaffold`.

## Root cause (in short)

`resolveTemplateDir()` has four fallback paths; only the first (`moduleRoot/templates/codegen/`) matters for installed users. Paths #2-#4 resolve in the monorepo checkout, which is why CI + local development never surfaced the bug. The release workflow tar'd `-C cli/lucli .` with no copy step, shipping `admin/`, `app/`, `deploy/`, `migrations/`, `snippets/` under `templates/` but no `codegen/`.

## Verification

Locally copied `cli/src/templates/*` into `~/.wheels/modules/wheels/templates/codegen/` to simulate the post-fix install, then ran against a scratch project:

| Command | Before | After |
|---|---|---|
| `wheels generate snippets auth` | ✅ worked | ✅ worked |
| `wheels generate helper formatting truncateText formatCurrency` | ❌ *Template not found: HelperContent.txt* | ✅ FormattingHelper.cfc with both functions |
| `wheels generate controller Users index show` | stripped config/actions | full config + action stubs |
| `wheels generate api-resource Product name price:decimal sku:string` | model empty, controller missing | proper API controller + routes + tests |

Simulated the built tar (`tar czf ... -C cli/lucli .` after the new copy step) — resulting archive contains 60 files under `./templates/codegen/` including `HelperContent.txt`, `ModelContent.txt`, `ControllerContent.txt`, `ApiControllerContent.txt`, `ViewContent.txt`, `CRUDContent.txt`, and nested `admin/`, `crud/`, `dbmigrate/`, `tests/`, `bootstrap/`.

## Test plan

- [ ] Release workflow builds successfully with the new copy step
- [ ] `wheels-module-*.tar.gz` artifact contains `./templates/codegen/` with `HelperContent.txt` et al.
- [ ] In a fresh install of the new module, `wheels generate helper Foo bar` produces a non-empty `app/helpers/FooHelper.cfc`
- [ ] In a fresh install, `wheels generate api-resource Product name price:decimal` produces a non-empty `app/controllers/api/Products.cfc`

## Out of scope

- CI-level smoke test against the built tar — tracked separately as [#2208](https://github.com/wheels-dev/wheels/issues/2208). That is the long-term defense against this class of regression; this PR is the narrow fix.
- Pre-existing template bugs surfaced now that templates are reachable (e.g. `ApiControllerContent.txt` has unescaped `##varname##` placeholders that CFML tries to evaluate at runtime). Those are template-content bugs, orthogonal to packaging.

Closes #1944