### PR TITLE
ci(config): bump LUCLI_VERSION 0.3.3 → 0.3.7 to fix snapshot smoke test

### DIFF
--- a/.github/workflows/deploy-ci.yml
+++ b/.github/workflows/deploy-ci.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-      LUCLI_VERSION: "0.3.3"
+      LUCLI_VERSION: "0.3.7"
       WHEELS_CI: "true"
       PORT: "8080"
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
     name: "Lucee 7 + SQLite (LuCLI)"
     runs-on: ubuntu-latest
     env:
-      LUCLI_VERSION: "0.3.3"
+      LUCLI_VERSION: "0.3.7"
       WHEELS_CI: "true"
       WHEELS_BROWSER_TEST_BASE_URL: "http://localhost:60007"
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   WHEELS_PRERELEASE: false
-  LUCLI_VERSION: "0.3.3"
+  LUCLI_VERSION: "0.3.7"
 
 jobs:
   #############################################

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   WHEELS_PRERELEASE: true
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  LUCLI_VERSION: "0.3.3"
+  LUCLI_VERSION: "0.3.7"
 
 jobs:
   #############################################


### PR DESCRIPTION
## Summary

- Bumps `LUCLI_VERSION` from `0.3.3` to `0.3.7` in all four workflows that pin it: `release.yml`, `snapshot.yml`, `pr.yml`, `deploy-ci.yml`.
- Fixes the "Smoke Test Installed Distribution" job which has failed on every merge to `develop` since it was added in #2208.

## Root cause

The smoke test creates a pristine `LUCLI_HOME` via `mktemp` and extracts the built `wheels-module-*.tar.gz` into it, then runs `lucli wheels new smoke`. This fails with:

```
lucee.runtime.exp.ExpressionException: invalid component definition,
can't find component [modules.BaseModule]
```

LuCLI 0.3.3 has a bug where `ensureBaseModuleUpToDate()` — which copies the bundled `modules/BaseModule.cfc` out of the LuCLI JAR into `$LUCLI_HOME/modules/` — is not invoked on the `lucli wheels new` code path. Since `cli/lucli/Module.cfc` declares `extends=\"modules.BaseModule\"`, Lucee can't resolve the parent class and the module fails to construct.

Normal dev and CI workflows reuse `$HOME/.lucli` across invocations, so `BaseModule.cfc` gets seeded by some earlier lucli call and persists. The smoke test deliberately isolates state with `mktemp`, which exposed the bug for the first time.

LuCLI 0.3.7 (and later) triggers the BaseModule sync on the module-execution path that `wheels new` follows.

## Verification

Reproduced the failure locally against `lucli-0.3.3-macos`:
```
❌ Error: lucee.runtime.exp.ExpressionException: invalid component definition,
can't find component [modules.BaseModule]
```

Confirmed fix against `lucli-0.3.7-macos` — ran the full `tools/ci/smoke-test-module.sh` end-to-end:
```
=== Results ===
31/31 passed, 0 failed
ALL SMOKE TESTS PASSED
```

## Test plan

- [ ] Snapshot workflow on this PR completes successfully, including the "Smoke Test Installed Distribution" job.
- [ ] Normal PR workflow (`pr.yml`) still passes — no regression on the LuCLI 0.3.7 fast-test path.
- [ ] `deploy-ci.yml` CLI tests still green under 0.3.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)