### PR TITLE
fix(cli): legacy wheels g app defaults to 4.0 template + deprecation banner (#2227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 - RocketUnit test style for new tests — BDD syntax (via WheelsTest) is required going forward. Existing RocketUnit specs continue to run. (#1925)
 - `wheels.Test` test base class — extend `wheels.WheelsTest` instead (#1889)
 - In-dev-server HTTP MCP endpoint at `/wheels/mcp` — superseded by the LuCLI stdio MCP server (`wheels mcp wheels`). Emits a deprecation warning to the `wheels_mcp` log on first request and advertises `deprecated: true` in the `serverInfo` handshake. Scheduled for removal in a future release. Migrate existing projects with `wheels mcp setup --force`.
+- Legacy CommandBox `wheels-cli` module (`wheels g app`, `wheels new` via the CommandBox wizard) — superseded by LuCLI's canonical `wheels new`. Emits a deprecation banner on every invocation. Scheduled for removal in v5.0. (#2227)
 
 ### Removed
 
@@ -141,6 +142,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ### Fixed
 
+- Legacy CommandBox `wheels g app` now scaffolds a 4.0 app by default — the `wheels-base-template` default was pinned at `@^3.1.0`, so `box install wheels-cli && wheels g app myapp` produced a 3.x scaffold at 4.0 GA. Updated default (and the `WheelsBaseTemplate` shortcut + wizard default selection) to `@^4.0.0`, fixed the stale "Default is Bleeding Edge" docstring, and added a deprecation banner pointing users at LuCLI's `wheels new`. (#2227)
 - `changeColumn` on SQLite now works by implementing the SQLite-standard recreate-table pattern in `SQLiteMigrator`. Previously, SQLite migrations inherited MySQL's `ALTER TABLE ... CHANGE` syntax from `Abstract.cfc` and failed with `near "CHANGE": syntax error`. The migrator's `$execute` now accepts an array of statements so adapters can return multi-step DDL. v1 limitations: foreign-key constraints declared inline on `CREATE TABLE` and triggers are not preserved across the recreate. (#2207)
 - Framework-internal browser-test fixture controllers, views, and the `/_browser/*` routes no longer leak into application-level files. Moved from `app/controllers/BrowserTest*.cfc`, `app/views/browsertest*/`, and `config/routes.cfm` into `vendor/wheels/public/browser-fixtures/`, auto-mounted by `$lockedLoadRoutes` when environment is `testing` or `development` and the new opt-in setting `loadBrowserTestFixtures=true` is set. Apps upgrading from a 4.0 snapshot that had custom `/_browser/*` routes must opt in explicitly or re-declare them in `config/routes.cfm`. (#2135, #2138)
 - Stray `app/mailers/UserNotificationsMailer.cfc` demo removed from the framework repo root (byte-identical copies remain in the example apps under `examples/tweet/` and `examples/starter-app/`). (#2138)

--- a/cli/src/commands/wheels/generate/app-wizard.cfc
+++ b/cli/src/commands/wheels/generate/app-wizard.cfc
@@ -156,7 +156,7 @@ component aliases="wheels g app-wizard, wheels new" extends="../base" {
 
     var template = multiselect( 'Which Wheels Template shall we use? ' )
       .options( [
-        {value: 'wheels-base-template@^3.1.0', display: '3.1 - Wheels Base Template - Stable', selected: true},
+        {value: 'wheels-base-template@^4.0.0', display: '4.0 - Wheels Base Template - Stable', selected: true},
         {value: 'wheels-base-template@BE', display: 'Bleeding Edge - Wheels Base Template'},
         {value: 'wheels-template-htmx-alpine-simple', display: 'Wheels Template - HTMX - Alpine.js - Simple.css'},
         {value: 'wheels-starter-app', display: 'Wheels Starter App'},

--- a/cli/src/commands/wheels/generate/app.cfc
+++ b/cli/src/commands/wheels/generate/app.cfc
@@ -14,7 +14,7 @@
  *  {code}
  *
  *  Here are the basic templates that are available for you that come from ForgeBox
- *  - Wheels Base Template - 3.0 Stable (default)
+ *  - Wheels Base Template - 4.0 Stable (default)
  *  - Wheels Base Template - Bleeding Edge
  *  - Wheels Template - HelloWorld
  *  - Wheels Template - HelloDynamic
@@ -43,7 +43,7 @@ component aliases="wheels g app" extends="../base" {
 
     // Map these shortcut names to the actual ForgeBox slugs
     variables.templateMap = {
-      'WheelsBaseTemplate'        : 'wheels-base-template@^3.1.0',
+      'WheelsBaseTemplate'        : 'wheels-base-template@^4.0.0',
       'BleedingEdge'              : 'wheels-base-template@BE',
       'WheelsTemplateHTMX'        : 'wheels-template-htmx-alpine-simple',
       'WheelsStarterApp'          : 'wheels-starter-app',
@@ -55,7 +55,7 @@ component aliases="wheels g app" extends="../base" {
 
   /**
    * @name           The name of the app you want to create
-   * @template       The name of the app template to generate (or an endpoint ID like a forgebox slug). Default is Bleeding Edge
+   * @template       The name of the app template to generate (or an endpoint ID like a forgebox slug). Default is the stable Wheels Base Template (4.0).
    * @directory      The directory to create the app in
    * @reloadPassword The reload passwrod to set for the app
    * @datasourceName The datasource name to set for the app
@@ -68,7 +68,7 @@ component aliases="wheels g app" extends="../base" {
    **/
   function run(
     name     = 'MyApp',
-    template = 'wheels-base-template@^3.1.0',
+    template = 'wheels-base-template@^4.0.0',
     directory,
     reloadPassword = '',
     datasourceName,
@@ -85,6 +85,14 @@ component aliases="wheels g app" extends="../base" {
 
     // Initialize detail service
     var details = application.wirebox.getInstance("DetailOutputService@wheels-cli");
+
+    // Deprecation notice — legacy CommandBox surface is scheduled for removal in Wheels v5.0.
+    // Canonical 4.0+ CLI is LuCLI's `wheels new` (https://github.com/bpamiri/LuCLI).
+    details.getPrint().yellowBoldLine( "[DEPRECATED] 'wheels g app' (CommandBox wheels-cli) is deprecated." );
+    details.getPrint().yellowLine( "             Use LuCLI 'wheels new' instead — the canonical Wheels 4.0+ CLI." );
+    details.getPrint().yellowLine( "             Install: brew install lucli  (or see https://github.com/bpamiri/LuCLI)" );
+    details.getPrint().yellowLine( "             This command will be removed in Wheels v5.0." );
+    details.line();
 
     // set defaults based on app name
     if ( !len( arguments.directory ) ) {


### PR DESCRIPTION
## Summary

Closes #2227.

At 4.0 GA, the legacy CommandBox CLI (`cli/src/commands/wheels/generate/app.cfc`) still defaulted to `wheels-base-template@^3.1.0`, so `box install wheels-cli && wheels g app myapp` produced a 3.x scaffold. Its docstring also claimed "Default is Bleeding Edge" — which was never true.

### What changed

- **`cli/src/commands/wheels/generate/app.cfc`**
  - Default template `@^3.1.0` → `@^4.0.0` (line 71)
  - `WheelsBaseTemplate` shortcut mapping `@^3.1.0` → `@^4.0.0` (line 46)
  - Docstring "Default is Bleeding Edge" → "Default is the stable Wheels Base Template (4.0)"
  - Block-comment entry "3.0 Stable (default)" → "4.0 Stable (default)"
  - New deprecation banner printed at the start of `run()`, pointing users at LuCLI's `wheels new`, noting v5.0 removal
- **`cli/src/commands/wheels/generate/app-wizard.cfc`**
  - Pre-selected template option `@^3.1.0` / "3.1 - Wheels Base Template - Stable" → `@^4.0.0` / "4.0 - Wheels Base Template - Stable" (line 159). The wizard delegates to `wheels g app`, so without this the default fix above is bypassed when users accept the pre-selected menu entry.
- **`CHANGELOG.md`** — `### Deprecated` (legacy `wheels-cli` module, removal in v5.0) and `### Fixed` (the 4.0 default) entries under `[Unreleased]`.

### Issue checklist

- [x] Update default on line 71 to `wheels-base-template@^4.0.0`; keep `BleedingEdge` for BE snapshots
- [x] Update docstring to match
- [x] Add a deprecation banner when legacy `wheels g app` is invoked, pointing users at `wheels new` (LuCLI)
- [x] Schedule full removal for v5.0 (CHANGELOG `### Deprecated` + banner text)

## Test plan

- [ ] `box install wheels-cli && wheels g app foo` scaffolds a 4.0 app by default
- [ ] Deprecation banner prints at the top of `wheels g app` output
- [ ] `wheels new` (legacy CommandBox wizard path) — default-selected template reads "4.0 - Wheels Base Template - Stable", and after confirmation the banner still prints (wizard delegates to `wheels g app`)
- [ ] Existing callers passing an explicit `template=` arg still work (including `BleedingEdge` shortcut)

### Note on scope

The issue's checklist calls out only `app.cfc`, but `app-wizard.cfc` has the identical `@^3.1.0` pinned as the default-selected wizard option and delegates to `wheels g app`. Fixing only `app.cfc` would leave the wizard passing `@^3.1.0` explicitly when a user accepts the default, defeating the fix. Both must change for the acceptance to hold.

Out of scope: `tools/installer/*` (separate distribution), `web/sites/guides/src/content/docs/v3-0-0/*` (historical v3 docs).