### PR TITLE
ci(config): bump node-20 actions to node-24 majors in snapshot/release/web-deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Checkout Repository
         id: Checkout-Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -213,7 +213,7 @@ jobs:
           sha512sum wheels-module-${{ env.WHEELS_VERSION }}.zip > wheels-module-${{ env.WHEELS_VERSION }}.zip.sha512 || shasum -a 512 wheels-module-${{ env.WHEELS_VERSION }}.zip > wheels-module-${{ env.WHEELS_VERSION }}.zip.sha512
 
       - name: Upload Wheels Base Template Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts-base-template
           path: |
@@ -223,7 +223,7 @@ jobs:
             artifacts/wheels/wheels-base-template-be.zip
 
       - name: Upload Wheels Core Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts-core
           path: |
@@ -233,7 +233,7 @@ jobs:
             artifacts/wheels/wheels-core-be.zip
 
       - name: Upload Wheels CLI Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts-cli
           path: |
@@ -243,7 +243,7 @@ jobs:
             artifacts/wheels/wheels-cli-be.zip
       
       - name: Upload Wheels Starter App Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts-starter-app
           path: |
@@ -253,7 +253,7 @@ jobs:
             artifacts/wheels/wheels-starter-app-be.zip
 
       - name: Upload Wheels Module Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts-module
           path: |
@@ -263,7 +263,7 @@ jobs:
             artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.sha512
 
       - name: Upload All Wheels Artifacts (Combined)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts-all
           path: |
@@ -271,7 +271,7 @@ jobs:
 
       - name: Upload Workflow Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs-release
           path: |
@@ -294,7 +294,7 @@ jobs:
 
       - name: Create GitHub Release
         if: github.ref == 'refs/heads/main'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.WHEELS_VERSION }}
           name: Wheels ${{ env.WHEELS_VERSION }}
@@ -327,7 +327,7 @@ jobs:
 
       - name: Create Snapshot Pre-Release
         if: github.ref != 'refs/heads/main'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.WHEELS_VERSION }}
           name: Wheels ${{ env.WHEELS_VERSION }} (snapshot)

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -49,7 +49,7 @@ jobs:
 
       - name: Cache Playwright
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.wheels/browser/lib
@@ -231,7 +231,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download API docs snapshot artifact
         uses: actions/download-artifact@v6
@@ -240,12 +240,12 @@ jobs:
           path: docs/api/
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.23.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -30,15 +30,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.23.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -79,15 +79,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.23.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -98,7 +98,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload diffs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: visual-regression-diffs
           path: |


### PR DESCRIPTION
## Summary

Clears the \"Node.js 20 actions are deprecated\" warnings that GitHub emits on the **Wheels Snapshots** and **Deploy static sites** workflows. GitHub will force Node 24 starting June 2, 2026 and remove Node 20 on September 16, 2026 — getting ahead of it now.

## What the warnings said

From the latest snapshot + deploy runs:

- \`Wheels Snapshots\` → \`actions/checkout@v4\`, \`actions/upload-artifact@v4\`, \`softprops/action-gh-release@v1\`, \`actions/setup-node@v4\`, \`pnpm/action-setup@v4\`, \`actions/cache@v4\`, \`actions/setup-java@v4\`
- \`Deploy static sites\` → \`actions/checkout@v4\`, \`actions/setup-node@v4\`, \`pnpm/action-setup@v4\`, \`actions/cache@v4\` (Visual regression job also listed \`actions/cache@v4\`)

## Changes

| File | Action | Before | After |
|---|---|---|---|
| snapshot.yml | setup-java | v4 | **v5** |
| snapshot.yml | cache | v4 | **v5** |
| snapshot.yml | checkout | v4 | **v6** |
| snapshot.yml | setup-node | v4 | **v6** |
| snapshot.yml | pnpm/action-setup | v4 | **v5** |
| web-deploy.yml | checkout (×2) | v4 | **v6** |
| web-deploy.yml | pnpm/action-setup (×2) | v4 | **v5** |
| web-deploy.yml | setup-node (×2) | v4 | **v6** |
| web-deploy.yml | cache | v4 | **v5** |
| web-deploy.yml | upload-artifact | v4 | **v7** |
| release.yml | checkout | v4 | **v6** |
| release.yml | upload-artifact (×7) | v4 | **v7** |
| release.yml | softprops/action-gh-release (×2) | v1 | **v3** |

\`release.yml\` is bumped because it's called from \`snapshot.yml\` via \`uses: ./.github/workflows/release.yml\` and its annotations show up in snapshot runs.

## Notes

- Already-Node-24 actions (\`actions/checkout@v5\`, \`actions/upload-artifact@v6\`, \`actions/download-artifact@v6\`) left alone to minimise churn.
- All version bumps are internal-runtime / hardening updates — no schema or input changes that affect our usage (\`files:\`, \`tag_name:\`, \`body:\`, etc. for gh-release; pnpm install flow for pnpm/action-setup; same inputs for cache/checkout/setup-node).
- **Not in scope**: other workflows (\`pr.yml\`, \`docs-verify.yml\`, \`release-candidate.yml\`, \`deploy-ci.yml\`, \`generate-changelog.yml\`, \`version-bump.yml\`, \`publish-chocolatey.yml\`) carry the same class of warnings. Can be rolled up into a follow-up PR once this one lands and proves the bumps are harmless.

## Test plan

- [ ] \`Wheels Snapshots\` workflow runs green with no Node 20 deprecation annotations
- [ ] \`Deploy static sites\` runs green with no Node 20 annotations
- [ ] Released artifact names / paths unchanged (\`upload-artifact@v4→v7\` keeps artifact name conventions — but a release dry-run on the branch would confirm)