### PR TITLE
chore(config): ignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ tests/_output/
 .claude/scheduled_tasks.lock
 .claude/worktrees/
 .claude/launch.json
+CLAUDE.local.md
 .DS_Store
 .superpowers/
 


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.local.md` to `.gitignore` so contributors can keep personal Claude Code instructions at the repo root without risk of accidental commits.

Claude Code loads `CLAUDE.local.md` alongside the tracked `CLAUDE.md` and treats it as a local override — useful for per-user preferences (e.g. "auto-merge when green") that shouldn't be imposed on other contributors.

## Test plan
- [ ] `.gitignore` entry present
- [ ] `git check-ignore CLAUDE.local.md` returns 0
- [ ] No tracked files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)