### PR TITLE
fix(plugin): validate provides.mixins targets against allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,7 +365,7 @@ plugins/               # DEPRECATED: legacy plugins still work with warning
 }
 ```
 
-**`provides.mixins`**: Comma-delimited targets — `controller`, `view`, `model`, `global`, `none`. Determines which framework components receive the package's public methods. Default: `none` (explicit opt-in, unlike legacy plugins which default to `global`).
+**`provides.mixins`**: Comma-delimited targets from the allowlist `application,dispatch,controller,mapper,model,base,sqlserver,mysql,postgresql,h2,test`, plus the special values `global` (inject into all targets) and `none` (explicit opt-out). Determines which framework components receive the package's public methods. Default: `none` (explicit opt-in, unlike legacy plugins which default to `global`). Unknown targets (typos, `view`, `service`, etc.) are rejected with a clear error — view helpers belong in `controller` mixins since Wheels views execute in the controller's variables scope.
 
 ### Activating a Package
 

--- a/packages/basecoat/package.json
+++ b/packages/basecoat/package.json
@@ -5,7 +5,7 @@
 	"description": "Basecoat UI component helpers for Wheels. shadcn/ui-quality design using plain HTML + Tailwind CSS. No React required.",
 	"wheelsVersion": ">=3.0",
 	"provides": {
-		"mixins": "controller,view",
+		"mixins": "controller",
 		"services": [],
 		"middleware": []
 	},

--- a/packages/hotwire/package.json
+++ b/packages/hotwire/package.json
@@ -5,7 +5,7 @@
 	"description": "Hotwire infrastructure for Wheels: Turbo Drive, Turbo Frames, Turbo Streams, Stimulus helpers, and Hotwire Native mobile support",
 	"wheelsVersion": ">=3.0",
 	"provides": {
-		"mixins": "controller,view",
+		"mixins": "controller",
 		"services": [],
 		"middleware": []
 	},

--- a/vendor/wheels/PackageLoader.cfc
+++ b/vendor/wheels/PackageLoader.cfc
@@ -297,6 +297,11 @@ component output="false" {
 			local.mixinTargets = Trim(local.manifest.mixins);
 		}
 
+		// Validate declared mixin targets against the allowlist. Unknown targets
+		// (typos, unsupported names like "view") silently produce zero injection
+		// under the legacy behavior — reject them up front instead.
+		$validateMixinTargets(arguments.dirName, local.mixinTargets);
+
 		// Check for middleware
 		local.hasMiddleware = StructKeyExists(local.provides, "middleware")
 			&& IsArray(local.provides.middleware)
@@ -521,6 +526,40 @@ component output="false" {
 	public void function $invokeServiceProviderBoot(required struct app) {
 		for (local.pkgKey in variables.serviceProviders) {
 			variables.packages[local.pkgKey].boot(arguments.app);
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Mixin target validation
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Validates each declared mixin target against the known allowlist.
+	 * Accepts the special values "none" (explicit opt-out) and "global" (wildcard);
+	 * every other entry must match one of variables.mixableComponents. An unknown
+	 * entry (typo like "controler", or an unsupported target like "view") throws
+	 * so the package is recorded as failed instead of silently loading with zero
+	 * mixin injection.
+	 *
+	 * @pkgName  Package directory name, used in the error message
+	 * @targets  Raw mixin-target declaration from the manifest
+	 */
+	private void function $validateMixinTargets(required string pkgName, required string targets) {
+		local.normalized = LCase(Trim(arguments.targets));
+		if (!Len(local.normalized) || local.normalized == "none" || local.normalized == "global") {
+			return;
+		}
+		for (local.target in local.normalized) {
+			local.entry = Trim(local.target);
+			if (!Len(local.entry)) {
+				continue;
+			}
+			if (!ListFindNoCase(variables.mixableComponents, local.entry)) {
+				Throw(
+					type = "Wheels.PackageInvalidMixinTarget",
+					message = "Package '#arguments.pkgName#' declares unknown mixin target '#local.entry#'. Valid targets: #variables.mixableComponents#."
+				);
+			}
 		}
 	}
 

--- a/vendor/wheels/tests/_assets/packages/invalidmixin/Invalidmixin.cfc
+++ b/vendor/wheels/tests/_assets/packages/invalidmixin/Invalidmixin.cfc
@@ -1,0 +1,10 @@
+component {
+	public any function init() {
+		this.version = "1.0.0";
+		return this;
+	}
+
+	public string function $invalidmixinHelper() {
+		return "should-never-be-injected";
+	}
+}

--- a/vendor/wheels/tests/_assets/packages/invalidmixin/package.json
+++ b/vendor/wheels/tests/_assets/packages/invalidmixin/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "wheels-invalidmixin",
+	"version": "1.0.0",
+	"description": "Test fixture: declares unknown mixin target (typo)",
+	"provides": {
+		"mixins": "controler"
+	}
+}

--- a/vendor/wheels/tests/_assets/packages/invalidmixinview/Invalidmixinview.cfc
+++ b/vendor/wheels/tests/_assets/packages/invalidmixinview/Invalidmixinview.cfc
@@ -1,0 +1,10 @@
+component {
+	public any function init() {
+		this.version = "1.0.0";
+		return this;
+	}
+
+	public string function $invalidmixinviewHelper() {
+		return "should-never-be-injected";
+	}
+}

--- a/vendor/wheels/tests/_assets/packages/invalidmixinview/package.json
+++ b/vendor/wheels/tests/_assets/packages/invalidmixinview/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "wheels-invalidmixinview",
+	"version": "1.0.0",
+	"description": "Test fixture: declares a mixed valid+invalid mixin target list",
+	"provides": {
+		"mixins": "controller,view"
+	}
+}

--- a/vendor/wheels/tests/specs/PackageLoaderSpec.cfc
+++ b/vendor/wheels/tests/specs/PackageLoaderSpec.cfc
@@ -328,6 +328,80 @@ component extends="wheels.WheelsTest" {
 
 			});
 
+			describe("Mixin target validation", () => {
+
+				it("rejects packages with an unknown mixin target (typo)", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = fixturesPath,
+						componentPrefix = componentPrefix
+					);
+					var pkgs = loader.getPackages();
+					var failed = loader.getFailedPackages();
+
+					// invalidmixin declares "controler" (typo) — must not load
+					expect(pkgs).notToHaveKey("invalidmixin");
+
+					var foundInvalid = false;
+					var errorMessage = "";
+					for (var f in failed) {
+						if (f.name == "invalidmixin") {
+							foundInvalid = true;
+							errorMessage = f.error;
+						}
+					}
+					expect(foundInvalid).toBeTrue();
+					// Error must name the unknown target and list the allowlist
+					expect(errorMessage).toInclude("controler");
+					expect(errorMessage).toInclude("controller");
+				});
+
+				it("rejects packages whose target list contains any unknown entry", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = fixturesPath,
+						componentPrefix = componentPrefix
+					);
+					var pkgs = loader.getPackages();
+					var failed = loader.getFailedPackages();
+
+					// invalidmixinview declares "controller,view" — "view" is not mixable
+					expect(pkgs).notToHaveKey("invalidmixinview");
+
+					var foundInvalid = false;
+					var errorMessage = "";
+					for (var f in failed) {
+						if (f.name == "invalidmixinview") {
+							foundInvalid = true;
+							errorMessage = f.error;
+						}
+					}
+					expect(foundInvalid).toBeTrue();
+					expect(errorMessage).toInclude("view");
+				});
+
+				it("loads packages with valid single-target declarations", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = fixturesPath,
+						componentPrefix = componentPrefix
+					);
+					var pkgs = loader.getPackages();
+
+					// depA declares "controller" — a valid target
+					expect(pkgs).toHaveKey("depA");
+				});
+
+				it("accepts the special none target", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = fixturesPath,
+						componentPrefix = componentPrefix
+					);
+					var pkgs = loader.getPackages();
+
+					// nomixin declares "none" — must still load
+					expect(pkgs).toHaveKey("nomixin");
+				});
+
+			});
+
 			describe("Lazy loading", () => {
 
 				it("does not eagerly instantiate lazy packages", () => {


### PR DESCRIPTION
## Summary
- Adds `$validateMixinTargets()` to `PackageLoader` so packages declaring unknown mixin targets fail to load with a clear error instead of silently producing zero injection. Valid targets come from the existing `variables.mixableComponents` allowlist plus the special values `global` and `none`.
- Drops the silent-noop `"view"` target from `packages/basecoat/package.json` and `packages/hotwire/package.json`. Controller mixins already surface in views because Wheels views execute in the controller's variables scope, so helper availability is unchanged.
- Aligns the `provides.mixins` description in `CLAUDE.md` with the real allowlist and notes that `view` is not a valid target.
- Adds `invalidmixin` and `invalidmixinview` test fixtures plus a new `Mixin target validation` describe block in `PackageLoaderSpec.cfc` (4 cases).

Closes #2247.

### Before → after behavior
| Manifest | Before | After |
|---|---|---|
| `"mixins": "controler"` (typo) | package appears loaded, zero mixin injection | package recorded in `failedPackages` with error naming the unknown target |
| `"mixins": "controller,view"` | `controller` mixes; `view` silently ignored | package recorded in `failedPackages` (view not in allowlist) |
| `"mixins": "none"` or `"global"` | unchanged | unchanged |
| Valid single/multi target from allowlist | unchanged | unchanged |

## Test plan
- [x] RED: new tests fail against `develop` (2 of 4 fail because validator does not exist)
- [x] GREEN: `bash tools/test-local.sh` → 3300 pass / 0 fail / 0 error (Lucee 7 + SQLite)
- [ ] CI: full compat matrix (Lucee 5/6/7, Adobe 2018/2021/2023/2025, all DBs) green before merge
- [ ] Verify first-party packages `basecoat` and `hotwire` still load when copied into `vendor/` (manual smoke)

## Follow-ups (tracked as separate issues)
- Extend validation to the per-method `mixin` metadata override in `$collectMixins` (same typo-swallowing problem, narrower scope).
- `packages/basecoat/CLAUDE.md` and `packages/hotwire/CLAUDE.md` still claim mixins reach "view scope" directly; inaccurate but runtime-correct. Docs-only cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)