### PR TITLE
ci(config): smoke test installed wheels-module against clean filesystem (#2208)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ on:
 
 env:
   WHEELS_PRERELEASE: false
+  LUCLI_VERSION: "0.3.3"
 
 jobs:
   #############################################
@@ -341,3 +342,77 @@ jobs:
             artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip
             artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.md5
             artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.sha512
+
+  #############################################
+  # Smoke-test the built module against a clean install.
+  #
+  # Installs the just-built wheels-module-*.tar.gz into an isolated LUCLI_HOME,
+  # extracts wheels-core-*.zip for WHEELS_FRAMEWORK_PATH, then runs every
+  # template-driven generator against a scratch project. Catches packaging
+  # regressions like #1944 (codegen templates unbundled) that the monorepo
+  # test suite can't surface because it exercises source paths, not the
+  # built distribution. See #2208.
+  #############################################
+  smoke-test-distribution:
+    name: Smoke Test Installed Distribution
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Install LuCLI
+        run: |
+          curl -sL "https://github.com/cybersonic/LuCLI/releases/download/v${LUCLI_VERSION}/lucli-${LUCLI_VERSION}-linux" \
+            -o /usr/local/bin/lucli
+          chmod +x /usr/local/bin/lucli
+          lucli --version
+
+      - name: Download built module artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-module
+          path: smoke-artifacts/module/
+
+      - name: Download built core artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-core
+          path: smoke-artifacts/core/
+
+      - name: Locate artifacts
+        id: artifacts
+        run: |
+          MODULE_TAR=$(find smoke-artifacts/module -name 'wheels-module-*.tar.gz' | head -1)
+          CORE_ZIP=$(find smoke-artifacts/core -name 'wheels-core-*.zip' ! -name '*-be.zip' | head -1)
+          if [[ -z "$MODULE_TAR" || -z "$CORE_ZIP" ]]; then
+            echo "::error::Artifacts not found. module=$MODULE_TAR core=$CORE_ZIP"
+            find smoke-artifacts -type f
+            exit 1
+          fi
+          echo "module_tar=$MODULE_TAR" >> "$GITHUB_OUTPUT"
+          echo "core_zip=$CORE_ZIP"     >> "$GITHUB_OUTPUT"
+
+      - name: Run smoke test
+        env:
+          MODULE_TAR: ${{ steps.artifacts.outputs.module_tar }}
+          CORE_ZIP: ${{ steps.artifacts.outputs.core_zip }}
+        run: |
+          bash tools/ci/smoke-test-module.sh "$MODULE_TAR" "$CORE_ZIP"
+
+      - name: Upload smoke-test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-logs
+          path: |
+            smoke-artifacts/
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Prefer MCP tools when the Wheels MCP server is available (`mcp__wheels__*`). Fal
 | Task | MCP | CLI |
 |------|-----|-----|
 | Generate | `wheels_generate(type, name, attributes)` | `wheels g model/controller/scaffold Name attrs` |
-| Migrate | `wheels_migrate(action="latest\|up\|down\|info")` | `wheels dbmigrate latest\|up\|down\|info` |
+| Migrate | `wheels_migrate(action="latest\|up\|down\|info")` | `wheels migrate latest\|up\|down\|info` |
 | Test | `wheels_test()` | `wheels test run` |
 | Reload | `wheels_reload()` | `?reload=true&password=...` |
 | Server | `wheels_server(action="status")` | `wheels start\|stop\|status` |

--- a/tools/ci/smoke-test-module.sh
+++ b/tools/ci/smoke-test-module.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Smoke test for the built wheels-module-*.tar.gz.
+#
+# Installs the just-built Wheels LuCLI module into an isolated LUCLI_HOME, then
+# exercises every template-driven generator against a scratch project. Catches
+# packaging regressions (like #1944) where a generator silently produces empty
+# output or fails because its templates weren't copied into the module tar.
+#
+# Usage:
+#   tools/ci/smoke-test-module.sh <module-tar> <core-zip>
+#
+# Arguments:
+#   <module-tar>   Path to wheels-module-*.tar.gz (built by release.yml)
+#   <core-zip>     Path to wheels-core-*.zip     (built by release.yml)
+#
+# Requirements: lucli on PATH, java, unzip, tar. SQLite JDBC is not required
+# because we assert on generator output, not migration execution.
+#
+# See issue #2208.
+
+MODULE_TAR="${1:-}"
+CORE_ZIP="${2:-}"
+
+if [[ -z "$MODULE_TAR" || -z "$CORE_ZIP" ]]; then
+    echo "Usage: $0 <module-tar> <core-zip>" >&2
+    exit 2
+fi
+if [[ ! -f "$MODULE_TAR" ]]; then
+    echo "Module tar not found: $MODULE_TAR" >&2
+    exit 2
+fi
+if [[ ! -f "$CORE_ZIP" ]]; then
+    echo "Core zip not found: $CORE_ZIP" >&2
+    exit 2
+fi
+
+if ! command -v lucli >/dev/null 2>&1; then
+    echo "lucli not on PATH" >&2
+    exit 2
+fi
+
+SMOKE_ROOT="$(mktemp -d -t wheels-smoke.XXXXXX)"
+export LUCLI_HOME="$SMOKE_ROOT/lucli-home"
+FRAMEWORK_ROOT="$SMOKE_ROOT/framework"
+WORKDIR="$SMOKE_ROOT/work"
+
+cleanup() {
+    rm -rf "$SMOKE_ROOT"
+}
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_file_nonempty() {
+    local path="$1" label="$2"
+    if [[ -s "$path" ]]; then
+        pass "$label ($(wc -c < "$path" | tr -d ' ') bytes)"
+    else
+        fail "$label — file missing or empty: $path"
+    fi
+}
+
+assert_grep() {
+    local pattern="$1" path="$2" label="$3"
+    if [[ -f "$path" ]] && grep -qE "$pattern" "$path"; then
+        pass "$label"
+    else
+        fail "$label — pattern '$pattern' not found in $path"
+        if [[ -f "$path" ]]; then
+            echo "    --- first 20 lines of $path ---"
+            sed -n '1,20p' "$path" | sed 's/^/    /'
+        fi
+    fi
+}
+
+echo "=== Phase 1: Install module from built tar ==="
+mkdir -p "$LUCLI_HOME/modules/wheels"
+tar xzf "$MODULE_TAR" -C "$LUCLI_HOME/modules/wheels"
+
+for f in module.json Module.cfc; do
+    assert_file_nonempty "$LUCLI_HOME/modules/wheels/$f" "module root has $f"
+done
+
+for d in services templates templates/codegen; do
+    if [[ -d "$LUCLI_HOME/modules/wheels/$d" ]]; then
+        pass "module has $d/"
+    else
+        fail "module missing $d/ — codegen templates unbundled (see #1944)"
+    fi
+done
+
+# Spot-check a few codegen templates that are known to have gone missing.
+for t in HelperContent.txt ModelContent.txt ControllerContent.txt ApiControllerContent.txt; do
+    assert_file_nonempty "$LUCLI_HOME/modules/wheels/templates/codegen/$t" "codegen template $t bundled"
+done
+
+if lucli modules list 2>&1 | grep -q "wheels"; then
+    pass "lucli modules list shows 'wheels'"
+else
+    fail "lucli modules list does not show 'wheels'"
+fi
+
+echo ""
+echo "=== Phase 2: Extract framework core for WHEELS_FRAMEWORK_PATH ==="
+mkdir -p "$FRAMEWORK_ROOT"
+unzip -q "$CORE_ZIP" -d "$FRAMEWORK_ROOT"
+if [[ -d "$FRAMEWORK_ROOT/wheels" ]]; then
+    pass "wheels-core extracted to $FRAMEWORK_ROOT/wheels"
+    export WHEELS_FRAMEWORK_PATH="$FRAMEWORK_ROOT/wheels"
+else
+    fail "wheels-core zip layout unexpected (no wheels/ at root)"
+    ls "$FRAMEWORK_ROOT" || true
+    echo "Cannot continue without framework source."
+    exit 1
+fi
+
+echo ""
+echo "=== Phase 3: Scaffold a scratch app ==="
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+if lucli wheels new smoke --no-open-browser 2>&1 | sed 's/^/    /'; then
+    pass "wheels new smoke succeeded"
+else
+    fail "wheels new smoke failed"
+    exit 1
+fi
+
+if [[ -d "smoke" ]]; then
+    cd smoke
+    pass "smoke/ directory created"
+else
+    fail "smoke/ directory not created"
+    exit 1
+fi
+
+assert_file_nonempty "config/settings.cfm" "config/settings.cfm"
+assert_file_nonempty "config/routes.cfm" "config/routes.cfm"
+
+echo ""
+echo "=== Phase 4: Exercise every template-driven generator ==="
+
+echo ""
+echo "--- generate model User name:string email:string ---"
+lucli wheels generate model User name:string email:string 2>&1 | sed 's/^/    /' || true
+assert_file_nonempty "app/models/User.cfc" "model User.cfc generated"
+# Current ModelContent template renders component shell + config() scaffold but
+# does not emit validations from attrs. Assert structure, not content we don't emit.
+assert_grep 'extends="Model"' "app/models/User.cfc" "model extends Model"
+assert_grep "function config" "app/models/User.cfc" "model has config()"
+
+echo ""
+echo "--- generate controller Users index show ---"
+lucli wheels generate controller Users index show 2>&1 | sed 's/^/    /' || true
+assert_file_nonempty "app/controllers/Users.cfc" "controller Users.cfc generated"
+assert_grep "function index" "app/controllers/Users.cfc" "controller has function index"
+
+echo ""
+echo "--- generate api-resource Product name price:decimal ---"
+lucli wheels generate api-resource Product name price:decimal 2>&1 | sed 's/^/    /' || true
+# api-resource generator namespaces the controller under api/ to keep API and
+# web controllers separate.
+assert_file_nonempty "app/controllers/api/Products.cfc" "api-resource Products.cfc generated"
+assert_grep "renderWith" "app/controllers/api/Products.cfc" "api-resource has renderWith"
+assert_file_nonempty "app/models/Product.cfc" "api-resource Product.cfc model generated"
+
+echo ""
+echo "--- generate helper formatting truncateText ---"
+lucli wheels generate helper formatting truncateText 2>&1 | sed 's/^/    /' || true
+# Helper file path convention: app/helpers/<Name>Helper.cfc
+if [[ -s "app/helpers/FormattingHelper.cfc" ]]; then
+    assert_file_nonempty "app/helpers/FormattingHelper.cfc" "helper FormattingHelper.cfc generated"
+elif [[ -s "app/helpers/Formatting.cfc" ]]; then
+    assert_file_nonempty "app/helpers/Formatting.cfc" "helper Formatting.cfc generated"
+else
+    fail "no FormattingHelper.cfc or Formatting.cfc under app/helpers/"
+    ls -la app/helpers 2>/dev/null || echo "    app/helpers missing"
+fi
+
+echo ""
+echo "--- generate scaffold Post title:string body:text ---"
+lucli wheels generate scaffold Post title:string body:text 2>&1 | sed 's/^/    /' || true
+assert_file_nonempty "app/views/posts/index.cfm" "scaffold view posts/index.cfm generated"
+assert_file_nonempty "app/controllers/Posts.cfc" "scaffold controller Posts.cfc generated"
+assert_file_nonempty "app/models/Post.cfc" "scaffold model Post.cfc generated"
+# Scaffold must also drop a migration — template path that gets missed otherwise.
+migration_count=$(find app/migrator/migrations -maxdepth 1 -name '*.cfc' 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$migration_count" -gt 0 ]]; then
+    pass "scaffold created $migration_count migration(s)"
+else
+    fail "scaffold did not create any migration under app/migrator/migrations"
+fi
+
+echo ""
+echo "--- generate snippets auth ---"
+lucli wheels generate snippets auth 2>&1 | sed 's/^/    /' || true
+assert_file_nonempty "app/controllers/Sessions.cfc" "snippets auth created Sessions.cfc"
+
+echo ""
+echo "=== Results ==="
+TOTAL=$((PASS + FAIL))
+echo "$PASS/$TOTAL passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+    echo "SMOKE TEST FAILED — installed distribution regressions present" >&2
+    exit 1
+fi
+echo "ALL SMOKE TESTS PASSED"


### PR DESCRIPTION
## Summary

Adds a CI smoke test that installs the just-built `wheels-module-*.tar.gz` into a clean filesystem location and exercises every template-driven generator against a scratch project. Closes [#2208](https://github.com/wheels-dev/wheels/issues/2208).

Would have caught [#1944](https://github.com/wheels-dev/wheels/issues/1944) same-day instead of weeks later. The existing test suite runs in monorepo mode where `Templates.cfc::resolveTemplateDir()` falls back to source paths that don't exist in installed distributions, masking packaging regressions.

## What changed

- **`tools/ci/smoke-test-module.sh`** — new bash smoke test, runnable locally:
  ```
  bash tools/ci/smoke-test-module.sh <module-tar> <core-zip>
  ```
- **`.github/workflows/release.yml`** — new `smoke-test-distribution` job, `needs: build`. Runs on every develop push (via `snapshot.yml` → `release.yml` workflow_call) and every main push. Uses isolated `LUCLI_HOME` so nothing pollutes the runner's home dir.

## What the smoke test checks

1. `templates/codegen/` + 4 key codegen templates (`HelperContent.txt`, `ModelContent.txt`, `ControllerContent.txt`, `ApiControllerContent.txt`) are bundled — direct #1944 assertion
2. `lucli modules list` sees the installed module
3. `wheels new smoke` scaffolds a working project (with `wheels-core` as `WHEELS_FRAMEWORK_PATH`)
4. Each generator produces non-empty, grep-verifiable output:
   - `model User name:string email:string` — extends Model, has `config()`
   - `controller Users index show` — has `function index`
   - `api-resource Product name price:decimal` — controller at `app/controllers/api/Products.cfc` with `renderWith`, model at `app/models/Product.cfc`
   - `helper formatting truncateText` — creates `app/helpers/FormattingHelper.cfc`
   - `scaffold Post title:string body:text` — creates model + controller + views + migration
   - `snippets auth` — creates `app/controllers/Sessions.cfc`

## Deviations from the issue text

- Asserted `extends=\"Model\"` + `function config` on generated model instead of `validatesPresenceOf`. The current `ModelContent.txt` template doesn't emit validations from typed attrs. Worth a separate issue — the generator behavior is a gap, not a packaging bug.
- `api-resource` namespaces its controller under `app/controllers/api/` (not `app/controllers/`).
- Skipped `wheels dbmigrate latest` — LuCLI only registers `wheels migrate`, and running migrations requires SQLite JDBC + Lucee server setup duplicating `snapshot.yml`'s fast-test. Migration *template* path is covered because scaffold and api-resource create migrations and we assert their presence.

## Verification (local)

Used a recent snapshot (`wheels-module-4.0.0-SNAPSHOT+1550.tar.gz`) + a fake core zip built from `vendor/wheels/`:

| Scenario | Result |
|---|---|
| Current snapshot tar | **29/29 pass**, exit 0 |
| Simulated #1944 regression (codegen/ stripped) | **22/29, 7 fail, exit 1** — pinpoints missing templates and downstream empty generator output |

## Placement rationale

Placed in `release.yml` (not `snapshot.yml` as the issue suggested) because `release.yml` is called by `snapshot.yml` *and* triggered directly on main push — one job, both paths. Runs post-hoc to the existing publish step: if a regression ships to snapshot-artifacts, the next develop push's required check fails. A true gate (splitting `build` into `build → smoke → publish`) is a bigger refactor worth doing separately.

## Test plan

- [ ] PR CI runs the smoke-test-distribution job green against this branch's own build
- [ ] Spot-check the uploaded `smoke-test-logs` artifact on a failing scenario (would need a follow-up regression test to validate)
- [ ] Merge → watch first real develop push exercise it