### PR TITLE
docs(plugin): declare v5.0 sunset for legacy plugins/ folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ### Deprecated
 
-- Legacy `plugins/` folder — superseded by the new `packages/` → `vendor/` activation model. Plugins still load, with a deprecation warning. (#1995)
+- Legacy `plugins/` folder — superseded by the new `packages/` → `vendor/` activation model. Plugins still load, with a deprecation warning. Scheduled for removal in v5.0. (#1995)
 - RocketUnit test style for new tests — BDD syntax (via WheelsTest) is required going forward. Existing RocketUnit specs continue to run. (#1925)
 - `wheels.Test` test base class — extend `wheels.WheelsTest` instead (#1889)
 - In-dev-server HTTP MCP endpoint at `/wheels/mcp` — superseded by the LuCLI stdio MCP server (`wheels mcp wheels`). Emits a deprecation warning to the `wheels_mcp` log on first request and advertises `deprecated: true` in the `serverInfo` handshake. Scheduled for removal in a future release. Migrate existing projects with `wheels mcp setup --force`.

--- a/docs/releases/blog-skeletons/02-upgrading-from-3x.md
+++ b/docs/releases/blog-skeletons/02-upgrading-from-3x.md
@@ -47,7 +47,7 @@ Use a consistent 4-part micro-template per item: **What changed / How to detect 
 - Link to LCA docs.
 
 ### 4. Deprecations to address (not breakers, but don't sleep on them)
-- **Legacy `plugins/` folder** ([#1995](https://github.com/wheels-dev/wheels/pull/1995)) — still works, warns on load. Plan a migration to `packages/` → `vendor/`.
+- **Legacy `plugins/` folder** ([#1995](https://github.com/wheels-dev/wheels/pull/1995)) — still works in 4.x with a deprecation warning; scheduled for removal in v5.0. Migrate to `packages/` → `vendor/` before upgrading to 5.x.
 - **Monolithic `paginationLinks()`** ([#1930](https://github.com/wheels-dev/wheels/pull/1930)) — retained for back-compat; new code should use `paginationNav()` or the composable helpers.
 - **`wheels.Test` extension** — retained; new specs extend `wheels.WheelsTest`.
 

--- a/vendor/wheels/Plugins.cfc
+++ b/vendor/wheels/Plugins.cfc
@@ -561,7 +561,7 @@ component output="false" extends="wheels.Global"{
 			local.pluginList = StructKeyList(variables.$class.plugins);
 			WriteLog(
 				type = "warning",
-				text = "[Wheels] The plugins/ directory is deprecated. Plugins found: #local.pluginList#. Move them to packages/ and activate by copying to vendor/. See: https://wheels.dev/docs/packages"
+				text = "[Wheels] The plugins/ directory is deprecated as of Wheels 4.0 and will be removed in Wheels 5.0. Plugins found: #local.pluginList#. Move them to packages/ and activate by copying to vendor/. See: https://wheels.dev/docs/packages"
 			);
 		}
 	}


### PR DESCRIPTION
## Summary
- Adds the v5.0 removal target to the `plugins/` deprecation warning (`vendor/wheels/Plugins.cfc`), CHANGELOG entry, and 3x→4x upgrade-guide skeleton so adopters can plan migration off the legacy folder.
- Uses the same phrasing (`Scheduled for removal in v5.0`) already used for the CommandBox `wheels-cli` deprecation (CHANGELOG.md:134) — consistent language across deprecations.

Closes #2251

## Scope notes
- **Out of scope** (deliberately): the separate "Mixin-only plugins will be deprecated in Wheels 4.0" warning at `Plugins.cfc:171` — different concern, different surface. Can be handled in its own pass.
- **Out of scope**: writing the standalone `packages/` migration how-to guide — tracked separately as P3 per the v4 GA architectural review. The existing `https://wheels.dev/docs/packages` link is kept in the warning as the forward-looking destination.
- Issue body referenced `Plugins.cfc:128-132`, but the actual warning lives in `$checkPluginsDeprecation()` at line 564; 128-132 is an unrelated `$pluginDelete` stub.

## Acceptance (from issue #2251)
- [x] Running an app with a `plugins/` directory prints a warning that includes "removed in 5.0" and a link to `https://wheels.dev/docs/packages`.
- [x] CHANGELOG and upgrade guide cite the same version (v5.0).

## Test plan
- [ ] CI full suite green (Lucee 5/6/7, Adobe 2018/2021/2023/2025, BoxLang × SQLite/MySQL/Postgres/MSSQL/CRDB).
- [ ] Browser-test CI gate green.
- [ ] `tools/test-local.sh` pass locally (no behavior change; warning text only).
- [ ] Spot-check: no tests asserting on the old warning string (confirmed via grep — none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)