### PR TITLE
fix(cli): hard-fail invalid WHEELS_FRAMEWORK_PATH instead of silent fallback (#2215)

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -3484,17 +3484,30 @@ component extends="modules.BaseModule" {
 		variables.frameworkSearchPaths = [];
 
 		// 1. Explicit override via environment variable — highest priority.
+		//    When the user sets WHEELS_FRAMEWORK_PATH they are giving an
+		//    imperative "use this" — if the path doesn't exist, hard-fail
+		//    rather than silently falling through to auto-discovery (a stale
+		//    or typo'd path could otherwise resolve to a surprising framework
+		//    version). See GH #2215.
+		var override = "";
 		try {
 			var javaSystem = createObject("java", "java.lang.System");
-			var override = javaSystem.getenv("WHEELS_FRAMEWORK_PATH");
-			if (!isNull(override) && len(trim(override))) {
-				arrayAppend(variables.frameworkSearchPaths, override & "  (from $WHEELS_FRAMEWORK_PATH)");
-				if (directoryExists(override)) {
-					return override;
-				}
+			var envValue = javaSystem.getenv("WHEELS_FRAMEWORK_PATH");
+			if (!isNull(envValue)) {
+				override = envValue;
 			}
 		} catch (any e) {
-			// Ignore — env var not accessible in this runtime.
+			// Env var not accessible in this runtime — treat as unset.
+		}
+		if (len(trim(override))) {
+			arrayAppend(variables.frameworkSearchPaths, override & "  (from $WHEELS_FRAMEWORK_PATH)");
+			if (directoryExists(override)) {
+				return override;
+			}
+			throw(
+				type="Wheels.FrameworkPathInvalid",
+				message="WHEELS_FRAMEWORK_PATH is set to '#override#' but that directory does not exist. Unset the variable to fall back to auto-discovery, or point it at a valid vendor/wheels/ source."
+			);
 		}
 
 		// 2. Project root (e.g. user ran `wheels new` from inside an existing

--- a/cli/lucli/tests/test-new-exit-codes.sh
+++ b/cli/lucli/tests/test-new-exit-codes.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Regression test for GH #2211 and GH #2214: `wheels new` must exit
-# non-zero on every user-facing error path, not silently succeed.
+# Regression tests for wheels new exit-code contracts.
 #
-# Coverage:
-#   - #2211: framework source not found
-#   - #2214: target directory already exists
-#   - #2214: app name missing (args supplied but none parsed as appname)
+#   GH #2211 — framework source not found anywhere must exit non-zero
+#   GH #2215 — explicit WHEELS_FRAMEWORK_PATH pointing at a non-existent
+#              directory must hard-fail (not silently fall through to
+#              auto-discovery)
+#   GH #2214 — target directory already exists must exit non-zero
+#   GH #2214 — app name missing (args supplied but none parsed) must exit non-zero
 #
 # Prerequisites:
 #   - wheels binary on PATH
@@ -67,6 +68,46 @@ if [ ! -d "$TMPDIR/fixture" ]; then
 else
     fail "partial fixture/ directory left behind"
 fi
+
+echo ""
+echo "=== GH #2215: invalid WHEELS_FRAMEWORK_PATH must hard-fail ==="
+echo ""
+
+# Fresh subdir so a leftover fixture/ from case #2211 doesn't poison the check.
+SUBDIR="$TMPDIR/case-2215"
+mkdir -p "$SUBDIR"
+cd "$SUBDIR"
+
+BAD_PATH="$SUBDIR/does-not-exist/vendor/wheels"
+export WHEELS_FRAMEWORK_PATH="$BAD_PATH"
+
+OUT=$(wheels new fixture --no-open-browser 2>&1)
+CODE=$?
+
+echo "--- output (last 8 lines) ---"
+echo "$OUT" | tail -8
+echo "--- exit code: $CODE ---"
+echo ""
+
+if [ "$CODE" -ne 0 ]; then
+    pass "wheels new exits non-zero when WHEELS_FRAMEWORK_PATH is invalid"
+else
+    fail "wheels new exited 0 despite invalid WHEELS_FRAMEWORK_PATH (GH #2215)"
+fi
+
+if echo "$OUT" | grep -qF "$BAD_PATH"; then
+    pass "error message echoes the invalid path"
+else
+    fail "error message does not mention the invalid path"
+fi
+
+if [ ! -d "$SUBDIR/fixture" ]; then
+    pass "no partial fixture/ directory left behind (case 2215)"
+else
+    fail "partial fixture/ directory left behind (case 2215)"
+fi
+
+unset WHEELS_FRAMEWORK_PATH
 
 echo ""
 echo "=== GH #2214: wheels new target-directory-exists regression ==="


### PR DESCRIPTION
Fixes #2215.

## Summary
- `resolveFrameworkSource()` used to append an invalid `WHEELS_FRAMEWORK_PATH` to the search list and silently fall through to tier 2/3 auto-discovery — the user's explicit override was ignored, and a typo'd or stale path could resolve to a surprising framework version.
- Now throws `Wheels.FrameworkPathInvalid` when the env var is set but `directoryExists()` is false. Picocli maps this to exit code 1 (same mechanism as #2216).
- Error message echoes the bad path and suggests both remedies (unset to use auto-discovery, or point at a valid `vendor/wheels/`).

## Structural note
Moved `override` out of the `try` block so the new `throw` isn't swallowed by the catch-all that guards `getenv()` availability. The catch still only suppresses Java/env-access errors (`override` stays empty → tier 1 skipped → fallbacks engage normally).

## Acceptance criteria (from #2215)
- [x] `WHEELS_FRAMEWORK_PATH=/does/not/exist wheels new foo` exits non-zero with a clear message
- [x] Unsetting the variable restores the auto-discovery fallback behavior (tier 2/3 unchanged)
- [x] `WHEELS_FRAMEWORK_PATH=/valid/path wheels new foo` still works

## Test plan
- [x] Extended `cli/lucli/tests/test-new-exit-codes.sh` with a `GH #2215` section that:
    - Sets `WHEELS_FRAMEWORK_PATH` to a non-existent path
    - Asserts exit non-zero
    - Asserts the error message echoes the invalid path
    - Asserts no partial scaffold directory is left behind
- [x] Verified **RED** against pre-fix code (exit 0, silent fallback succeeded)
- [x] Verified **GREEN** against the fix (exit 1, `Wheels.FrameworkPathInvalid` message)
- [x] Happy path spot-checked: `WHEELS_FRAMEWORK_PATH=…/vendor/wheels wheels new happyapp` exits 0, scaffolds `vendor/wheels/` as expected.
- [ ] Reviewer: run `bash cli/lucli/tests/test-new-exit-codes.sh` after local install to confirm both #2211 and #2215 sections pass.

## Related
- #2211 / #2216 — the exit-code fix that made this silent-fallback discoverable