### PR TITLE
ci(test): activate browser-test CI gate and root-fix route table leaks (#2234)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,7 @@ jobs:
       LUCLI_VERSION: "0.3.7"
       WHEELS_CI: "true"
       WHEELS_BROWSER_TEST_BASE_URL: "http://localhost:60007"
+      WHEELS_BROWSER_CI_ENABLE: "true"
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       WHEELS_CI: "true"
       WHEELS_BROWSER_TEST_BASE_URL: "http://localhost:60007"
+      WHEELS_BROWSER_CI_ENABLE: "true"
     steps:
       - uses: actions/checkout@v5
 

--- a/tools/ci/run-tests.sh
+++ b/tools/ci/run-tests.sh
@@ -37,7 +37,7 @@ fi
 
 # --- Warm up Wheels application ---
 echo "Warming up Wheels application..."
-curl -s -o /dev/null --max-time 120 "${BASE_URL}/?reload=true&password=wheels_test_password" || true
+curl -s -o /dev/null --max-time 120 "${BASE_URL}/?reload=true&password=wheels-dev" || true
 sleep 2
 
 # --- Run tests ---

--- a/vendor/wheels/tests/specs/dispatch/findMatchingRouteMegaSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/findMatchingRouteMegaSpec.cfc
@@ -3,6 +3,7 @@ component extends="wheels.WheelsTest" {
 	function beforeAll() {
 		_originalRoutes = Duplicate(application.wheels.routes)
 		_originalStaticRoutes = StructKeyExists(application.wheels, "staticRoutes") ? StructCopy(application.wheels.staticRoutes) : {}
+		_originalNamedRoutePositions = StructKeyExists(application.wheels, "namedRoutePositions") ? StructCopy(application.wheels.namedRoutePositions) : {}
 		nounPlurals = [
 			"people",
 			"dogs",
@@ -83,6 +84,7 @@ component extends="wheels.WheelsTest" {
 	function afterAll() {
 		application.wheels.routes = _originalRoutes
 		application.wheels.staticRoutes = _originalStaticRoutes
+		application.wheels.namedRoutePositions = _originalNamedRoutePositions
 	}
 	
 	function run() {

--- a/vendor/wheels/tests/specs/global/urlforSpec.cfc
+++ b/vendor/wheels/tests/specs/global/urlforSpec.cfc
@@ -11,6 +11,7 @@ component extends="wheels.WheelsTest" {
 				_params = {controller = "test", action = "index"}
 				_originalRoutes = Duplicate(application.wheels.routes)
 				_originalStaticRoutes = StructKeyExists(application.wheels, "staticRoutes") ? StructCopy(application.wheels.staticRoutes) : {}
+				_originalNamedRoutePositions = StructKeyExists(application.wheels, "namedRoutePositions") ? StructCopy(application.wheels.namedRoutePositions) : {}
 				_originalUrlRewriting = application.wheels.URLRewriting
 				_originalObfuscateUrls = application.wheels.obfuscateUrls
 			})
@@ -18,6 +19,7 @@ component extends="wheels.WheelsTest" {
 			afterEach(() => {
 				application.wheels.routes = _originalRoutes
 				application.wheels.staticRoutes = _originalStaticRoutes
+				application.wheels.namedRoutePositions = _originalNamedRoutePositions
 				application.wheels.URLRewriting = _originalUrlRewriting
 				application.wheels.obfuscateUrls = _originalObfuscateUrls
 			})

--- a/vendor/wheels/tests/specs/mapperModernSpec.cfc
+++ b/vendor/wheels/tests/specs/mapperModernSpec.cfc
@@ -5,11 +5,13 @@ component extends="wheels.Testbox" {
 		_params = {controller = "test", action = "index"}
 		_originalRoutes = Duplicate(application.wheels.routes)
 		_originalStaticRoutes = StructKeyExists(application.wheels, "staticRoutes") ? StructCopy(application.wheels.staticRoutes) : {}
+		_originalNamedRoutePositions = StructKeyExists(application.wheels, "namedRoutePositions") ? StructCopy(application.wheels.namedRoutePositions) : {}
 	}
 
 	function afterAll() {
 		application.wheels.routes = _originalRoutes
 		application.wheels.staticRoutes = _originalStaticRoutes
+		application.wheels.namedRoutePositions = _originalNamedRoutePositions
 	}
 
 	function run() {

--- a/vendor/wheels/tests/specs/mapperSpec.cfc
+++ b/vendor/wheels/tests/specs/mapperSpec.cfc
@@ -5,11 +5,13 @@ component extends="wheels.WheelsTest" {
 		_params = {controller = "test", action = "index"}
 		_originalRoutes = Duplicate(application.wheels.routes)
 		_originalStaticRoutes = StructKeyExists(application.wheels, "staticRoutes") ? StructCopy(application.wheels.staticRoutes) : {}
+		_originalNamedRoutePositions = StructKeyExists(application.wheels, "namedRoutePositions") ? StructCopy(application.wheels.namedRoutePositions) : {}
 	}
 
 	function afterAll() {
 		application.wheels.routes = _originalRoutes
 		application.wheels.staticRoutes = _originalStaticRoutes
+		application.wheels.namedRoutePositions = _originalNamedRoutePositions
 	}
 
 	function run() {

--- a/vendor/wheels/tests/specs/security/PaginationXssSpec.cfc
+++ b/vendor/wheels/tests/specs/security/PaginationXssSpec.cfc
@@ -10,6 +10,7 @@ component extends="wheels.WheelsTest" {
 				_params = {controller = "dummy", action = "dummy"};
 				_controller = g.controller("dummy", _params);
 				_originalRoutes = Duplicate(application.wheels.routes);
+				_originalNamedRoutePositions = StructKeyExists(application.wheels, "namedRoutePositions") ? StructCopy(application.wheels.namedRoutePositions) : {};
 				_originalRewrite = application.wheels.URLRewriting;
 				$clearRoutes();
 				g.mapper().$match(name = "pagination", pattern = "pag/ina/tion/[special]", to = "pagi##nation").end();
@@ -21,6 +22,7 @@ component extends="wheels.WheelsTest" {
 
 			afterEach(() => {
 				application.wheels.routes = _originalRoutes;
+				application.wheels.namedRoutePositions = _originalNamedRoutePositions;
 				application.wheels.URLRewriting = _originalRewrite;
 				g.set(functionName = "linkTo", encode = true);
 				g.set(functionName = "paginationLinks", encode = true);

--- a/vendor/wheels/tests/specs/view/formsSpec.cfc
+++ b/vendor/wheels/tests/specs/view/formsSpec.cfc
@@ -865,6 +865,7 @@ component extends="wheels.WheelsTest" {
 				request.$wheelsProtectedFromForgery = true
 				// Save and configure routes so "root" route is available
 				_savedRoutes = Duplicate(application.wheels.routes)
+				_savedNamedRoutePositions = StructKeyExists(application.wheels, "namedRoutePositions") ? StructCopy(application.wheels.namedRoutePositions) : {}
 				_savedRewrite = application.wheels.URLRewriting
 				application.wheels.URLRewriting = "On"
 				$clearRoutes()
@@ -880,6 +881,7 @@ component extends="wheels.WheelsTest" {
 				g.set(functionName = "startFormTag", encode = true)
 				request.$wheelsProtectedFromForgery = false
 				application.wheels.routes = _savedRoutes
+				application.wheels.namedRoutePositions = _savedNamedRoutePositions
 				application.wheels.URLRewriting = _savedRewrite
 			})
 

--- a/vendor/wheels/tests/specs/view/linksSpec.cfc
+++ b/vendor/wheels/tests/specs/view/linksSpec.cfc
@@ -11,6 +11,7 @@ component extends="wheels.WheelsTest" {
 				_controller = g.controller("dummy", _params)
 				_originalRoutes = Duplicate(application.wheels.routes)
 				_originalStaticRoutes = StructKeyExists(application.wheels, "staticRoutes") ? StructCopy(application.wheels.staticRoutes) : {}
+				_originalNamedRoutePositions = StructKeyExists(application.wheels, "namedRoutePositions") ? StructCopy(application.wheels.namedRoutePositions) : {}
 				_originalRewrite = application.wheels.URLRewriting
 				$clearRoutes()
 				g.mapper().$match(name = "pagination", pattern = "pag/ina/tion/[special]", to = "pagi##nation").end()
@@ -23,6 +24,7 @@ component extends="wheels.WheelsTest" {
 			afterEach(() => {
 				application.wheels.routes = _originalRoutes
 				application.wheels.staticRoutes = _originalStaticRoutes
+				application.wheels.namedRoutePositions = _originalNamedRoutePositions
 				application.wheels.URLRewriting = _originalRewrite
 				g.set(functionName = "linkTo", encode = true)
 				g.set(functionName = "paginationLinks", encode = true)

--- a/vendor/wheels/wheelstest/BrowserTest.cfc
+++ b/vendor/wheels/wheelstest/BrowserTest.cfc
@@ -57,18 +57,6 @@ component extends="wheels.WheelsTest" {
             return;
         }
 
-        // Browser specs depend on named fixture routes (browserTestHome,
-        // browserTestLogin, etc.) declared in vendor/wheels/tests/routes.cfm.
-        // Other specs in the suite (mapperSpec, security/PaginationXssSpec,
-        // view/formsSpec, view/linksSpec) legitimately clear the route table
-        // via `$clearRoutes()` to test route-registration behavior, and do
-        // not restore it afterwards. If those specs run before browser
-        // specs — which happens alphabetically in the core suite — the
-        // fixture routes are gone by the time browser specs execute.
-        // Re-include the test routes here so browser specs are self-contained.
-        application.wo.$include(template="/wheels/tests/routes.cfm");
-        application.wo.$setNamedRoutePositions();
-
         try {
             variables.$launcher = $ensureLauncher();
         } catch (Wheels.BrowserNotInstalled e) {


### PR DESCRIPTION
## Summary

- Flips `WHEELS_BROWSER_CI_ENABLE=true` in `pr.yml` + `snapshot.yml` so the 119 browser specs actually execute in CI (was silently skipping under `$isCiSkipEnabled()`).
- Root-fixes the `namedRoutePositions` leak in 7 specs that mutated routes without restoring the named-route index. This was the real cause behind `BrowserLoginSpec`/`BrowserRouteSpec` breakage when run alongside the rest of the suite.
- Removes the workaround route re-include in `BrowserTest.beforeAll()` — with the source leaks plugged, the base class no longer needs to paper over test pollution, and removing it turns future regressions into loud red builds instead of silent recoveries.
- Corrects the reload-password mismatch in `tools/ci/run-tests.sh` (`wheels_test_password` → `wheels-dev`) so the core warm-up actually reloads the app.

## Root cause

`$setNamedRoutePositions()` appends to `application.wheels.namedRoutePositions`. Two specs (`security/PaginationXssSpec`, `view/formsSpec`) explicitly zeroed that map in their `$clearRoutes()` helpers and rebuilt it for their own test routes, but their `afterEach`/`afterAll` restored only `application.wheels.routes` — not the positions index. By the time alphabetical ordering reached `wheelstest.BrowserLoginSpec` / `BrowserRouteSpec`, the positions map no longer contained `browserTestHome` / `browserTestLogin` / etc., so `urlFor(route=…)` threw `Wheels.RouteNotFound`.

Five other specs (`findMatchingRouteMegaSpec`, `urlforSpec`, `mapperModernSpec`, `mapperSpec`, `linksSpec`) had the same snapshot-without-positions shape. Bundled them into the same fix for defense in depth.

The `createDynamicProxy` concern from the issue proved stale — verified locally on LuCLI 0.3.5-SNAPSHOT / Lucee 7.0.0.395 (CI runs 0.3.7 after #2226), all 9 `BrowserDialogSpec` tests pass.

## Verification

- Full local suite: **3251 pass / 0 fail / 0 error** (6 browser bundles × 119 specs actually execute).
- Load-bearing check: temporarily reverted `PaginationXssSpec`'s positions snapshot → `BrowserLoginSpec` 6 errors, `BrowserRouteSpec` 5 errors (exact failure pattern from the issue). Restored → green. Proves the fix isn't coincidental and that Fix 3 surfaces regressions rather than hiding them.

## Test plan

- [x] Full local suite green (Lucee 7 + SQLite via LuCLI)
- [x] Browser bundles execute (not skip): 9+63+26+7+5+9 = 119 specs pass
- [x] Leak reproduced + fix proven by revert/re-apply
- [ ] `pr.yml` fast-test job shows browser specs executing in CI
- [ ] `snapshot.yml` browser specs executing in CI

Closes #2234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)