### PR TITLE
fix(migration): implement sqlite changecolumn via recreate-table pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ### Fixed
 
+- `changeColumn` on SQLite now works by implementing the SQLite-standard recreate-table pattern in `SQLiteMigrator`. Previously, SQLite migrations inherited MySQL's `ALTER TABLE ... CHANGE` syntax from `Abstract.cfc` and failed with `near "CHANGE": syntax error`. The migrator's `$execute` now accepts an array of statements so adapters can return multi-step DDL. v1 limitations: foreign-key constraints declared inline on `CREATE TABLE` and triggers are not preserved across the recreate. (#2207)
 - Framework-internal browser-test fixture controllers, views, and the `/_browser/*` routes no longer leak into application-level files. Moved from `app/controllers/BrowserTest*.cfc`, `app/views/browsertest*/`, and `config/routes.cfm` into `vendor/wheels/public/browser-fixtures/`, auto-mounted by `$lockedLoadRoutes` when environment is `testing` or `development` and the new opt-in setting `loadBrowserTestFixtures=true` is set. Apps upgrading from a 4.0 snapshot that had custom `/_browser/*` routes must opt in explicitly or re-declare them in `config/routes.cfm`. (#2135, #2138)
 - Stray `app/mailers/UserNotificationsMailer.cfc` demo removed from the framework repo root (byte-identical copies remain in the example apps under `examples/tweet/` and `examples/starter-app/`). (#2138)
 - View lookup after `renderText()` / `renderWith()` no longer breaks subsequent partial rendering (#1991)

--- a/vendor/wheels/databaseAdapters/SQLite/SQLiteMigrator.cfc
+++ b/vendor/wheels/databaseAdapters/SQLite/SQLiteMigrator.cfc
@@ -108,4 +108,164 @@ component extends="wheels.databaseAdapters.Abstract" {
 		return "DROP INDEX IF EXISTS #quoteTableName(arguments.indexName)#";
 	}
 
+	/**
+	 * SQLite does not support ALTER TABLE ... CHANGE / ALTER COLUMN. The
+	 * documented workaround is the "recreate table" pattern: build a new table
+	 * with the desired schema, copy data, drop the original, rename the new
+	 * table, and recreate indexes. Returns an array of statements — the
+	 * migrator's `$execute` accepts arrays.
+	 *
+	 * Limitations (v1): triggers and foreign-key constraints defined on the
+	 * original CREATE TABLE are not preserved. Indexes declared outside the
+	 * CREATE TABLE (CREATE INDEX) are preserved.
+	 */
+	public any function changeColumnInTable(required string name, required any column) {
+		local.tableName = arguments.name;
+		local.changedColumnName = arguments.column.name;
+		local.quotedTable = quoteTableName(local.tableName);
+		local.tempTableName = "_wheels_new_" & local.tableName;
+		local.quotedTempTable = quoteTableName(local.tempTableName);
+		local.appKey = $appKey();
+		local.dsName = application[local.appKey].dataSourceName;
+
+		// Read columns via PRAGMA — authoritative SQLite metadata.
+		local.cols = $query(
+			datasource = local.dsName,
+			sql = "PRAGMA table_info(#local.quotedTable#)"
+		);
+		if (!IsQuery(local.cols) || local.cols.recordCount == 0) {
+			throw(
+				type = "Wheels.MigratorError",
+				message = "Table '#local.tableName#' not found or has no columns."
+			);
+		}
+
+		// Detect AUTOINCREMENT on INTEGER PK by inspecting the original CREATE TABLE.
+		local.master = $query(
+			datasource = local.dsName,
+			sql = "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = '#local.tableName#'"
+		);
+		local.hasAutoIncrement = false;
+		if (IsQuery(local.master) && local.master.recordCount > 0 && Len(local.master.sql[1])) {
+			local.hasAutoIncrement = FindNoCase("AUTOINCREMENT", local.master.sql[1]) > 0;
+		}
+
+		// Count primary-key columns to choose inline vs table-level PK constraint.
+		local.pkCount = 0;
+		for (local.i = 1; local.i <= local.cols.recordCount; local.i++) {
+			if (local.cols.pk[local.i] > 0) {
+				local.pkCount++;
+			}
+		}
+
+		// Build new column definitions, preserving unchanged columns.
+		local.columnDefs = [];
+		local.allColumnNames = [];
+		local.changedColumnFound = false;
+		for (local.i = 1; local.i <= local.cols.recordCount; local.i++) {
+			local.colName = local.cols.name[local.i];
+			ArrayAppend(local.allColumnNames, local.colName);
+			if (local.colName == local.changedColumnName) {
+				ArrayAppend(local.columnDefs, arguments.column.toSQL());
+				local.changedColumnFound = true;
+			} else {
+				ArrayAppend(
+					local.columnDefs,
+					$sqliteBuildColumnDef(
+						cols = local.cols,
+						i = local.i,
+						hasAutoIncrement = local.hasAutoIncrement,
+						inlinePK = local.pkCount == 1
+					)
+				);
+			}
+		}
+		if (!local.changedColumnFound) {
+			throw(
+				type = "Wheels.MigratorError",
+				message = "Column '#local.changedColumnName#' not found in table '#local.tableName#'."
+			);
+		}
+
+		// Composite PK becomes a table-level constraint.
+		if (local.pkCount > 1) {
+			local.pkCols = [];
+			for (local.i = 1; local.i <= local.cols.recordCount; local.i++) {
+				if (local.cols.pk[local.i] > 0) {
+					local.pkCols[local.cols.pk[local.i]] = quoteColumnName(local.cols.name[local.i]);
+				}
+			}
+			ArrayAppend(local.columnDefs, "PRIMARY KEY (" & ArrayToList(local.pkCols, ", ") & ")");
+		}
+
+		local.createSQL = "CREATE TABLE #local.quotedTempTable# (" & ArrayToList(local.columnDefs, ", ") & ")";
+
+		// Build the column list for INSERT ... SELECT data copy.
+		local.quotedColList = [];
+		for (local.colName in local.allColumnNames) {
+			ArrayAppend(local.quotedColList, quoteColumnName(local.colName));
+		}
+		local.columnList = ArrayToList(local.quotedColList, ", ");
+
+		// Capture non-auto indexes to recreate after rename.
+		local.indexes = $query(
+			datasource = local.dsName,
+			sql = "SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = '#local.tableName#' AND sql IS NOT NULL"
+		);
+
+		// PRAGMA foreign_keys must toggle outside any active transaction.
+		local.statements = [
+			"PRAGMA foreign_keys = OFF",
+			"BEGIN TRANSACTION",
+			local.createSQL,
+			"INSERT INTO #local.quotedTempTable# (#local.columnList#) SELECT #local.columnList# FROM #local.quotedTable#",
+			"DROP TABLE #local.quotedTable#",
+			"ALTER TABLE #local.quotedTempTable# RENAME TO #quoteTableName(local.tableName)#",
+			"COMMIT"
+		];
+		if (IsQuery(local.indexes)) {
+			for (local.j = 1; local.j <= local.indexes.recordCount; local.j++) {
+				ArrayAppend(local.statements, local.indexes.sql[local.j]);
+			}
+		}
+		ArrayAppend(local.statements, "PRAGMA foreign_keys = ON");
+		return local.statements;
+	}
+
+	/**
+	 * Build a column-definition SQL fragment from PRAGMA table_info output for a
+	 * single column. Preserves type, PRIMARY KEY (with AUTOINCREMENT for INTEGER
+	 * PKs when the original table had it), NOT NULL, and DEFAULT.
+	 */
+	public string function $sqliteBuildColumnDef(
+		required query cols,
+		required numeric i,
+		required boolean hasAutoIncrement,
+		required boolean inlinePK
+	) {
+		local.name = arguments.cols.name[arguments.i];
+		local.type = arguments.cols.type[arguments.i];
+		local.notNull = arguments.cols.notnull[arguments.i];
+		local.dflt = arguments.cols.dflt_value[arguments.i];
+		local.pk = arguments.cols.pk[arguments.i];
+
+		local.def = quoteColumnName(local.name) & " " & local.type;
+		if (arguments.inlinePK && local.pk > 0) {
+			local.def &= " PRIMARY KEY";
+			if (arguments.hasAutoIncrement && UCase(Trim(local.type)) == "INTEGER") {
+				local.def &= " AUTOINCREMENT";
+			}
+		}
+		if (local.notNull) {
+			local.def &= " NOT NULL";
+		}
+		// PRAGMA table_info returns dflt_value already as a SQL literal
+		// (quoted string, bare number, or NULL expression) so it can be
+		// concatenated directly after DEFAULT.
+		if (IsSimpleValue(local.dflt) && Len(local.dflt)) {
+			local.def &= " DEFAULT " & local.dflt;
+		}
+		return local.def;
+	}
+
 }

--- a/vendor/wheels/interfaces/database/DatabaseMigratorAdapterInterface.cfc
+++ b/vendor/wheels/interfaces/database/DatabaseMigratorAdapterInterface.cfc
@@ -121,11 +121,16 @@ interface {
 	/**
 	 * Generate an ALTER TABLE ... ALTER COLUMN statement.
 	 *
+	 * Most adapters return a single SQL string. SQLite returns an array of
+	 * statements because its ALTER TABLE does not support column type/constraint
+	 * changes — the recreate-table pattern requires multiple steps. The migrator's
+	 * `$execute` accepts either form.
+	 *
 	 * @name Table name.
 	 * @column Column definition struct with new settings.
-	 * @return The ALTER COLUMN SQL statement.
+	 * @return The ALTER COLUMN SQL statement, or an array of statements.
 	 */
-	public string function changeColumnInTable(required string name, required any column);
+	public any function changeColumnInTable(required string name, required any column);
 
 	/**
 	 * Generate an ALTER TABLE ... RENAME COLUMN statement.

--- a/vendor/wheels/migrator/Base.cfc
+++ b/vendor/wheels/migrator/Base.cfc
@@ -101,7 +101,17 @@ component extends="wheels.Global"{
 		return local.foreignKeyList;
 	}
 
-	private void function $execute(required string sql, string dataSource = "") {
+	private void function $execute(required any sql, string dataSource = "") {
+		// Adapters may return an array of statements for multi-step DDL
+		// (notably SQLite's recreate-table pattern for changeColumnInTable).
+		if (IsArray(arguments.sql)) {
+			for (local.stmt in arguments.sql) {
+				if (Len(Trim(local.stmt))) {
+					$execute(sql = local.stmt, dataSource = arguments.dataSource);
+				}
+			}
+			return;
+		}
 		local.appKey = $appKey();
 		local.dsName = Len(arguments.dataSource) ? arguments.dataSource : application[local.appKey].dataSourceName;
 		local.sql = Trim(arguments.sql);

--- a/vendor/wheels/tests/specs/migrator/migrationSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migrationSpec.cfc
@@ -803,10 +803,49 @@ component extends="wheels.WheelsTest" {
 
 		describe("Tests changeColumn", () => {
 
+			it("changes a column on SQLite via recreate-table pattern", () => {
+				if (get("adapterName") neq 'SQLiteModel') return;
+				tableName = "dbm_sqlite_changecolumn"
+				columnName = "stringcolumn"
+
+				t = migration.createTable(name = tableName, force = true)
+				t.string(columnNames = columnName, limit = 10, allowNull = true)
+				t.integer(columnNames = "othercolumn", default = 0)
+				t.create()
+
+				// Insert data to confirm preservation across recreate.
+				g.$query(datasource = application.wheels.dataSourceName, sql = "INSERT INTO #tableName# (stringcolumn, othercolumn) VALUES ('keep', 42)")
+
+				migration.changeColumn(
+					table = tableName,
+					columnName = columnName,
+					columnType = 'string',
+					limit = 50,
+					allowNull = false,
+					default = "foo"
+				)
+
+				pragma = g.$query(datasource = application.wheels.dataSourceName, sql = "PRAGMA table_info(#tableName#)")
+				changedRow = 0
+				for (i = 1; i <= pragma.recordCount; i++) {
+					if (pragma.name[i] == columnName) { changedRow = i; break; }
+				}
+
+				// Preserved row survives the recreate.
+				rowCheck = g.$query(datasource = application.wheels.dataSourceName, sql = "SELECT stringcolumn, othercolumn FROM #tableName# WHERE stringcolumn = 'keep'")
+				migration.dropTable(tableName)
+
+				expect(changedRow).toBeGT(0)
+				expect(pragma.notnull[changedRow]).toBe(1)
+				expect(pragma.dflt_value[changedRow]).toInclude("foo")
+				expect(rowCheck.recordCount).toBe(1)
+				expect(rowCheck.othercolumn[1]).toBe(42)
+			})
+
 			it("is changing column", () => {
 				if (_isCockroachDB) return;
 				if(get("adapterName") eq 'SQLiteModel') {
-					skip("SQLite does not allow altering Columns.")
+					skip("SQLite changeColumn is covered by the SQLite-specific spec above.")
 				}
 				tableName = "dbm_changecolumn_tests"
 				columnName = "stringcolumn"


### PR DESCRIPTION
## Summary

Closes #2207 — SQLite migrations calling `changeColumn()` failed with `[SQLITE_ERROR] near "CHANGE": syntax error`. SQLite's `ALTER TABLE` does not support `CHANGE`/`MODIFY`/`ALTER COLUMN`, and `SQLiteMigrator` did not override the MySQL-style default from `Abstract.cfc`.

- `SQLiteMigrator.changeColumnInTable` now returns an array of statements implementing the SQLite-standard recreate-table pattern: `PRAGMA foreign_keys=OFF` → `BEGIN TRANSACTION` → create new table with swapped column → `INSERT ... SELECT` → drop old → `ALTER TABLE ... RENAME TO` → `COMMIT` → recreate non-auto indexes → `PRAGMA foreign_keys=ON`.
- The migrator's `$execute` now accepts `string` or `array` so multi-step DDL works without changing any call sites. All other adapters still return strings and work unchanged.
- Schema introspection uses `PRAGMA table_info` for authoritative column metadata and `sqlite_master.sql` for AUTOINCREMENT detection and CREATE INDEX preservation.
- Interface return type for `changeColumnInTable` widened from `string` to `any` with docstring explaining the SQLite exception.

### v1 limitations (documented in the adapter code and changelog)

- **Not preserved:** triggers, and foreign-key constraints declared inline on the original `CREATE TABLE`.
- **Preserved:** columns with type/NOT NULL/DEFAULT/PRIMARY KEY (including AUTOINCREMENT for INTEGER PK), composite primary keys, and separately-declared `CREATE INDEX` indexes.

## Test plan

- [x] New SQLite-specific spec in `migrationSpec.cfc` that calls `migration.changeColumn()` end-to-end and asserts (a) `NOT NULL` + `DEFAULT` applied via `PRAGMA table_info`, (b) pre-existing row data preserved across the recreate.
- [x] Existing cross-engine `changeColumn` test's SQLite skip message updated to point at the new spec.
- [x] `bash tools/test-local.sh` on Lucee 7 + SQLite: **3251 passed, 0 failed, 0 errored** (up from 3250 — the delta is the new spec).
- [ ] CI matrix will cover Adobe/BoxLang + MySQL/Postgres/MSSQL/CockroachDB to confirm non-SQLite adapters still work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)