### PR TITLE
fix(cli): wheels new throws on remaining silent-exit paths (#2214)

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -446,7 +446,13 @@ component extends="modules.BaseModule" {
 		if (!len(appName)) {
 			out("Error: app name is required.", "red");
 			out("Usage: wheels new <appname>");
-			return "";
+			// Args were supplied (the zero-args branch above already returned
+			// usage help) but none parsed as an app name — e.g. `wheels new
+			// --port=3000`. Throw so LuCLI surfaces a non-zero exit (GH #2214).
+			throw(
+				type="Wheels.InvalidArguments",
+				message="wheels new: app name argument is required"
+			);
 		}
 
 		// Default datasource to app name, generate random reload password
@@ -3216,7 +3222,12 @@ component extends="modules.BaseModule" {
 
 		if (directoryExists(targetDir)) {
 			out("Directory already exists: #appName#", "red");
-			return "";
+			// Throw so LuCLI exits non-zero instead of silently succeeding and
+			// fooling automation (GH #2214). Done before any files are written.
+			throw(
+				type="Wheels.TargetDirectoryExists",
+				message="wheels new #appName#: target directory already exists at #targetDir#"
+			);
 		}
 
 		// Merge defaults for any missing options
@@ -3243,7 +3254,13 @@ component extends="modules.BaseModule" {
 		var templateDir = variables.moduleRoot & "templates/app";
 		if (!directoryExists(templateDir)) {
 			out("Project template not found at: #templateDir#", "red");
-			return "";
+			// Indicates a broken install (distribution zip missing templates/app/).
+			// Throw so LuCLI exits non-zero — otherwise the partial scaffold from
+			// an earlier step would look successful to automation (GH #2214).
+			throw(
+				type="Wheels.TemplateNotFound",
+				message="wheels new #appName#: project template directory not found at #templateDir#"
+			);
 		}
 
 		// Template variable context — all config values flow through here

--- a/cli/lucli/tests/test-new-exit-codes.sh
+++ b/cli/lucli/tests/test-new-exit-codes.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-# Regression test for GH #2211: wheels new must exit non-zero when the
-# Wheels framework source cannot be located.
+# Regression test for GH #2211 and GH #2214: `wheels new` must exit
+# non-zero on every user-facing error path, not silently succeed.
+#
+# Coverage:
+#   - #2211: framework source not found
+#   - #2214: target directory already exists
+#   - #2214: app name missing (args supplied but none parsed as appname)
 #
 # Prerequisites:
 #   - wheels binary on PATH
@@ -61,6 +66,77 @@ if [ ! -d "$TMPDIR/fixture" ]; then
     pass "no partial fixture/ directory left behind"
 else
     fail "partial fixture/ directory left behind"
+fi
+
+echo ""
+echo "=== GH #2214: wheels new target-directory-exists regression ==="
+
+# Use a second tmpdir so we have a predictable pre-existing directory and a
+# discoverable framework source (so the only failure surface is the dir check).
+TMPDIR2=$(mktemp -d)
+cleanup2() { rm -rf "$TMPDIR2"; }
+trap 'cleanup; cleanup2' EXIT
+
+# Point at this repo's checkout so we bypass the framework-not-found path
+# and exercise only the target-directory-exists path. Resolve the repo root
+# relative to this script so it works regardless of cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+if [ -d "$REPO_ROOT/vendor/wheels" ]; then
+    export WHEELS_FRAMEWORK_PATH="$REPO_ROOT/vendor/wheels"
+else
+    echo "  SKIP: could not locate vendor/wheels from $REPO_ROOT — skipping #2214 dir-exists case"
+    echo ""
+    echo "=== Summary: $PASS pass, $FAIL fail (dir-exists case skipped) ==="
+    [ "$FAIL" -eq 0 ] && exit 0 || exit 1
+fi
+
+cd "$TMPDIR2"
+mkdir collision
+OUT=$(wheels new collision --no-open-browser 2>&1)
+CODE=$?
+
+echo "--- output (last 6 lines) ---"
+echo "$OUT" | tail -6
+echo "--- exit code: $CODE ---"
+echo ""
+
+if [ "$CODE" -ne 0 ]; then
+    pass "wheels new exits non-zero when target directory already exists"
+else
+    fail "wheels new exited 0 despite target-directory-exists error (GH #2214)"
+fi
+
+if echo "$OUT" | grep -qi "already exists"; then
+    pass "error message mentions 'already exists'"
+else
+    fail "error message missing 'already exists' diagnostic"
+fi
+
+echo ""
+echo "=== GH #2214: wheels new app-name-missing regression ==="
+
+cd "$TMPDIR2"
+# Args supplied, but none parse as an app name. The zero-args path still
+# prints usage and exits 0 (see issue "Not in scope"); this case must throw.
+OUT=$(wheels new --port=3000 --no-open-browser 2>&1)
+CODE=$?
+
+echo "--- output (last 6 lines) ---"
+echo "$OUT" | tail -6
+echo "--- exit code: $CODE ---"
+echo ""
+
+if [ "$CODE" -ne 0 ]; then
+    pass "wheels new exits non-zero when args supplied but no app name parsed"
+else
+    fail "wheels new exited 0 despite missing app name (GH #2214)"
+fi
+
+if echo "$OUT" | grep -qi "app name is required"; then
+    pass "error message mentions 'app name is required'"
+else
+    fail "error message missing 'app name is required' diagnostic"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #2214.

Follow-up to #2211 / #2216. Three error paths in `scaffoldNewApp()` and its caller `new()` in `cli/lucli/Module.cfc` still used `return ""`, producing exit 0 with a friendly stderr message — enough to fool shell automation into thinking scaffolding succeeded.

## Changes

Mirror the #2211/#2216 pattern byte-for-byte: keep the `out()` diagnostic block, then `throw()` a namespaced `Wheels.*` exception so LuCLI's Picocli `ExecutionExceptionHandler` emits exit 1.

| Path | Throws |
|---|---|
| `new()` — args supplied but no app name parsed (e.g. `wheels new --port=3000`) | `Wheels.InvalidArguments` |
| `scaffoldNewApp()` — target directory already exists | `Wheels.TargetDirectoryExists` |
| `scaffoldNewApp()` — `templates/app/` missing (broken install) | `Wheels.TemplateNotFound` |

### Case 2 narrowing (per issue "Not in scope")

The zero-args help path at line 395 (`!arrayLen(args)`) is deliberately **not** touched — bare `wheels new` still prints usage and exits 0. The `!len(appName)` check at line 446 can only fire when args were provided but none resolved to a name, which is the exact case the issue asks to harden. No extra guard needed.

## Tests

Extends `cli/lucli/tests/test-new-exit-codes.sh` with two additional end-to-end cases:
- `wheels new <existing-dir>` exits non-zero + error mentions "already exists"
- `wheels new --port=3000` exits non-zero + error mentions "app name is required"

The template-missing case requires corrupting an installed module to exercise, so it's covered by code inspection and type-parity with the other throws rather than a live shell assertion.

## Acceptance

- [x] `wheels new <existing-dir-name>` exits non-zero
- [x] `wheels new --port=3000` (args provided, no appname) exits non-zero
- [x] `wheels new foo` with broken install (missing `templates/app/`) throws `Wheels.TemplateNotFound` → exits non-zero (code-inspected)
- [x] Existing friendly error messages preserved (diagnostic `out()` still fires before throw)
- [x] Bare `wheels new` help path unchanged — still exits 0