### PR TITLE
fix(config): read framework version from box.json (closes #2232)

### DIFF
--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -2753,6 +2753,40 @@ return local.$wheels;
 		return local.rv;
 	}
 
+	public string function $readFrameworkVersion(string boxJsonPath = "") {
+		local.path = Len(arguments.boxJsonPath)
+			? arguments.boxJsonPath
+			: GetDirectoryFromPath(GetCurrentTemplatePath()) & "box.json";
+		if (!FileExists(local.path)) {
+			Throw(
+				type = "Wheels.VersionReadFailed",
+				message = "Framework box.json not found at #local.path#.",
+				extendedInfo = "This file is expected to ship with the framework. A distributed copy of Wheels should always contain it."
+			);
+		}
+		try {
+			local.contents = FileRead(local.path);
+			local.box = DeserializeJSON(local.contents);
+		} catch (any e) {
+			Throw(
+				type = "Wheels.VersionReadFailed",
+				message = "Framework box.json at #local.path# could not be parsed as JSON.",
+				extendedInfo = e.message
+			);
+		}
+		if (!IsStruct(local.box) || !StructKeyExists(local.box, "version") || !Len(local.box.version)) {
+			Throw(
+				type = "Wheels.VersionReadFailed",
+				message = "Framework box.json at #local.path# is missing a non-empty 'version' key.",
+				extendedInfo = "The release build pipeline substitutes @build.version@; a dev checkout should still define the key with the placeholder."
+			);
+		}
+		if (local.box.version == "@build.version@") {
+			return "0.0.0-dev";
+		}
+		return local.box.version;
+	}
+
 	public string function $checkMinimumVersion(required string engine, required string version) {
 		local.rv = "";
 		local.version = Replace(arguments.version, ".", ",", "all");

--- a/vendor/wheels/box.json
+++ b/vendor/wheels/box.json
@@ -1,4 +1,5 @@
 {
+    "version":"@build.version@",
     "testbox":{
         "runner":"/tests/runner.cfm"
     }

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -81,8 +81,7 @@ component {
 		request.cgi = application.wo.$cgiScope();
 
 		// Set up containers for routes, caches, settings etc.
-		// TODO remove the static version number
-		application.$wheels.version = "4.0.0";
+		application.$wheels.version = application.wo.$readFrameworkVersion();
 		try {
 			application.$wheels.hostName = CreateObject("java", "java.net.InetAddress").getLocalHost().getHostName();
 		} catch (any e) {

--- a/vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc
+++ b/vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc
@@ -1,0 +1,81 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo;
+
+		describe("Framework version resolution", () => {
+
+			it("exposes application.wheels.version as a non-empty string after boot", () => {
+				expect(StructKeyExists(application.wheels, "version")).toBeTrue();
+				expect(Len(application.wheels.version) > 0).toBeTrue("application.wheels.version is empty");
+			});
+
+			it("does not expose the literal unreplaced build placeholder at runtime", () => {
+				expect(application.wheels.version).notToBe("@build.version@");
+			});
+
+			it("$readFrameworkVersion reads the version key from a box.json file", () => {
+				var tmp = getTempDirectory() & "wheels-version-#CreateUUID()#.json";
+				fileWrite(tmp, '{"version":"4.1.2"}');
+				try {
+					expect(g.$readFrameworkVersion(tmp)).toBe("4.1.2");
+				} finally {
+					fileDelete(tmp);
+				}
+			});
+
+			it("$readFrameworkVersion substitutes a dev sentinel when version is the unreplaced build placeholder", () => {
+				var tmp = getTempDirectory() & "wheels-version-#CreateUUID()#.json";
+				fileWrite(tmp, '{"version":"@build.version@"}');
+				try {
+					expect(g.$readFrameworkVersion(tmp)).toBe("0.0.0-dev");
+				} finally {
+					fileDelete(tmp);
+				}
+			});
+
+			it("$readFrameworkVersion throws Wheels.VersionReadFailed when the file is missing", () => {
+				var missing = getTempDirectory() & "wheels-version-missing-#CreateUUID()#.json";
+				var threw = false;
+				try {
+					g.$readFrameworkVersion(missing);
+				} catch (Wheels.VersionReadFailed e) {
+					threw = true;
+				}
+				expect(threw).toBeTrue("expected Wheels.VersionReadFailed when box.json is missing");
+			});
+
+			it("$readFrameworkVersion throws Wheels.VersionReadFailed when the JSON has no version key", () => {
+				var tmp = getTempDirectory() & "wheels-version-#CreateUUID()#.json";
+				fileWrite(tmp, '{"testbox":{"runner":"/tests/runner.cfm"}}');
+				var threw = false;
+				try {
+					g.$readFrameworkVersion(tmp);
+				} catch (Wheels.VersionReadFailed e) {
+					threw = true;
+				} finally {
+					fileDelete(tmp);
+				}
+				expect(threw).toBeTrue("expected Wheels.VersionReadFailed when version key is absent");
+			});
+
+			it("$readFrameworkVersion throws Wheels.VersionReadFailed when the JSON is malformed", () => {
+				var tmp = getTempDirectory() & "wheels-version-#CreateUUID()#.json";
+				fileWrite(tmp, "this is not json {");
+				var threw = false;
+				try {
+					g.$readFrameworkVersion(tmp);
+				} catch (Wheels.VersionReadFailed e) {
+					threw = true;
+				} finally {
+					fileDelete(tmp);
+				}
+				expect(threw).toBeTrue("expected Wheels.VersionReadFailed when box.json is malformed");
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary
- Introduces `$readFrameworkVersion()` in `vendor/wheels/Global.cfc` which reads the `version` key from `vendor/wheels/box.json` (sibling of `Global.cfc`).
- `onapplicationstart.cfc` now calls this helper instead of hardcoding `"4.0.0"`. TODO comment removed.
- `vendor/wheels/box.json` gets a `"version":"@build.version@"` key. `tools/build/scripts/prepare-core.sh` already runs `sed 's/@build.version@/${VERSION}/g'` across `.json|.cfm|.cfc` during release packaging, so a distributed framework carries its real version.
- Dev checkouts ship the `@build.version@` literal; the helper detects this and returns `"0.0.0-dev"`.
- Missing/unparseable box.json or missing `version` key → throws `Wheels.VersionReadFailed` loudly (per issue spec: _"fail loudly — but this should never happen in a distributed copy"_).
- Adds `vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc` with 7 specs covering runtime post-condition, happy path, placeholder detection, and three failure modes.

Closes #2232.

## Acceptance criteria (from issue)
- [x] `application.wheels.version` matches `box.json` `version` field at runtime (confirmed via `/wheels/cli` → `wheelsVersion: 0.0.0-dev`).
- [x] No hardcoded `4.0.0` in CFML source (`grep -rn '"4\.0\.0"' vendor/wheels/` → empty).
- [x] TODO comment gone.
- [x] Release tooling only needs to bump `box.json` — no code edit required for 4.0.1+.

## Test plan
- [x] Full core suite on Lucee 7 + SQLite: **3258 pass, 0 fail, 0 error** (baseline had 7 pre-existing pagination flakes in `linksSpec` that happened to pass this run; no new failures).
- [x] Runtime check: `curl /wheels/cli` → `wheelsVersion: 0.0.0-dev` (placeholder correctly translated).
- [x] Grep: no `"4.0.0"` string literal remains in `vendor/wheels/`.
- [ ] CI matrix (Lucee 5/6/7, Adobe 2018/2021/2023/2025, BoxLang × databases) — pending green check.

## Cross-engine notes
Uses only portable CFML built-ins: `FileExists`, `FileRead`, `DeserializeJSON`, `GetCurrentTemplatePath`, `GetDirectoryFromPath`, `Throw`. No engine-specific APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)