### PR TITLE
ci(config): bump node-20 actions to node-24 majors across remaining workflows

### DIFF
--- a/.github/workflows/deploy-ci.yml
+++ b/.github/workflows/deploy-ci.yml
@@ -11,7 +11,7 @@
 #
 # Prerequisites (already present in this repo's CI):
 #   - LuCLI install recipe mirrors .github/workflows/pr.yml (cybersonic/LuCLI release).
-#   - Java 21 via actions/setup-java@v4.
+#   - Java 21 via actions/setup-java@v5.
 #
 # Gating model:
 #   1. cli-tests              - runs `tools/test-cli-local.sh`, must be 365+/0/0.
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -23,15 +23,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.23.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -42,7 +42,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,6 @@ jobs:
     name: "Lucee 7 + SQLite (LuCLI)"
     runs-on: ubuntu-latest
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       LUCLI_VERSION: "0.3.3"
       WHEELS_CI: "true"
       WHEELS_BROWSER_TEST_BASE_URL: "http://localhost:60007"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,10 +17,10 @@ jobs:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
       - run: npm ci
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -59,7 +59,7 @@ jobs:
 
       - name: Cache Playwright
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.wheels/browser/lib

--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -26,7 +26,7 @@ jobs:
           }
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download LuCLI and compute checksum
         shell: pwsh
@@ -70,7 +70,7 @@ jobs:
           choco push $nupkg.FullName --source https://push.chocolatey.org/ --api-key $env:CHOCO_API_KEY
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chocolatey-package
           path: tools/installer/chocolatey/lucli.*.nupkg

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout Repository
         id: Checkout-Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -176,7 +176,7 @@ jobs:
           ./tools/build/scripts/build-starterApp.sh "${{ env.WHEELS_VERSION }}"
 
       - name: Upload Wheels Base Template Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rc-build-artifacts-base-template
           path: |
@@ -185,7 +185,7 @@ jobs:
             artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.sha512
 
       - name: Upload Wheels Core Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rc-build-artifacts-core
           path: |
@@ -194,7 +194,7 @@ jobs:
             artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.sha512
 
       - name: Upload Wheels CLI Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rc-build-artifacts-cli
           path: |
@@ -203,7 +203,7 @@ jobs:
             artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.sha512
 
       - name: Upload Wheels Starter App Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rc-build-artifacts-starter-app
           path: |
@@ -212,7 +212,7 @@ jobs:
             artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.sha512
 
       - name: Upload All Wheels Artifacts (Combined)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rc-build-artifacts-all
           path: |
@@ -220,7 +220,7 @@ jobs:
 
       - name: Upload Workflow Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs-release-candidate
           path: |
@@ -241,7 +241,7 @@ jobs:
           cat release-notes.md
 
       - name: Create GitHub Prerelease
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.WHEELS_VERSION }}
           name: Wheels ${{ env.WHEELS_VERSION }} (Release Candidate)

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to [#2212](https://github.com/wheels-dev/wheels/pull/2212). Applies the same Node-24 migration to the 7 workflows that still carried the \"Node.js 20 actions are deprecated\" warnings.

## Scope

Every remaining workflow with an \`@v4\` action on a Node-20 runtime (plus \`softprops/action-gh-release@v1\`). After this PR, no workflow in \`.github/workflows/\` references a Node-20 action.

| File | Action | Before | After |
|---|---|---|---|
| pr.yml | checkout, setup-node | v4 | **v6** |
| pr.yml | setup-java | v4 | **v5** |
| pr.yml | cache | v4 | **v5** |
| release-candidate.yml | checkout | v4 | **v6** |
| release-candidate.yml | upload-artifact (×6) | v4 | **v7** |
| release-candidate.yml | softprops/action-gh-release | v1 | **v3** |
| deploy-ci.yml | setup-java | v4 | **v5** |
| docs-verify.yml | checkout | v4 | **v6** |
| docs-verify.yml | pnpm/action-setup | v4 | **v5** |
| docs-verify.yml | setup-node | v4 | **v6** |
| generate-changelog.yml | checkout | v4 | **v6** |
| version-bump.yml | checkout | v4 | **v6** |
| publish-chocolatey.yml | checkout | v4 | **v6** |
| publish-chocolatey.yml | upload-artifact | v4 | **v7** |

## Notes

- \`pr.yml\` already had \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true\` as an env-level escape hatch — bumping the action versions makes that opt-in flag redundant for these steps. Left the env var in place since it doesn't hurt and other steps in the job might still benefit (though in practice every action in the job is now on Node 24; happy to strip it in a separate cleanup).
- \`compat-matrix.yml\` and \`label.yml\` already run Node-24 actions; no changes needed there.
- Same version choices as #2212: latest major for each action as of today — checkout v6, setup-node v6, setup-java v5, cache v5, upload-artifact v7, pnpm/action-setup v5, softprops/action-gh-release v3.

## Test plan

- [ ] \`pr.yml\` runs green on this PR itself (the \"Wheels Pull Requests\" workflow triggers on this PR's events)
- [ ] No \"Node.js 20 actions are deprecated\" annotations on any workflow run
- [ ] \`docs-verify.yml\` harness step still passes (verify-docs harness fix from #2210 not affected by the version bumps)

Related: #2212.