### PR TITLE
docs(plugin): add user-facing readmes for basecoat and hotwire packages

### DIFF
--- a/packages/basecoat/README.md
+++ b/packages/basecoat/README.md
@@ -1,0 +1,139 @@
+# wheels-basecoat
+
+A Wheels package that ships CFML view helpers for [Basecoat UI](https://basecoatui.com) — shadcn/ui-quality components rendered as plain HTML + Tailwind CSS classes. No React, no build step. Works with or without [wheels-hotwire](../hotwire/README.md).
+
+## Requirements
+
+- Wheels 3.0+
+- Lucee 5+ or Adobe ColdFusion 2018+
+- Basecoat CSS (served from your app — see **Serving Basecoat CSS** below)
+
+## Installation
+
+```bash
+# Activate the package
+cp -r packages/basecoat vendor/basecoat
+
+# Restart or reload your app
+wheels reload
+```
+
+All `ui*` helpers become available in views and controllers via the package mixin system.
+
+## Configuration
+
+Basecoat has no `set()`-style application settings. Configuration is passed to helpers directly — the only helper with knobs is `basecoatIncludes()`:
+
+```cfml
+#basecoatIncludes(
+    alpine = true,
+    alpineVersion = "3",
+    basecoatCSSPath = "/plugins/basecoat/assets/basecoat/basecoat.min.css",
+    turboAware = true
+)#
+```
+
+| Argument | Default | Description |
+|---|---|---|
+| `alpine` | `true` | Include the Alpine.js CDN script (needed for dropdowns, dialogs with transitions, tabs). |
+| `alpineVersion` | `"3"` | Alpine.js major version. |
+| `basecoatCSSPath` | `"/plugins/basecoat/assets/basecoat/basecoat.min.css"` | Path to the Basecoat CSS file your app serves. |
+| `turboAware` | `true` | Emit the `<meta name="turbo-cache-control" content="no-preview">` tag — safe default when paired with wheels-hotwire. |
+
+### Serving Basecoat CSS
+
+This package ships helpers, not CSS assets. Grab `basecoat.min.css` from the [Basecoat UI releases](https://basecoatui.com) and serve it from your app — for example under `public/assets/basecoat.min.css` — then point `basecoatCSSPath` at it.
+
+## Usage
+
+### 1. Include CSS + JS in your layout
+
+```cfm
+<!-- app/views/layout.cfm -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>My App</title>
+    #basecoatIncludes(basecoatCSSPath="/assets/basecoat.min.css")#
+</head>
+<body>
+    #includeContent()#
+</body>
+</html>
+```
+
+### 2. Render components in views
+
+```cfm
+<!-- Buttons -->
+#uiButton(text="Save", variant="primary")#
+#uiButton(text="Cancel", variant="outline", href="/users")#
+#uiButton(text="Delete", variant="destructive", turboConfirm="Are you sure?")#
+
+<!-- Badges -->
+#uiBadge(text="Active", variant="default")#
+#uiBadge(text="Archived", variant="secondary")#
+
+<!-- Alert -->
+#uiAlert(title="Heads up", description="Your trial expires in 3 days.", variant="default")#
+
+<!-- Card (block component — remember uiCardEnd()) -->
+#uiCard()#
+    #uiCardHeader(title="Order ##1234", description="Placed 2 days ago")#
+    #uiCardContent()#
+        <p>Order details go here.</p>
+    #uiCardContentEnd()#
+    #uiCardFooter()#
+        #uiButton(text="View", href="/orders/1234")#
+    #uiCardFooterEnd()#
+#uiCardEnd()#
+
+<!-- Form field (handles label + input + error) -->
+#uiField(label="Email", name="user[email]", type="email", required=true)#
+#uiField(label="Bio", name="user[bio]", type="textarea", rows=4)#
+#uiField(label="Role", name="user[role]", type="select", options="admin:Admin,user:User")#
+```
+
+### 3. Component reference
+
+All helpers live on `Basecoat.cfc` and are injected into controllers and views.
+
+| Category | Helpers |
+|---|---|
+| Includes | `basecoatIncludes` |
+| Buttons & icons | `uiButton`, `uiBadge`, `uiIcon`, `uiSpinner`, `uiSkeleton`, `uiProgress`, `uiSeparator` |
+| Tooltip | `uiTooltip` / `uiTooltipEnd` |
+| Alert | `uiAlert` |
+| Card | `uiCard` / `uiCardHeader` / `uiCardContent` / `uiCardContentEnd` / `uiCardFooter` / `uiCardFooterEnd` / `uiCardEnd` |
+| Dialog | `uiDialog` / `uiDialogFooter` / `uiDialogEnd` |
+| Forms | `uiField` (text, email, textarea, select, checkbox, switch, …) |
+| Table | `uiTable` / `uiTableHeader` / `uiTableBody` / `uiTableRow` / `uiTableHead` / `uiTableCell` + matching `*End` helpers |
+| Tabs | `uiTabs` / `uiTabList` / `uiTabTrigger` / `uiTabContent` + matching `*End` helpers |
+| Dropdown | `uiDropdown` / `uiDropdownItem` / `uiDropdownSeparator` / `uiDropdownEnd` |
+| Pagination | `uiPagination` |
+| Layout | `uiBreadcrumb` / `uiBreadcrumbItem` / `uiBreadcrumbSeparator` / `uiBreadcrumbEnd`, `uiSidebar` / `uiSidebarSection` / `uiSidebarItem` + matching `*End` helpers |
+
+### Turbo-awareness
+
+Basecoat does not depend on wheels-hotwire, but its helpers are Turbo-friendly:
+
+- `uiButton()` accepts `turboConfirm` and `turboMethod` — emitted as `data-turbo-confirm` / `data-turbo-method` attributes and ignored when Turbo is absent.
+- `uiButton(close=true)` closes the enclosing `<dialog>` via the native `HTMLDialogElement.close()` API — no JS library required.
+- All block components generate markup that renders correctly inside `<turbo-frame>` elements.
+
+## Deactivating
+
+```bash
+rm -rf vendor/basecoat
+wheels reload
+```
+
+## Reference
+
+- `packages/basecoat/CLAUDE.md` — markup reference, naming conventions, component categories
+- `packages/basecoat/.ai/ARCHITECTURE.md` — design principles, phased component inventory
+- [Basecoat UI](https://basecoatui.com) — upstream CSS component library
+
+## License
+
+MIT

--- a/packages/hotwire/README.md
+++ b/packages/hotwire/README.md
@@ -1,0 +1,199 @@
+# wheels-hotwire
+
+A Wheels package that ships [Hotwire](https://hotwired.dev) infrastructure: Turbo Drive, Turbo Frames, Turbo Streams, Stimulus helpers, and Hotwire Native mobile support. This is the **interaction layer** — it has zero opinions about CSS or visual design. Pair it with [wheels-basecoat](../basecoat/README.md), your own design system, or none at all.
+
+## Requirements
+
+- Wheels 3.0+
+- Lucee 5+ or Adobe ColdFusion 2018+
+
+## Installation
+
+```bash
+# Activate the package
+cp -r packages/hotwire vendor/hotwire
+
+# Restart or reload your app
+wheels reload
+```
+
+All `turbo*`, `hotwire*`, `stimulus*`, and `is*` helpers become available in views and controllers via the package mixin system.
+
+## Configuration
+
+Hotwire has no `set()`-style application settings. The only helper with knobs is `hotwireIncludes()`:
+
+```cfml
+#hotwireIncludes(
+    turbo = true,
+    stimulus = true,
+    turboVersion = "8",
+    stimulusVersion = "3",
+    turboCacheControl = "no-preview"
+)#
+```
+
+| Argument | Default | Description |
+|---|---|---|
+| `turbo` | `true` | Include the Turbo ES module (`@hotwired/turbo`). |
+| `stimulus` | `true` | Include the Stimulus ES module and start a global `window.Stimulus` Application. |
+| `turboVersion` | `"8"` | Turbo major version served from jsDelivr. |
+| `stimulusVersion` | `"3"` | Stimulus major version served from jsDelivr. |
+| `turboCacheControl` | `"no-preview"` | Value for the `<meta name="turbo-cache-control">` tag. Pass an empty string to omit the tag. |
+
+## Usage
+
+### 1. Include Turbo + Stimulus in your layout
+
+```cfm
+<!-- app/views/layout.cfm -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>My App</title>
+    #hotwireIncludes()#
+</head>
+<body>
+    #includeContent()#
+</body>
+</html>
+```
+
+### 2. Opt a controller into Turbo Stream responses
+
+Detect the request, then respond with one or more streams using `renderTurboStream()`:
+
+```cfm
+component extends="Controller" {
+
+    function create() {
+        comment = model("Comment").create(params.comment);
+
+        if (isHotwireRequest()) {
+            // `content` is any HTML string — render a partial to a string first,
+            // or build markup inline as shown here.
+            renderTurboStream([
+                turboStreamAppend(target="comments-list", content="<li>#comment.body#</li>"),
+                turboStreamUpdate(target="comment-count", content="#model('Comment').count()# comments")
+            ]);
+            return;
+        }
+
+        redirectTo(action="index");
+    }
+}
+```
+
+Available stream actions map 1:1 to the Turbo spec: `turboStreamAppend`, `turboStreamPrepend`, `turboStreamReplace`, `turboStreamUpdate`, `turboStreamRemove`, `turboStreamBefore`, `turboStreamAfter`, `turboStreamRefresh`. `renderTurboStream()` sets the `text/vnd.turbo-stream.html` content type and aborts for you.
+
+### 3. Use Turbo Frames for scoped updates
+
+```cfm
+<!-- app/views/posts/show.cfm -->
+#turboFrame(id="post-#post.id#")#
+    <h1>#post.title#</h1>
+    <p>#post.body#</p>
+    #linkTo(text="Edit", route="editPost", key=post.id)#
+#turboFrameEnd()#
+
+<!-- Lazy-loaded frame -->
+#turboFrame(id="recent-activity", src=urlFor(controller="activity"), loading="lazy")#
+    <p>Loading…</p>
+#turboFrameEnd()#
+```
+
+### 4. Stimulus controller conventions
+
+Place Stimulus controllers in `public/controllers/` (or wherever your asset pipeline serves JS from) and register them against the global `window.Stimulus` application started by `hotwireIncludes()`:
+
+```js
+// public/controllers/clipboard_controller.js
+import { Controller } from "https://cdn.jsdelivr.net/npm/@hotwired/stimulus@3/+esm";
+
+export default class extends Controller {
+    static targets = ["source"];
+    copy() { navigator.clipboard.writeText(this.sourceTarget.value); }
+}
+
+window.Stimulus.register("clipboard", (await import("/controllers/clipboard_controller.js")).default);
+```
+
+Use the Stimulus convenience helpers to build data attributes without string-concat bugs:
+
+```cfm
+<div #stimulusController("clipboard")#>
+    <input #stimulusTarget(controller="clipboard", name="source")# value="Copy me" />
+    <button #stimulusAction("click->clipboard##copy")#>Copy</button>
+</div>
+```
+
+Available helpers: `stimulusController`, `stimulusAction`, `stimulusTarget`, `stimulusValue`.
+
+### 5. Hotwire Native navigation
+
+When a request comes from a Turbo Native iOS/Android shell, redirect through the special interception paths instead of a normal HTTP redirect. Each helper falls through to `redirectTo()` on web requests, so the same controller code works for both clients:
+
+```cfm
+function create() {
+    post = model("Post").create(params.post);
+
+    // Native: dismiss/pop. Web: redirect to index.
+    recedeOrRedirectTo(route="posts");
+}
+
+function update() {
+    post = model("Post").findByKey(params.key);
+    post.update(params.post);
+
+    // Native: refresh current screen. Web: redirect to show.
+    refreshOrRedirectTo(route="post", key=post.id);
+}
+```
+
+Available helpers: `recedeOrRedirectTo` (pops), `refreshOrRedirectTo` (reloads), `resumeOrRedirectTo` (no-op). Detect native requests directly with `hotwireNativeApp()`.
+
+### 6. Path configuration endpoint (Native)
+
+Serve a JSON document controlling navigation behavior in native apps:
+
+```cfm
+// In a controller action routed at GET /native/config
+function config() {
+    hotwireNativePathConfiguration(
+        settings = {
+            tabs: [
+                {title: "Home", path: "/dashboard", icon: "house"},
+                {title: "Orders", path: "/orders", icon: "list.clipboard"}
+            ]
+        }
+        // Sensible default rules are applied if `rules` is omitted —
+        // see hotwireNativePathConfiguration() for the defaults.
+    );
+}
+```
+
+## Request detection
+
+| Helper | Returns true when |
+|---|---|
+| `isHotwireRequest()` | `Accept` header contains `text/vnd.turbo-stream.html` |
+| `isTurboFrameRequest()` | `Turbo-Frame` request header is present |
+| `turboFrameRequestId()` | Returns the requesting frame's id (or `""`) |
+| `hotwireNativeApp()` | `User-Agent` contains `Turbo Native` |
+
+## Deactivating
+
+```bash
+rm -rf vendor/hotwire
+wheels reload
+```
+
+## Reference
+
+- `packages/hotwire/CLAUDE.md` — markup reference, helper inventory, naming conventions
+- `packages/hotwire/.ai/ARCHITECTURE.md` — detailed architecture notes
+- [Hotwire](https://hotwired.dev) — upstream documentation for Turbo, Stimulus, and Hotwire Native
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Closes #2250. Adds the two missing user-facing READMEs so `packages/basecoat/` and `packages/hotwire/` have parity with `packages/sentry/` and `packages/legacyadapter/`, and the registry/`/wheels/packages` UI renders them consistently.

- `packages/basecoat/README.md` — 139 lines. Documents `basecoatIncludes()` args, layout inclusion, component usage examples, and a full reference table for the 40+ shipped `ui*` helpers. Calls out Turbo-awareness without requiring wheels-hotwire.
- `packages/hotwire/README.md` — 199 lines. Documents `hotwireIncludes()` args, Turbo Stream controller responses (`renderTurboStream` + all 8 stream actions), Turbo Frames, Stimulus conventions, Hotwire Native navigation helpers, path configuration, and the request-detection predicates.

Both follow the sentry template's section order (Requirements → Installation → Configuration → Usage → Reference → License). Activation uses the current `vendor/` package model (matching legacyadapter).

### Accuracy checks

- Every helper and argument referenced was verified against `Basecoat.cfc` / `Hotwire.cfc` via grep.
- `uiField` select example uses the actual `"value:label,value:label"` CSV format (not array of structs).
- Turbo Stream controller example uses inline HTML strings to avoid implying `includePartial()` works in controller scope.

## Test plan

- [ ] CI runs pass (docs-only change, no code paths touched)
- [ ] Confirm both READMEs render correctly on github.com (markdown tables, code blocks)
- [ ] Follow-up (not in this PR): verify `wheels.dev/packages/<name>` and in-app `/wheels/packages` UI pick them up once this lands on `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)