### PR TITLE
fix(cli): wheels new exits non-zero on framework-not-found (#2211)

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -3229,6 +3229,13 @@ component extends="modules.BaseModule" {
 			openBrowser: structKeyExists(options, "openBrowser") ? options.openBrowser : true
 		};
 
+		// Resolve the Wheels framework source BEFORE creating any files. A
+		// scaffolded app requires vendor/wheels/ to boot, and failing after
+		// emitting "create" lines left automation confused (GH #2211). On
+		// failure this prints a diagnostic and throws, so the caller sees a
+		// non-zero exit code instead of a silent success.
+		var wheelsSource = resolveFrameworkSourceOrFail(appName);
+
 		out("Creating new Wheels application: #appName#...", "cyan");
 		out("");
 
@@ -3252,21 +3259,8 @@ component extends="modules.BaseModule" {
 		// Copy template directory tree to target, processing placeholders
 		copyTemplateDir(templateDir, targetDir, appName, context);
 
-		// Install Wheels framework into vendor/wheels/ — abort (and clean up)
-		// if the framework source cannot be located. Without vendor/wheels/
-		// the scaffolded app cannot boot (onApplicationStart would fail on the
-		// missing `/wheels/Injector.cfc` mapping, producing a misleading
-		// "key [WO] doesn't exist" error downstream).
-		if (!installWheelsFramework(targetDir, appName)) {
-			// Remove the partially-created app directory so the user can retry
-			// cleanly after providing a framework source.
-			try {
-				directoryDelete(targetDir, true);
-			} catch (any e) {
-				// Best-effort cleanup — if this fails the user can remove it manually.
-			}
-			return "";
-		}
+		// Copy the framework into vendor/wheels/ (source was resolved above).
+		copyFrameworkToVendor(wheelsSource, targetDir, appName);
 
 		// Set up embedded database: H2 if explicitly requested, SQLite by default
 		if (opts.setupH2) {
@@ -3409,38 +3403,56 @@ component extends="modules.BaseModule" {
 	}
 
 	/**
-	 * Copy the Wheels framework into the new application's vendor/wheels/ directory.
-	 * Resolves the framework source from the current project installation.
+	 * Resolve the Wheels framework source or fail fast. Prints a diagnostic
+	 * listing every path tried plus a WHEELS_FRAMEWORK_PATH hint, then throws
+	 * so LuCLI surfaces a non-zero exit code. Returns the resolved path on
+	 * success. Called before any files are created so the caller sees a clean
+	 * failure rather than a partial scaffold followed by cleanup (GH #2211).
 	 */
-	private boolean function installWheelsFramework(required string targetDir, required string appName) {
+	private string function resolveFrameworkSourceOrFail(required string appName) {
 		var wheelsSource = resolveFrameworkSource();
-
-		if (!len(wheelsSource)) {
-			out("", "red");
-			out("Error: Could not locate the Wheels framework source.", "red");
-			out("");
-			out("A scaffolded app requires vendor/wheels/ to boot. Tried:", "yellow");
-			for (var candidate in variables.frameworkSearchPaths ?: []) {
-				out("  - #candidate#");
-			}
-			out("");
-			out("To fix, either:", "bold");
-			out("  1. Run `wheels new` from inside a directory that contains");
-			out("     vendor/wheels/ (e.g. an existing Wheels project, or a");
-			out("     checkout of the wheels repository).");
-			out("  2. Set WHEELS_FRAMEWORK_PATH to point at a vendor/wheels/ directory:");
-			out("       WHEELS_FRAMEWORK_PATH=/path/to/vendor/wheels wheels new #appName#");
-			out("");
-			out("See: https://guides.wheels.dev/docs/getting-started");
-			return false;
+		if (len(wheelsSource)) {
+			return wheelsSource;
 		}
 
+		out("", "red");
+		out("Error: Could not locate the Wheels framework source.", "red");
+		out("");
+		out("A scaffolded app requires vendor/wheels/ to boot. Tried:", "yellow");
+		for (var candidate in variables.frameworkSearchPaths ?: []) {
+			out("  - #candidate#");
+		}
+		out("");
+		out("To fix, either:", "bold");
+		out("  1. Run `wheels new` from inside a directory that contains");
+		out("     vendor/wheels/ (e.g. an existing Wheels project, or a");
+		out("     checkout of the wheels repository).");
+		out("  2. Set WHEELS_FRAMEWORK_PATH to point at a vendor/wheels/ directory:");
+		out("       WHEELS_FRAMEWORK_PATH=/path/to/vendor/wheels wheels new #appName#");
+		out("");
+		out("See: https://guides.wheels.dev/docs/getting-started");
+
+		throw(
+			type="Wheels.FrameworkNotFound",
+			message="wheels new #appName#: Wheels framework source not found (see output above for search paths and WHEELS_FRAMEWORK_PATH hint)"
+		);
+	}
+
+	/**
+	 * Copy a resolved Wheels framework source into the new application's
+	 * vendor/wheels/ directory. The source must already exist — callers should
+	 * obtain it via resolveFrameworkSourceOrFail() before any file creation.
+	 */
+	private void function copyFrameworkToVendor(
+		required string wheelsSource,
+		required string targetDir,
+		required string appName
+	) {
 		out("Installing Wheels framework from #wheelsSource#...");
 		var vendorDir = targetDir & "/vendor/wheels";
 		ensureDirectory(vendorDir);
 		directoryCopy(wheelsSource, vendorDir, true);
 		printCreated(appName & "/vendor/wheels/");
-		return true;
 	}
 
 	/**

--- a/cli/lucli/tests/test-module-install.sh
+++ b/cli/lucli/tests/test-module-install.sh
@@ -90,6 +90,17 @@ fi
 echo ""
 echo "--- Phase 3: Scaffold a test project ---"
 cd "$TMPDIR"
+# `wheels new` requires a discoverable vendor/wheels/ framework source and
+# now exits non-zero if one isn't found (GH #2211). The distribution module
+# itself does not ship the framework, so the caller must point at a checkout
+# via WHEELS_FRAMEWORK_PATH. Skip the scaffold phase gracefully if it isn't set.
+if [ -z "${WHEELS_FRAMEWORK_PATH:-}" ]; then
+    echo "  SKIP: WHEELS_FRAMEWORK_PATH not set — skipping scaffold phases"
+    echo "  Set WHEELS_FRAMEWORK_PATH=/path/to/wheels/vendor/wheels to run full test"
+    echo ""
+    echo "=== Summary: $PASS pass, $FAIL fail (scaffold phases skipped) ==="
+    [ "$FAIL" -eq 0 ] && exit 0 || exit 1
+fi
 if lucli wheels new testapp 2>&1; then
     pass "wheels new testapp succeeded"
 else

--- a/cli/lucli/tests/test-new-exit-codes.sh
+++ b/cli/lucli/tests/test-new-exit-codes.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Regression test for GH #2211: wheels new must exit non-zero when the
+# Wheels framework source cannot be located.
+#
+# Prerequisites:
+#   - wheels binary on PATH
+#
+# Usage:
+#   bash cli/lucli/tests/test-new-exit-codes.sh
+
+# NOTE: no `set -e` — we want to observe non-zero exits from `wheels new`
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+if ! command -v wheels &>/dev/null; then
+    echo "ERROR: wheels not found on PATH"
+    exit 1
+fi
+
+# Isolate from any vendor/wheels/ discoverable via cwd or the binary's module dir.
+TMPDIR=$(mktemp -d)
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+echo "=== GH #2211: wheels new framework-not-found regression ==="
+echo "Working dir: $TMPDIR"
+echo ""
+
+cd "$TMPDIR"
+
+# Unset WHEELS_FRAMEWORK_PATH so discovery relies solely on cwd/module root
+# (both of which should miss in this temp dir).
+unset WHEELS_FRAMEWORK_PATH
+
+OUT=$(wheels new fixture --no-open-browser 2>&1)
+CODE=$?
+
+echo "--- output (last 8 lines) ---"
+echo "$OUT" | tail -8
+echo "--- exit code: $CODE ---"
+echo ""
+
+if [ "$CODE" -ne 0 ]; then
+    pass "wheels new exits non-zero when framework source is not found"
+else
+    fail "wheels new exited 0 despite framework-not-found error (GH #2211)"
+fi
+
+if echo "$OUT" | grep -qi "WHEELS_FRAMEWORK_PATH"; then
+    pass "error message mentions WHEELS_FRAMEWORK_PATH hint"
+else
+    fail "error message missing WHEELS_FRAMEWORK_PATH hint"
+fi
+
+if [ ! -d "$TMPDIR/fixture" ]; then
+    pass "no partial fixture/ directory left behind"
+else
+    fail "partial fixture/ directory left behind"
+fi
+
+echo ""
+echo "=== Summary: $PASS pass, $FAIL fail ==="
+[ "$FAIL" -eq 0 ]

--- a/tools/test-cli-e2e.sh
+++ b/tools/test-cli-e2e.sh
@@ -127,6 +127,10 @@ fi
 section "Phase 1: wheels new $APP_NAME"
 
 cd "$TMPDIR"
+# Point `wheels new` at this checkout's framework source. Without this, running
+# in a temp dir with no ancestor vendor/wheels/ now fails hard (GH #2211) —
+# which is the correct behavior for real users but breaks this in-monorepo test.
+export WHEELS_FRAMEWORK_PATH="$PROJECT_ROOT/vendor/wheels"
 if lucli wheels new "$APP_NAME" --port="$PORT" --no-open-browser > "$TMPDIR/new.log" 2>&1; then
     pass "wheels new $APP_NAME succeeded"
 else


### PR DESCRIPTION
Fixes #2211.

## Summary
- `scaffoldNewApp` used to `return ""` when the framework source couldn't be located — LuCLI prints that as empty and Picocli exits 0, silently fooling automation (surfaced by the verify-docs harness in #2178).
- Split `installWheelsFramework` into `resolveFrameworkSourceOrFail` (throws `Wheels.FrameworkNotFound` so Picocli produces exit 1) and `copyFrameworkToVendor` (pure copy).
- Resolve framework source **before** any file creation — eliminates the confusing "create X, create Y, …, Error" sequence mentioned in the issue's optional expectation.
- Diagnostic output and `WHEELS_FRAMEWORK_PATH` hint preserved verbatim.

## Acceptance criteria (from #2211)
- [x] `cd /tmp/empty && wheels new fixture` exits non-zero when `vendor/wheels/` cannot be located
- [x] `WHEELS_FRAMEWORK_PATH` hint remains in the error message
- [x] The verify-docs harness's `createFixture` fallback guard can eventually be simplified to just trust `result.code`

## Collateral
Two local (non-CI) harnesses relied on the buggy exit-0 behavior — updated so they keep passing:
- `tools/test-cli-e2e.sh` — exports `WHEELS_FRAMEWORK_PATH=$PROJECT_ROOT/vendor/wheels`
- `cli/lucli/tests/test-module-install.sh` — skips the scaffold phase gracefully if the env var isn't set

## Follow-ups (out of scope, filed separately)
- #2214 — remaining silent-exit-0 paths in `scaffoldNewApp` (directory exists, app name required, template not found)
- #2215 — explicit `WHEELS_FRAMEWORK_PATH` should hard-fail when the path doesn't exist, not silently fall through

## Test plan
- [x] Added `cli/lucli/tests/test-new-exit-codes.sh` — reproduces the exact scenario from #2211, asserts non-zero exit + hint preserved + no partial scaffold. Verified RED against pre-fix code, GREEN against the fix.
- [x] Happy path spot-checked: `WHEELS_FRAMEWORK_PATH=…/vendor/wheels wheels new happyapp` exits 0, scaffolds `vendor/wheels/` as expected.
- [ ] Reviewer: run `bash cli/lucli/tests/test-new-exit-codes.sh` after local install to confirm