### PR TITLE
fix(cli): wheels deploy returns success summary in real mode (#2230)

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -1314,40 +1314,33 @@ component extends="modules.BaseModule" {
 
 		switch (sub) {
 			case "deploy":
-				dmc.deploy(opts);
-				return arrayToList(dmc.dryRunOutput(), chr(10));
+				return dmc.deploy(opts);
 			case "redeploy":
-				dmc.redeploy(opts);
-				return arrayToList(dmc.dryRunOutput(), chr(10));
+				return dmc.redeploy(opts);
 			case "rollback":
 				if (arrayLen(positional) < 2) {
 					throw(message="rollback requires a version argument: wheels deploy rollback <version>");
 				}
 				opts.version = positional[2];
-				dmc.rollback(opts);
-				return arrayToList(dmc.dryRunOutput(), chr(10));
+				return dmc.rollback(opts);
 			case "config":
 				return dmc.config(opts);
 			case "init":
 				return dmc.init_stub(opts);
 			case "setup":
-				dmc.setup(opts);
-				return arrayToList(dmc.dryRunOutput(), chr(10));
+				return dmc.setup(opts);
 			case "version":
 				return dmc.version();
 			case "audit":
-				dmc.audit(opts);
-				return arrayToList(dmc.dryRunOutput(), chr(10));
+				return dmc.audit(opts);
 			case "docs":
 				// `docs [SECTION]` — section is the optional second positional.
 				opts.section = arrayLen(positional) >= 2 ? positional[2] : "";
 				return dmc.docs(opts);
 			case "details":
-				dmc.details(opts);
-				return arrayToList(dmc.dryRunOutput(), chr(10));
+				return dmc.details(opts);
 			case "remove":
-				dmc.remove(opts);
-				return arrayToList(dmc.dryRunOutput(), chr(10));
+				return dmc.remove(opts);
 			case "app":
 				if (arrayLen(positional) < 2) {
 					throw(message="wheels deploy app requires a verb");
@@ -1367,8 +1360,7 @@ component extends="modules.BaseModule" {
 					case "live":
 					case "maintenance":
 					case "remove":
-						appCli[appVerb](opts);
-						return arrayToList(appCli.dryRunOutput(), chr(10));
+						return invoke(appCli, appVerb, [opts]);
 					default:
 						throw(message="Unknown wheels deploy app verb: #appVerb#");
 				}
@@ -1389,8 +1381,7 @@ component extends="modules.BaseModule" {
 					case "details":
 					case "logs":
 					case "remove":
-						invoke(proxyCli, proxyVerb, [opts]);
-						return arrayToList(proxyCli.dryRunOutput(), chr(10));
+						return invoke(proxyCli, proxyVerb, [opts]);
 					default:
 						throw(message="Unknown wheels deploy proxy verb: #proxyVerb#");
 				}
@@ -1407,8 +1398,7 @@ component extends="modules.BaseModule" {
 					case "login":
 					case "logout":
 					case "remove":
-						invoke(registryCli, registryVerb, [opts]);
-						return arrayToList(registryCli.dryRunOutput(), chr(10));
+						return invoke(registryCli, registryVerb, [opts]);
 					default:
 						throw(message="Unknown wheels deploy registry verb: #registryVerb#");
 				}
@@ -1428,8 +1418,7 @@ component extends="modules.BaseModule" {
 					case "remove":
 					case "details":
 					case "dev":
-						invoke(buildCli, buildVerb, [opts]);
-						return arrayToList(buildCli.dryRunOutput(), chr(10));
+						return invoke(buildCli, buildVerb, [opts]);
 					default:
 						throw(message="Unknown wheels deploy build verb: #buildVerb#");
 				}
@@ -1451,8 +1440,7 @@ component extends="modules.BaseModule" {
 					case "details":
 					case "logs":
 					case "remove":
-						invoke(accCli, accVerb, [opts]);
-						return arrayToList(accCli.dryRunOutput(), chr(10));
+						return invoke(accCli, accVerb, [opts]);
 					default:
 						throw(message="Unknown wheels deploy accessory verb: #accVerb#");
 				}
@@ -1467,8 +1455,7 @@ component extends="modules.BaseModule" {
 				var pruneCli = new cli.lucli.services.deploy.cli.DeployPruneCli(
 					new cli.lucli.services.deploy.lib.SshPool()
 				);
-				invoke(pruneCli, pruneVerb, [opts]);
-				return arrayToList(pruneCli.dryRunOutput(), chr(10));
+				return invoke(pruneCli, pruneVerb, [opts]);
 			case "server":
 				if (arrayLen(positional) < 2) {
 					throw(message="wheels deploy server requires a verb (exec or bootstrap)");
@@ -1490,11 +1477,9 @@ component extends="modules.BaseModule" {
 				);
 				switch (serverVerb) {
 					case "exec":
-						serverCli.exec(opts);
-						return arrayToList(serverCli.dryRunOutput(), chr(10));
+						return serverCli.exec(opts);
 					case "bootstrap":
-						serverCli.bootstrap(opts);
-						return arrayToList(serverCli.dryRunOutput(), chr(10));
+						return serverCli.bootstrap(opts);
 					default:
 						throw(message="Unknown wheels deploy server verb: #serverVerb#");
 				}
@@ -1507,8 +1492,7 @@ component extends="modules.BaseModule" {
 				var lockCli = new cli.lucli.services.deploy.cli.DeployLockCli(
 					new cli.lucli.services.deploy.lib.SshPool()
 				);
-				invoke(lockCli, lockVerb, [opts]);
-				return arrayToList(lockCli.dryRunOutput(), chr(10));
+				return invoke(lockCli, lockVerb, [opts]);
 			case "secrets":
 				if (arrayLen(positional) < 2) {
 					throw(message="wheels deploy secrets requires a verb (fetch/extract/print)");

--- a/cli/lucli/services/deploy/cli/DeployAccessoryCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployAccessoryCli.cfc
@@ -23,25 +23,25 @@ component {
 
     public array function dryRunOutput() { return variables.dryRunBuffer; }
 
-    public void function boot(required struct opts)     { $forEach(arguments.opts, "run"); }
-    public void function reboot(required struct opts)   { $forEach(arguments.opts, "reboot"); }
-    public void function start(required struct opts)    { $forEach(arguments.opts, "start"); }
-    public void function stop(required struct opts)     { $forEach(arguments.opts, "stop"); }
-    public void function restart(required struct opts)  { $forEach(arguments.opts, "restart"); }
-    public void function details(required struct opts)  { $forEach(arguments.opts, "details"); }
-    public void function remove(required struct opts)   { $forEach(arguments.opts, "remove"); }
+    public string function boot(required struct opts)     { return $forEach(arguments.opts, "run",     "Booted accessory"); }
+    public string function reboot(required struct opts)   { return $forEach(arguments.opts, "reboot",  "Rebooted accessory"); }
+    public string function start(required struct opts)    { return $forEach(arguments.opts, "start",   "Started accessory"); }
+    public string function stop(required struct opts)     { return $forEach(arguments.opts, "stop",    "Stopped accessory"); }
+    public string function restart(required struct opts)  { return $forEach(arguments.opts, "restart", "Restarted accessory"); }
+    public string function details(required struct opts)  { return $forEach(arguments.opts, "details", "Collected accessory details"); }
+    public string function remove(required struct opts)   { return $forEach(arguments.opts, "remove",  "Removed accessory"); }
 
-    public void function logs(required struct opts) {
+    public string function logs(required struct opts) {
         var logOpts = {
             tail: arguments.opts.tail ?: 100,
             follow: arguments.opts.follow ?: false
         };
-        $forEach(arguments.opts, "logs", logOpts);
+        return $forEach(arguments.opts, "logs", "Tailed accessory logs", logOpts);
     }
 
     // ── Private plumbing ───────────────────────────────────────
 
-    private void function $forEach(required struct opts, required string method, struct methodOpts = {}) {
+    private string function $forEach(required struct opts, required string method, required string verbLabel, struct methodOpts = {}) {
         arrayClear(variables.dryRunBuffer);
         if (!len(arguments.opts.name ?: "")) {
             throw(
@@ -58,13 +58,27 @@ component {
         var targets = (arguments.opts.name == "all")
             ? cfg.accessories()
             : [cfg.accessory(arguments.opts.name)];
+        var names = [];
 
         for (var acc in targets) {
             var cmd = structIsEmpty(arguments.methodOpts)
                 ? invoke(accCmds, arguments.method, [acc])
                 : invoke(accCmds, arguments.method, [acc, arguments.methodOpts]);
             $dispatch(acc.hosts(), cmd, dryRun);
+            arrayAppend(names, acc.name());
         }
+
+        return $renderResult(
+            arguments.opts,
+            arguments.verbLabel & " " & arrayToList(names, ", ")
+        );
+    }
+
+    private string function $renderResult(required struct opts, required string summary) {
+        if (arguments.opts.dryRun ?: false) {
+            return arrayToList(variables.dryRunBuffer, chr(10));
+        }
+        return arguments.summary;
     }
 
     private void function $dispatch(required array hosts, required string cmd, required boolean dryRun) {

--- a/cli/lucli/services/deploy/cli/DeployAppCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployAppCli.cfc
@@ -22,74 +22,84 @@ component {
 
     public array function dryRunOutput() { return variables.dryRunBuffer; }
 
-    public void function boot(required struct opts) {
-        $forEachHost(arguments.opts, function(cmds, role, version) {
+    public string function boot(required struct opts) {
+        var n = $forEachHost(arguments.opts, function(cmds, role, version) {
             return cmds.run(role, version);
         });
+        return $renderResult(arguments.opts, "Booted app on " & n & " host(s)");
     }
 
-    public void function start(required struct opts) {
-        $forEachHost(arguments.opts, function(cmds, role, version) {
+    public string function start(required struct opts) {
+        var n = $forEachHost(arguments.opts, function(cmds, role, version) {
             return cmds.start(role, version);
         });
+        return $renderResult(arguments.opts, "Started app on " & n & " host(s)");
     }
 
-    public void function stop(required struct opts) {
-        $forEachHost(arguments.opts, function(cmds, role, version) {
+    public string function stop(required struct opts) {
+        var n = $forEachHost(arguments.opts, function(cmds, role, version) {
             return cmds.stop(role, version);
         });
+        return $renderResult(arguments.opts, "Stopped app on " & n & " host(s)");
     }
 
-    public void function details(required struct opts) {
-        $forEachHost(arguments.opts, function(cmds, role, version) {
+    public string function details(required struct opts) {
+        var n = $forEachHost(arguments.opts, function(cmds, role, version) {
             return cmds.status(role, version);
         });
+        return $renderResult(arguments.opts, "Collected app details on " & n & " host(s)");
     }
 
-    public void function containers(required struct opts) {
-        $forEachHost(arguments.opts, function(cmds, role, version) {
+    public string function containers(required struct opts) {
+        var n = $forEachHost(arguments.opts, function(cmds, role, version) {
             return cmds.containers();
         }, {versionOptional: true});
+        return $renderResult(arguments.opts, "Listed app containers on " & n & " host(s)");
     }
 
-    public void function images(required struct opts) {
-        $forEachHost(arguments.opts, function(cmds, role, version) {
+    public string function images(required struct opts) {
+        var n = $forEachHost(arguments.opts, function(cmds, role, version) {
             return cmds.images();
         }, {versionOptional: true});
+        return $renderResult(arguments.opts, "Listed app images on " & n & " host(s)");
     }
 
-    public void function logs(required struct opts) {
+    public string function logs(required struct opts) {
         var logOpts = {
             tail: arguments.opts.tail ?: 100,
             follow: arguments.opts.follow ?: false,
             container: arguments.opts.container ?: ""
         };
-        $forEachHost(arguments.opts, function(cmds, role, version) {
+        var n = $forEachHost(arguments.opts, function(cmds, role, version) {
             return cmds.logs(logOpts);
         }, {versionOptional: true});
+        return $renderResult(arguments.opts, "Tailed app logs on " & n & " host(s)");
     }
 
-    public void function live(required struct opts) {
-        $forEachHost(arguments.opts, function(cmds, role, version) {
+    public string function live(required struct opts) {
+        var n = $forEachHost(arguments.opts, function(cmds, role, version) {
             return cmds.live(role, version);
         });
+        return $renderResult(arguments.opts, "Marked app live on " & n & " host(s)");
     }
 
-    public void function maintenance(required struct opts) {
-        $forEachHost(arguments.opts, function(cmds, role, version) {
+    public string function maintenance(required struct opts) {
+        var n = $forEachHost(arguments.opts, function(cmds, role, version) {
             return cmds.maintenance(role, version);
         });
+        return $renderResult(arguments.opts, "Put app into maintenance mode on " & n & " host(s)");
     }
 
-    public void function remove(required struct opts) {
-        $forEachHost(arguments.opts, function(cmds, role, version) {
+    public string function remove(required struct opts) {
+        var n = $forEachHost(arguments.opts, function(cmds, role, version) {
             return cmds.remove(role, version);
         });
+        return $renderResult(arguments.opts, "Removed app from " & n & " host(s)");
     }
 
     // ── Private plumbing ───────────────────────────────────────
 
-    private void function $forEachHost(required struct opts, required any cmdFn, struct flags = {}) {
+    private numeric function $forEachHost(required struct opts, required any cmdFn, struct flags = {}) {
         arrayClear(variables.dryRunBuffer);
         var cfg = variables.loader.load(
             arguments.opts.configPath,
@@ -104,14 +114,24 @@ component {
         var dryRun = arguments.opts.dryRun ?: false;
         var appCmds = new cli.lucli.services.deploy.commands.AppCommands(cfg);
         var roleFilter = arguments.opts.role ?: "";
+        var hostCount = 0;
 
         for (var role in cfg.roles()) {
             if (len(roleFilter) && role.name() != roleFilter) continue;
             for (var host in role.hosts()) {
                 var cmd = arguments.cmdFn(appCmds, role, version);
                 $dispatch([host], cmd, dryRun);
+                hostCount++;
             }
         }
+        return hostCount;
+    }
+
+    private string function $renderResult(required struct opts, required string summary) {
+        if (arguments.opts.dryRun ?: false) {
+            return arrayToList(variables.dryRunBuffer, chr(10));
+        }
+        return arguments.summary;
     }
 
     private void function $dispatch(required array hosts, required string cmd, required boolean dryRun) {

--- a/cli/lucli/services/deploy/cli/DeployBuildCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployBuildCli.cfc
@@ -21,24 +21,31 @@ component {
 
     public array function dryRunOutput() { return variables.dryRunBuffer; }
 
-    public void function deliver(required struct opts) {
+    public string function deliver(required struct opts) {
         // push clears the buffer and writes; tell pull to preserve what push wrote.
         push(arguments.opts);
         var pullOpts = duplicate(arguments.opts);
         pullOpts.preserveBuffer = "1";
         pull(pullOpts);
+        var cfg = $loadCfg(arguments.opts);
+        var version = arguments.opts.version ?: $gitShortSha();
+        return $renderResult(
+            arguments.opts,
+            "Delivered " & cfg.image() & ":" & version & " (pushed + pulled)"
+        );
     }
 
-    public void function push(required struct opts) {
+    public string function push(required struct opts) {
         var cfg = $loadCfg(arguments.opts);
         var version = arguments.opts.version ?: $gitShortSha();
         var dryRun = arguments.opts.dryRun ?: false;
         if (!len(arguments.opts.preserveBuffer ?: "")) arrayClear(variables.dryRunBuffer);
         var builder = new cli.lucli.services.deploy.commands.BuilderCommands(cfg);
         $runLocal(builder.push(version), dryRun);
+        return $renderResult(arguments.opts, "Pushed " & cfg.image() & ":" & version);
     }
 
-    public void function pull(required struct opts) {
+    public string function pull(required struct opts) {
         var cfg = $loadCfg(arguments.opts);
         var version = arguments.opts.version ?: $gitShortSha();
         var dryRun = arguments.opts.dryRun ?: false;
@@ -46,37 +53,52 @@ component {
         var builder = new cli.lucli.services.deploy.commands.BuilderCommands(cfg);
         var hosts = $allHosts(cfg);
         $dispatchSsh(hosts, builder.pull(version), dryRun);
+        return $renderResult(
+            arguments.opts,
+            "Pulled " & cfg.image() & ":" & version & " on " & arrayLen(hosts) & " host(s)"
+        );
     }
 
-    public void function create(required struct opts) {
+    public string function create(required struct opts) {
         var cfg = $loadCfg(arguments.opts);
         var dryRun = arguments.opts.dryRun ?: false;
         arrayClear(variables.dryRunBuffer);
         $runLocal(new cli.lucli.services.deploy.commands.BuilderCommands(cfg).create(), dryRun);
+        return $renderResult(arguments.opts, "Created builder for " & cfg.image());
     }
 
-    public void function remove(required struct opts) {
+    public string function remove(required struct opts) {
         var cfg = $loadCfg(arguments.opts);
         var dryRun = arguments.opts.dryRun ?: false;
         arrayClear(variables.dryRunBuffer);
         $runLocal(new cli.lucli.services.deploy.commands.BuilderCommands(cfg).remove(), dryRun);
+        return $renderResult(arguments.opts, "Removed builder for " & cfg.image());
     }
 
-    public void function details(required struct opts) {
+    public string function details(required struct opts) {
         var cfg = $loadCfg(arguments.opts);
         var dryRun = arguments.opts.dryRun ?: false;
         arrayClear(variables.dryRunBuffer);
         $runLocal(new cli.lucli.services.deploy.commands.BuilderCommands(cfg).details(), dryRun);
+        return $renderResult(arguments.opts, "Collected builder details for " & cfg.image());
     }
 
-    public void function dev(required struct opts) {
+    public string function dev(required struct opts) {
         var cfg = $loadCfg(arguments.opts);
         var dryRun = arguments.opts.dryRun ?: false;
         arrayClear(variables.dryRunBuffer);
         $runLocal(new cli.lucli.services.deploy.commands.BuilderCommands(cfg).dev(), dryRun);
+        return $renderResult(arguments.opts, "Ran dev build for " & cfg.image());
     }
 
     // ── Private plumbing ───────────────────────────────────────
+
+    private string function $renderResult(required struct opts, required string summary) {
+        if (arguments.opts.dryRun ?: false) {
+            return arrayToList(variables.dryRunBuffer, chr(10));
+        }
+        return arguments.summary;
+    }
 
     private any function $loadCfg(required struct opts) {
         return variables.loader.load(

--- a/cli/lucli/services/deploy/cli/DeployLockCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployLockCli.cfc
@@ -17,7 +17,7 @@ component {
 
     public array function dryRunOutput() { return variables.dryRunBuffer; }
 
-    public void function acquire(required struct opts) {
+    public string function acquire(required struct opts) {
         var cfg = $loadCfg(arguments.opts);
         var dryRun = arguments.opts.dryRun ?: false;
         arrayClear(variables.dryRunBuffer);
@@ -27,22 +27,32 @@ component {
             message: arguments.opts.message ?: "manual acquire"
         });
         $dispatchAny($allHosts(cfg), cmd, dryRun);
+        return $renderResult(arguments.opts, "Acquired deploy lock for " & cfg.service());
     }
 
-    public void function release(required struct opts) {
+    public string function release(required struct opts) {
         var cfg = $loadCfg(arguments.opts);
         var dryRun = arguments.opts.dryRun ?: false;
         arrayClear(variables.dryRunBuffer);
         var lock = new cli.lucli.services.deploy.commands.LockCommands(cfg);
         $dispatchAny($allHosts(cfg), lock.release(), dryRun);
+        return $renderResult(arguments.opts, "Released deploy lock for " & cfg.service());
     }
 
-    public void function status(required struct opts) {
+    public string function status(required struct opts) {
         var cfg = $loadCfg(arguments.opts);
         var dryRun = arguments.opts.dryRun ?: false;
         arrayClear(variables.dryRunBuffer);
         var lock = new cli.lucli.services.deploy.commands.LockCommands(cfg);
         $dispatchAny($allHosts(cfg), lock.status(), dryRun);
+        return $renderResult(arguments.opts, "Checked deploy lock status for " & cfg.service());
+    }
+
+    private string function $renderResult(required struct opts, required string summary) {
+        if (arguments.opts.dryRun ?: false) {
+            return arrayToList(variables.dryRunBuffer, chr(10));
+        }
+        return arguments.summary;
     }
 
     private any function $loadCfg(required struct opts) {

--- a/cli/lucli/services/deploy/cli/DeployMainCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployMainCli.cfc
@@ -51,7 +51,7 @@ component {
         });
     }
 
-    public void function deploy(required struct opts) {
+    public string function deploy(required struct opts) {
         arrayClear(variables.dryRunBuffer);
         var cfg = variables.loader.load(
             arguments.opts.configPath,
@@ -111,13 +111,19 @@ component {
             $fireHook(hooks, "post-deploy-failure", hookEnv, dryRun);
             rethrow;
         }
+
+        return $renderResult(
+            arguments.opts,
+            "Deployed " & cfg.service() & " version " & ver
+                & " to " & arrayLen(hosts) & " host(s): " & arrayToList(hosts, ", ")
+        );
     }
 
-    public void function redeploy(required struct opts) {
-        deploy(arguments.opts);
+    public string function redeploy(required struct opts) {
+        return deploy(arguments.opts);
     }
 
-    public void function rollback(required struct opts) {
+    public string function rollback(required struct opts) {
         arrayClear(variables.dryRunBuffer);
         if (!len(arguments.opts.version ?: "")) {
             throw(
@@ -129,6 +135,7 @@ component {
         var app = new cli.lucli.services.deploy.commands.AppCommands(cfg);
         var proxy = new cli.lucli.services.deploy.commands.ProxyCommands(cfg);
         var dryRun = arguments.opts.dryRun ?: false;
+        var hostList = [];
         for (var role in cfg.roles()) {
             for (var host in role.hosts()) {
                 $dispatch([host], app.start(role, arguments.opts.version), dryRun);
@@ -137,13 +144,20 @@ component {
                     proxy.deploy(role, app.container_name(role, arguments.opts.version) & ":3000"),
                     dryRun
                 );
+                arrayAppend(hostList, host);
             }
         }
+
+        return $renderResult(
+            arguments.opts,
+            "Rolled back " & cfg.service() & " to version " & arguments.opts.version
+                & " on " & arrayLen(hostList) & " host(s): " & arrayToList(hostList, ", ")
+        );
     }
 
-    public void function setup(required struct opts) {
+    public string function setup(required struct opts) {
         // Phase 2 will add accessory boot; for Phase 1 this equals deploy.
-        deploy(arguments.opts);
+        return deploy(arguments.opts);
     }
 
     /**
@@ -161,7 +175,11 @@ component {
         var hosts = $allHosts(cfg);
         var dryRun = arguments.opts.dryRun ?: false;
         $dispatch(hosts, cmd, dryRun);
-        return arrayToList(variables.dryRunBuffer, chr(10));
+        return $renderResult(
+            arguments.opts,
+            "Tailed audit log (last " & tail & " lines) on "
+                & arrayLen(hosts) & " host(s): " & arrayToList(hosts, ", ")
+        );
     }
 
     /**
@@ -214,14 +232,18 @@ component {
                 $dispatch(acc.hosts(), accCmds.details(acc), dryRun);
             }
         }
-        return arrayToList(variables.dryRunBuffer, chr(10));
+        return $renderResult(
+            arguments.opts,
+            "Collected app + proxy + accessory details from "
+                & arrayLen(hosts) & " host(s): " & arrayToList(hosts, ", ")
+        );
     }
 
     /**
      * Destructive teardown. Requires --confirm. Chains app container
      * removal → proxy removal → accessory removal → registry logout.
      */
-    public void function remove(required struct opts) {
+    public string function remove(required struct opts) {
         if (!(arguments.opts.confirm ?: false)) {
             throw(
                 type = "DeployMainCli.RemoveNotConfirmed",
@@ -259,6 +281,12 @@ component {
         }
         // Logout of registry.
         $dispatch(hosts, regCmds.logout(), dryRun);
+
+        return $renderResult(
+            arguments.opts,
+            "Removed " & cfg.service() & " and its containers from "
+                & arrayLen(hosts) & " host(s): " & arrayToList(hosts, ", ")
+        );
     }
 
     private array function $docsSections() {
@@ -329,6 +357,20 @@ component {
     }
 
     // ── Private helpers ────────────────────────────────────────────
+
+    /**
+     * Unified result renderer. In --dry-run mode, returns the buffered
+     * commands so the operator can inspect them. In real mode, returns
+     * the caller-supplied summary so the user gets visible confirmation
+     * that the deploy completed. Avoids the blank-string bug that occurs
+     * when Module.cfc wraps void verbs with dryRunOutput().
+     */
+    private string function $renderResult(required struct opts, required string summary) {
+        if (arguments.opts.dryRun ?: false) {
+            return arrayToList(variables.dryRunBuffer, chr(10));
+        }
+        return arguments.summary;
+    }
 
     private void function $dispatch(
         required array hosts,

--- a/cli/lucli/services/deploy/cli/DeployProxyCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployProxyCli.cfc
@@ -22,26 +22,28 @@ component {
 
     public array function dryRunOutput() { return variables.dryRunBuffer; }
 
-    public void function boot(required struct opts)    { $runOnAllHosts(arguments.opts, "boot"); }
-    public void function reboot(required struct opts)  { $runOnAllHosts(arguments.opts, "reboot"); }
-    public void function start(required struct opts)   { $runOnAllHosts(arguments.opts, "start"); }
-    public void function stop(required struct opts)    { $runOnAllHosts(arguments.opts, "stop"); }
-    public void function restart(required struct opts) { $runOnAllHosts(arguments.opts, "restart"); }
-    public void function details(required struct opts) { $runOnAllHosts(arguments.opts, "details"); }
-    public void function remove(required struct opts)  { $runOnAllHosts(arguments.opts, "remove"); }
+    public string function boot(required struct opts)    { return $runOnAllHosts(arguments.opts, "boot",    "Booted kamal-proxy"); }
+    public string function reboot(required struct opts)  { return $runOnAllHosts(arguments.opts, "reboot",  "Rebooted kamal-proxy"); }
+    public string function start(required struct opts)   { return $runOnAllHosts(arguments.opts, "start",   "Started kamal-proxy"); }
+    public string function stop(required struct opts)    { return $runOnAllHosts(arguments.opts, "stop",    "Stopped kamal-proxy"); }
+    public string function restart(required struct opts) { return $runOnAllHosts(arguments.opts, "restart", "Restarted kamal-proxy"); }
+    public string function details(required struct opts) { return $runOnAllHosts(arguments.opts, "details", "Collected kamal-proxy details"); }
+    public string function remove(required struct opts)  { return $runOnAllHosts(arguments.opts, "remove",  "Removed kamal-proxy"); }
 
-    public void function logs(required struct opts) {
+    public string function logs(required struct opts) {
         var tail = arguments.opts.tail ?: 100;
-        $runOnAllHostsWithArg(arguments.opts, "logs", {tail: tail});
+        var n = $runOnAllHostsWithArg(arguments.opts, "logs", {tail: tail});
+        return $renderResult(arguments.opts, "Tailed kamal-proxy logs on " & n & " host(s)");
     }
 
     // ── Private plumbing ───────────────────────────────────────
 
-    private void function $runOnAllHosts(required struct opts, required string method) {
-        $runOnAllHostsWithArg(arguments.opts, arguments.method, {});
+    private string function $runOnAllHosts(required struct opts, required string method, required string verbLabel) {
+        var n = $runOnAllHostsWithArg(arguments.opts, arguments.method, {});
+        return $renderResult(arguments.opts, arguments.verbLabel & " on " & n & " host(s)");
     }
 
-    private void function $runOnAllHostsWithArg(required struct opts, required string method, required struct methodOpts) {
+    private numeric function $runOnAllHostsWithArg(required struct opts, required string method, required struct methodOpts) {
         arrayClear(variables.dryRunBuffer);
         var cfg = variables.loader.load(
             arguments.opts.configPath,
@@ -54,6 +56,14 @@ component {
             ? invoke(proxyCmds, arguments.method)
             : invoke(proxyCmds, arguments.method, [arguments.methodOpts]);
         $dispatch(hosts, cmdStr, dryRun);
+        return arrayLen(hosts);
+    }
+
+    private string function $renderResult(required struct opts, required string summary) {
+        if (arguments.opts.dryRun ?: false) {
+            return arrayToList(variables.dryRunBuffer, chr(10));
+        }
+        return arguments.summary;
     }
 
     private array function $allHosts(required any cfg) {

--- a/cli/lucli/services/deploy/cli/DeployPruneCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployPruneCli.cfc
@@ -13,11 +13,11 @@ component {
 
     public array function dryRunOutput() { return variables.dryRunBuffer; }
 
-    public void function all(required struct opts)        { $runOnAllHosts(arguments.opts, "all"); }
-    public void function images(required struct opts)     { $runOnAllHosts(arguments.opts, "images"); }
-    public void function containers(required struct opts) { $runOnAllHosts(arguments.opts, "containers"); }
+    public string function all(required struct opts)        { return $runOnAllHosts(arguments.opts, "all",        "Pruned all (images + containers)"); }
+    public string function images(required struct opts)     { return $runOnAllHosts(arguments.opts, "images",     "Pruned images"); }
+    public string function containers(required struct opts) { return $runOnAllHosts(arguments.opts, "containers", "Pruned containers"); }
 
-    private void function $runOnAllHosts(required struct opts, required string method) {
+    private string function $runOnAllHosts(required struct opts, required string method, required string verbLabel) {
         arrayClear(variables.dryRunBuffer);
         var cfg = variables.loader.load(
             arguments.opts.configPath,
@@ -36,6 +36,17 @@ component {
 
         var hosts = $allHosts(cfg);
         $dispatch(hosts, cmdStr, dryRun);
+        return $renderResult(
+            arguments.opts,
+            arguments.verbLabel & " on " & arrayLen(hosts) & " host(s) (keep=" & keep & ")"
+        );
+    }
+
+    private string function $renderResult(required struct opts, required string summary) {
+        if (arguments.opts.dryRun ?: false) {
+            return arrayToList(variables.dryRunBuffer, chr(10));
+        }
+        return arguments.summary;
     }
 
     private array function $allHosts(required any cfg) {

--- a/cli/lucli/services/deploy/cli/DeployRegistryCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployRegistryCli.cfc
@@ -19,14 +19,14 @@ component {
 
     public array function dryRunOutput() { return variables.dryRunBuffer; }
 
-    public void function setup(required struct opts)  { login(arguments.opts); }
-    public void function login(required struct opts)  { $runLogin(arguments.opts, true); }
-    public void function logout(required struct opts) { $runLogin(arguments.opts, false); }
-    public void function remove(required struct opts) { logout(arguments.opts); }
+    public string function setup(required struct opts)  { return login(arguments.opts); }
+    public string function login(required struct opts)  { return $runLogin(arguments.opts, true); }
+    public string function logout(required struct opts) { return $runLogin(arguments.opts, false); }
+    public string function remove(required struct opts) { return logout(arguments.opts); }
 
     // ── Private plumbing ───────────────────────────────────────
 
-    private void function $runLogin(required struct opts, required boolean isLogin) {
+    private string function $runLogin(required struct opts, required boolean isLogin) {
         arrayClear(variables.dryRunBuffer);
         var cfg = variables.loader.load(
             arguments.opts.configPath,
@@ -39,6 +39,19 @@ component {
             ? regCmds.login({password: arguments.opts.password ?: $resolvePassword(cfg)})
             : regCmds.logout();
         $dispatch(hosts, cmd, dryRun);
+        var action = arguments.isLogin ? "Logged into" : "Logged out of";
+        return $renderResult(
+            arguments.opts,
+            action & " registry " & cfg.registry().server()
+                & " on " & arrayLen(hosts) & " host(s)"
+        );
+    }
+
+    private string function $renderResult(required struct opts, required string summary) {
+        if (arguments.opts.dryRun ?: false) {
+            return arrayToList(variables.dryRunBuffer, chr(10));
+        }
+        return arguments.summary;
     }
 
     private string function $resolvePassword(required any cfg) {

--- a/cli/lucli/services/deploy/cli/DeployServerCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployServerCli.cfc
@@ -16,7 +16,7 @@ component {
 
     public array function dryRunOutput() { return variables.dryRunBuffer; }
 
-    public void function exec(required struct opts) {
+    public string function exec(required struct opts) {
         if (!len(arguments.opts.cmd ?: "")) {
             throw(type="DeployServerCli.MissingCommand",
                   message="server exec requires a command (opts.cmd)");
@@ -26,15 +26,31 @@ component {
         arrayClear(variables.dryRunBuffer);
         var hosts = $filteredHosts(cfg, arguments.opts.host ?: "");
         $dispatch(hosts, arguments.opts.cmd, dryRun);
+        return $renderResult(
+            arguments.opts,
+            "Ran '" & arguments.opts.cmd & "' on " & arrayLen(hosts) & " host(s): "
+                & arrayToList(hosts, ", ")
+        );
     }
 
-    public void function bootstrap(required struct opts) {
+    public string function bootstrap(required struct opts) {
         var cfg = $loadCfg(arguments.opts);
         var dryRun = arguments.opts.dryRun ?: false;
         arrayClear(variables.dryRunBuffer);
         var hosts = $allHosts(cfg);
         var cmd = "which docker >/dev/null 2>&1 || curl -fsSL https://get.docker.com | sh";
         $dispatch(hosts, cmd, dryRun);
+        return $renderResult(
+            arguments.opts,
+            "Bootstrapped Docker on " & arrayLen(hosts) & " host(s): " & arrayToList(hosts, ", ")
+        );
+    }
+
+    private string function $renderResult(required struct opts, required string summary) {
+        if (arguments.opts.dryRun ?: false) {
+            return arrayToList(variables.dryRunBuffer, chr(10));
+        }
+        return arguments.summary;
     }
 
     private any function $loadCfg(required struct opts) {

--- a/cli/lucli/tests/specs/deploy/cli/DeployAppCliSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/cli/DeployAppCliSpec.cfc
@@ -77,6 +77,25 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 expect(out).toInclude("docker stop");
                 expect(out).toInclude("[1.2.3.4]");
             });
+
+            // Regression for issue #2230 — the real-mode path must return a
+            // visible success summary, not an empty string.
+
+            it("boot (real mode) returns a non-empty success summary", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var cli = new cli.lucli.services.deploy.cli.DeployAppCli(fake);
+                var out = cli.boot({configPath: variables.fixture, version: "v1"});
+                expect(len(out)).toBeGT(0);
+                expect(out).toInclude("Booted");
+            });
+
+            it("stop --dry-run returns the buffered command list", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var cli = new cli.lucli.services.deploy.cli.DeployAppCli(fake);
+                var out = cli.stop({configPath: variables.fixture, version: "v1", dryRun: true});
+                expect(len(out)).toBeGT(0);
+                expect(out).toInclude("docker stop");
+            });
         });
     }
 

--- a/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
@@ -270,6 +270,76 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 expect($anyInclude(cmds, "docker stop kamal-proxy")).toBeTrue();
                 expect($anyInclude(cmds, "docker logout")).toBeTrue();
             });
+
+            // Regression tests for issue #2230 — deploy verbs returned a blank
+            // string in real (non-dry-run) mode because Module.cfc wrapped the
+            // void methods with dryRunOutput(), which is only populated during
+            // dry-run. Real deploys must return a visible success summary;
+            // dry-run must continue to return the buffered command list.
+
+            it("deploy (real mode) returns a non-empty success summary", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                var out = dc.deploy({configPath: variables.fixture, version: "v1"});
+                expect(len(out)).toBeGT(0);
+                expect(out).toInclude("Deployed");
+                expect(out).toInclude("demo");
+                expect(out).toInclude("v1");
+            });
+
+            it("deploy --dry-run returns the buffered command list", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                var out = dc.deploy({
+                    configPath: variables.fixture,
+                    dryRun: true,
+                    version: "v1"
+                });
+                expect(len(out)).toBeGT(0);
+                expect(out).toInclude("docker pull");
+            });
+
+            it("rollback (real mode) returns a non-empty success summary", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                var out = dc.rollback({configPath: variables.fixture, version: "v-old"});
+                expect(len(out)).toBeGT(0);
+                expect(out).toInclude("Rolled back");
+                expect(out).toInclude("v-old");
+            });
+
+            it("setup (real mode) returns a non-empty success summary", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                var out = dc.setup({configPath: variables.fixture, version: "v1"});
+                expect(len(out)).toBeGT(0);
+                expect(out).toInclude("Deployed");
+            });
+
+            it("audit (real mode) returns a non-empty success summary", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                var out = dc.audit({configPath: variables.fixture});
+                expect(len(out)).toBeGT(0);
+                expect(out).toInclude("audit log");
+            });
+
+            it("details (real mode) returns a non-empty success summary", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                var out = dc.details({configPath: variables.fixture});
+                expect(len(out)).toBeGT(0);
+                expect(out).toInclude("details");
+            });
+
+            it("remove --confirm (real mode) returns a non-empty success summary", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                var out = dc.remove({configPath: variables.fixture, confirm: true});
+                expect(len(out)).toBeGT(0);
+                expect(out).toInclude("Removed");
+                expect(out).toInclude("demo");
+            });
         });
     }
 


### PR DESCRIPTION
## Summary

- Every deploy subcommand in `cli/lucli/Module.cfc` returned `arrayToList(cli.dryRunOutput(), chr(10))` unconditionally. The buffer is only populated in `--dry-run` mode, so real deploys returned a blank string and the operator had no visible confirmation.
- Change every public verb in the 9 `Deploy*Cli` classes from `void` → `string`, ending with a private `$renderResult(opts, summary)` helper: returns the dry-run buffer when `opts.dryRun` is truthy, otherwise a user-facing summary. Simplify the 16 `Module.cfc` dispatch sites accordingly.
- Also fixes the same inline bug in `DeployMainCli.audit()` and `details()` (they ended with `return arrayToList(variables.dryRunBuffer, chr(10))`).

Closes #2230.

## Acceptance

- [x] `wheels deploy` (no flag) prints a visible success confirmation — e.g. `Deployed demo version v1 to 1 host(s): 1.2.3.4`
- [x] `wheels deploy --dry-run` continues to print the command list
- [x] Same behavior across all subverbs: `deploy/redeploy/rollback/setup/audit/details/remove/app.*/proxy.*/accessory.*/build.*/prune/lock/server`

## Test plan

- [x] Added 9 regression specs across `DeployMainCliSpec` and `DeployAppCliSpec` covering both real-mode (non-empty summary) and dry-run (buffered command list)
- [x] Full CLI suite: `bash tools/test-cli-local.sh` → **375 pass, 0 fail, 0 error** (up from 366; +9 new tests, zero regressions)
- [ ] CI compat matrix green across engine/database combos