### PR TITLE
feat(plugin): detect and log mixin collisions across packages (#2245)

### DIFF
--- a/cli/lucli/services/Doctor.cfc
+++ b/cli/lucli/services/Doctor.cfc
@@ -29,6 +29,7 @@ component {
 		checkDatabaseConfig(results);
 		checkTestCoverage(results);
 		checkCliInstallFreshness(results);
+		checkMixinCollisions(results);
 
 		// Determine overall status
 		if (arrayLen(results.issues)) {
@@ -236,6 +237,163 @@ component {
 			"Installed CLI module at #variables.installedModuleRoot# diverges from this source checkout. "
 			& "Edits under cli/lucli/ will not take effect until you reinstall or replace the installed copy with a symlink."
 		);
+	}
+
+	/**
+	 * Static best-effort mixin collision scan for packages in vendor/ and
+	 * legacy plugins in plugins/. Reads manifests and regex-scans the main
+	 * CFC of each package for public-function declarations, mapping method
+	 * names to declared mixin targets. Reports method×target pairs that are
+	 * registered by more than one package/plugin unless the second source
+	 * acknowledged the override via provides.overrides.
+	 *
+	 * Limitations: regex-based, so unusual CFC shapes may under-detect; only
+	 * scans the main CFC (directory-name match) — included files and script-
+	 * imported functions are ignored. Runtime detection in PackageLoader is
+	 * authoritative; this check exists for pre-boot visibility.
+	 */
+	private void function checkMixinCollisions(required struct results) {
+		var vendorDir = variables.projectRoot & "/vendor";
+		var pluginsDir = variables.projectRoot & "/plugins";
+		var providers = {};
+
+		if (directoryExists(vendorDir)) {
+			for (var dirName in directoryList(vendorDir, false, "name")) {
+				if (lCase(dirName) == "wheels") continue;
+				var pkgPath = vendorDir & "/" & dirName;
+				if (!directoryExists(pkgPath)) continue;
+				var manifestPath = pkgPath & "/package.json";
+				if (!fileExists(manifestPath)) continue;
+				$recordProvidersFromManifest(providers, pkgPath, manifestPath, dirName, "package", "provides");
+			}
+		}
+
+		if (directoryExists(pluginsDir)) {
+			for (var dirName in directoryList(pluginsDir, false, "name")) {
+				var pluginPath = pluginsDir & "/" & dirName;
+				if (!directoryExists(pluginPath)) continue;
+				var manifestPath = pluginPath & "/plugin.json";
+				if (!fileExists(manifestPath)) continue;
+				$recordProvidersFromManifest(providers, pluginPath, manifestPath, dirName, "plugin", "");
+			}
+		}
+
+		var collisionCount = 0;
+		for (var key in providers) {
+			var entries = providers[key];
+			if (arrayLen(entries) < 2) continue;
+			// Static scan has no authoritative load order, so suppress the warning
+			// if ANY participant declared the method in provides.overrides — that
+			// signals someone is intentionally accepting the overlap. The runtime
+			// path in PackageLoader still enforces the stricter semantic.
+			var anyAcknowledged = false;
+			for (var entry in entries) {
+				if (entry.acknowledged) {
+					anyAcknowledged = true;
+					break;
+				}
+			}
+			if (anyAcknowledged) continue;
+			var first = entries[1];
+			for (var i = 2; i <= arrayLen(entries); i++) {
+				var second = entries[i];
+				collisionCount++;
+				arrayAppend(
+					arguments.results.warnings,
+					"Mixin collision: method '#second.method#' on '#second.target#' provided by #first.source# '#first.name#' is overwritten by #second.source# '#second.name#'. Acknowledge via provides.overrides to silence."
+				);
+				first = second;
+			}
+		}
+
+		if (collisionCount == 0 && (directoryExists(vendorDir) || directoryExists(pluginsDir))) {
+			arrayAppend(arguments.results.passed, "No static mixin collisions detected in vendor/ or plugins/");
+		}
+	}
+
+	/**
+	 * Reads a manifest + main CFC and appends provider records keyed by target+method.
+	 *
+	 * @providerStore Out-param struct keyed "target::method" → array of records
+	 * @providesKey   "provides" for packages (nested), "" for plugins (flat)
+	 */
+	private void function $recordProvidersFromManifest(
+		required struct providerStore,
+		required string pkgDir,
+		required string manifestPath,
+		required string name,
+		required string source,
+		required string providesKey
+	) {
+		var manifest = {};
+		try {
+			manifest = deserializeJSON(fileRead(arguments.manifestPath));
+		} catch (any e) {
+			return;
+		}
+		if (!isStruct(manifest)) return;
+
+		var provides = len(arguments.providesKey) && structKeyExists(manifest, arguments.providesKey) && isStruct(manifest[arguments.providesKey])
+			? manifest[arguments.providesKey]
+			: manifest;
+
+		var targetsRaw = "";
+		if (structKeyExists(provides, "mixins") && isSimpleValue(provides.mixins)) {
+			targetsRaw = trim(provides.mixins);
+		} else if (structKeyExists(manifest, "mixins") && isSimpleValue(manifest.mixins)) {
+			targetsRaw = trim(manifest.mixins);
+		}
+		if (!len(targetsRaw) || targetsRaw == "none") return;
+
+		var overrides = {};
+		if (structKeyExists(provides, "overrides") && isArray(provides.overrides)) {
+			for (var ov in provides.overrides) {
+				if (isSimpleValue(ov) && len(trim(ov))) overrides[lCase(trim(ov))] = true;
+			}
+		}
+
+		var cfcPath = arguments.pkgDir & "/" & arguments.name & ".cfc";
+		if (!fileExists(cfcPath)) {
+			var cfcs = directoryList(arguments.pkgDir, false, "name", "*.cfc");
+			if (!arrayLen(cfcs)) return;
+			cfcPath = arguments.pkgDir & "/" & cfcs[1];
+		}
+
+		var cfcSource = fileRead(cfcPath);
+		var lifecycleHooks = "init,onPluginLoad,onPluginActivate,register,boot";
+		var methods = {};
+		var pattern = "public\s+[a-zA-Z0-9_\[\]\.]+\s+function\s+([a-zA-Z0-9_\$]+)\s*\(";
+		var matches = reMatchNoCase(pattern, cfcSource);
+		for (var m in matches) {
+			var nameMatch = reFindNoCase(pattern, m, 1, true);
+			if (structKeyExists(nameMatch, "match") && arrayLen(nameMatch.match) >= 2) {
+				var methodName = nameMatch.match[2];
+				if (!listFindNoCase(lifecycleHooks, methodName)) {
+					methods[methodName] = true;
+				}
+			}
+		}
+
+		// Expand targets (global = all supported mixin component types)
+		var allTargets = "application,dispatch,controller,mapper,model,base,sqlserver,mysql,postgresql,h2,test";
+		var expanded = (targetsRaw == "global") ? allTargets : targetsRaw;
+		for (var target in expanded) {
+			target = trim(target);
+			if (!len(target) || !listFindNoCase(allTargets, target)) continue;
+			for (var methodName in methods) {
+				var key = target & "::" & methodName;
+				if (!structKeyExists(arguments.providerStore, key)) {
+					arguments.providerStore[key] = [];
+				}
+				arrayAppend(arguments.providerStore[key], {
+					name = arguments.name,
+					source = arguments.source,
+					target = target,
+					method = methodName,
+					acknowledged = structKeyExists(overrides, lCase(methodName))
+				});
+			}
+		}
 	}
 
 	// ── Path helpers ─────────────────────────────────────────

--- a/cli/lucli/services/Doctor.cfc
+++ b/cli/lucli/services/Doctor.cfc
@@ -362,22 +362,29 @@ component {
 		var cfcSource = fileRead(cfcPath);
 		var lifecycleHooks = "init,onPluginLoad,onPluginActivate,register,boot";
 		var methods = {};
-		var pattern = "public\s+[a-zA-Z0-9_\[\]\.]+\s+function\s+([a-zA-Z0-9_\$]+)\s*\(";
-		var matches = reMatchNoCase(pattern, cfcSource);
-		for (var m in matches) {
-			var nameMatch = reFindNoCase(pattern, m, 1, true);
-			if (structKeyExists(nameMatch, "match") && arrayLen(nameMatch.match) >= 2) {
-				var methodName = nameMatch.match[2];
-				if (!listFindNoCase(lifecycleHooks, methodName)) {
+		// Capture (access, methodName). Access and return type are both optional
+		// so we catch: `public string function x()`, `public function x()`,
+		// and the implicit-public `function x()`. Skip when access == "private".
+		var pattern = "\b(public|private|package|remote)?\s*(?:[a-zA-Z0-9_\[\]\.]+\s+)?function\s+([a-zA-Z0-9_\$]+)\s*\(";
+		var pos = 1;
+		while (true) {
+			var nameMatch = reFindNoCase(pattern, cfcSource, pos, true);
+			if (!structKeyExists(nameMatch, "pos") || !arrayLen(nameMatch.pos) || nameMatch.pos[1] == 0) break;
+			if (arrayLen(nameMatch.match) >= 3) {
+				var access = lCase(trim(nameMatch.match[2]));
+				var methodName = nameMatch.match[3];
+				if (access != "private" && !listFindNoCase(lifecycleHooks, methodName)) {
 					methods[methodName] = true;
 				}
 			}
+			pos = nameMatch.pos[1] + nameMatch.len[1];
 		}
 
-		// Expand targets (global = all supported mixin component types)
+		// Expand targets (global = all supported mixin component types).
+		// Wrap in listToArray so Adobe CF's for...in iterates elements, not chars.
 		var allTargets = "application,dispatch,controller,mapper,model,base,sqlserver,mysql,postgresql,h2,test";
 		var expanded = (targetsRaw == "global") ? allTargets : targetsRaw;
-		for (var target in expanded) {
+		for (var target in listToArray(expanded)) {
 			target = trim(target);
 			if (!len(target) || !listFindNoCase(allTargets, target)) continue;
 			for (var methodName in methods) {

--- a/cli/lucli/tests/specs/services/DoctorSpec.cfc
+++ b/cli/lucli/tests/specs/services/DoctorSpec.cfc
@@ -238,8 +238,104 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 			});
 
+			describe("checkMixinCollisions", () => {
+
+				it("reports passed when no packages/plugins exist", () => {
+					var root = makeProjectRoot();
+					var doctor = new cli.lucli.services.Doctor(projectRoot = root);
+					var results = doctor.runChecks();
+					var combined = arrayToList(results.warnings, " ");
+					expect(combined).notToInclude("Mixin collision");
+					directoryDelete(root, true);
+				});
+
+				it("reports passed when two packages provide non-overlapping methods", () => {
+					var root = makeProjectRoot();
+					makePackage(root, "pkgA", "controller", "$helperA", []);
+					makePackage(root, "pkgB", "controller", "$helperB", []);
+
+					var doctor = new cli.lucli.services.Doctor(projectRoot = root);
+					var results = doctor.runChecks();
+
+					var warningText = arrayToList(results.warnings, " ");
+					expect(warningText).notToInclude("Mixin collision");
+					var passedText = arrayToList(results.passed, " ");
+					expect(passedText).toInclude("No static mixin collisions");
+					directoryDelete(root, true);
+				});
+
+				it("warns when two packages provide the same method on the same target", () => {
+					var root = makeProjectRoot();
+					makePackage(root, "pkgA", "controller", "$shared", []);
+					makePackage(root, "pkgB", "controller", "$shared", []);
+
+					var doctor = new cli.lucli.services.Doctor(projectRoot = root);
+					var results = doctor.runChecks();
+
+					var warningText = arrayToList(results.warnings, " ");
+					expect(warningText).toInclude("Mixin collision");
+					expect(warningText).toInclude("$shared");
+					expect(warningText).toInclude("controller");
+					directoryDelete(root, true);
+				});
+
+				it("suppresses warning when overriding package declares provides.overrides", () => {
+					var root = makeProjectRoot();
+					makePackage(root, "pkgA", "controller", "$shared", []);
+					makePackage(root, "pkgB", "controller", "$shared", ["$shared"]);
+
+					var doctor = new cli.lucli.services.Doctor(projectRoot = root);
+					var results = doctor.runChecks();
+
+					var warningText = arrayToList(results.warnings, " ");
+					expect(warningText).notToInclude("Mixin collision");
+					directoryDelete(root, true);
+				});
+
+			});
+
 		});
 
+	}
+
+	// ── Mixin collision spec helpers ─────────────────────────
+
+	private string function makeProjectRoot() {
+		var root = getTempDirectory() & "wheels-collision-" & createUUID();
+		directoryCreate(root & "/vendor", true);
+		directoryCreate(root & "/config", true);
+		directoryCreate(root & "/app", true);
+		directoryCreate(root & "/app/controllers", true);
+		directoryCreate(root & "/app/models", true);
+		directoryCreate(root & "/app/views", true);
+		directoryCreate(root & "/public", true);
+		fileWrite(root & "/config/routes.cfm", "mapper().wildcard().end();");
+		fileWrite(root & "/config/settings.cfm", "set(dataSourceName='test');");
+		return root;
+	}
+
+	private void function makePackage(
+		required string root,
+		required string name,
+		required string target,
+		required string methodName,
+		required array overrides
+	) {
+		var pkgDir = arguments.root & "/vendor/" & arguments.name;
+		directoryCreate(pkgDir, true);
+		var manifest = {
+			"name": "wheels-" & arguments.name,
+			"version": "1.0.0",
+			"provides": {"mixins": arguments.target}
+		};
+		if (arrayLen(arguments.overrides)) {
+			manifest.provides.overrides = arguments.overrides;
+		}
+		fileWrite(pkgDir & "/package.json", serializeJSON(manifest));
+		fileWrite(
+			pkgDir & "/" & arguments.name & ".cfc",
+			'component { public any function init() { return this; } public string function ' & arguments.methodName & '() { return "x"; } }'
+		);
 	}
 
 	// ── Spec helpers ─────────────────────────────────────────

--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -2940,11 +2940,51 @@ return local.$wheels;
 		application[local.appKey].packageMeta = application[local.appKey].PackageLoaderObj.getPackageMeta();
 		application[local.appKey].failedPackages = application[local.appKey].PackageLoaderObj.getFailedPackages();
 
-		// Merge package mixins into the existing mixins struct (plugins loaded first, packages overlay)
+		// Ensure mixinCollisions exists (unset when no plugins loaded before packages)
+		if (!StructKeyExists(application[local.appKey], "mixinCollisions")) {
+			application[local.appKey].mixinCollisions = [];
+		}
+
+		// Carry forward any collisions the PackageLoader detected internally
+		for (local.c in application[local.appKey].PackageLoaderObj.getMixinCollisions()) {
+			ArrayAppend(application[local.appKey].mixinCollisions, local.c);
+		}
+
+		// Merge package mixins into the existing mixins struct (plugins loaded first, packages overlay).
+		// Detect cross-system collisions — a package method that shadows a plugin method on the
+		// same target — before StructAppend silently overwrites.
 		local.pkgMixins = application[local.appKey].PackageLoaderObj.getMixins();
+		local.pluginProviders = StructKeyExists(application[local.appKey], "PluginObj")
+			? application[local.appKey].PluginObj.getMethodProviders()
+			: {};
+		local.pkgProviders = application[local.appKey].PackageLoaderObj.$methodProviders();
 		for (local.target in local.pkgMixins) {
 			if (!StructKeyExists(application[local.appKey].mixins, local.target)) {
 				application[local.appKey].mixins[local.target] = {};
+			}
+			for (local.methodName in local.pkgMixins[local.target]) {
+				if (StructKeyExists(application[local.appKey].mixins[local.target], local.methodName)) {
+					local.pluginName = StructKeyExists(local.pluginProviders, local.target)
+						&& StructKeyExists(local.pluginProviders[local.target], local.methodName)
+						? local.pluginProviders[local.target][local.methodName]
+						: "(unknown plugin)";
+					local.pkgName = StructKeyExists(local.pkgProviders, local.target)
+						&& StructKeyExists(local.pkgProviders[local.target], local.methodName)
+						? local.pkgProviders[local.target][local.methodName]
+						: "(unknown package)";
+					ArrayAppend(application[local.appKey].mixinCollisions, {
+						target = local.target,
+						method = local.methodName,
+						firstProvider = local.pluginName,
+						secondProvider = local.pkgName,
+						acknowledged = false,
+						source = "cross"
+					});
+					WriteLog(
+						type = "warning",
+						text = "[Wheels] Cross-system mixin collision: method '#local.methodName#' on target '#local.target#' provided by plugin '#local.pluginName#' is being overwritten by package '#local.pkgName#'. Migrate the plugin to a package or remove the duplicate to resolve."
+					);
+				}
 			}
 			StructAppend(application[local.appKey].mixins[local.target], local.pkgMixins[local.target]);
 		}

--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -2957,17 +2957,23 @@ return local.$wheels;
 		local.pluginProviders = StructKeyExists(application[local.appKey], "PluginObj")
 			? application[local.appKey].PluginObj.getMethodProviders()
 			: {};
-		local.pkgProviders = application[local.appKey].PackageLoaderObj.$methodProviders();
+		local.pkgProviders = application[local.appKey].PackageLoaderObj.getMethodProviders();
 		for (local.target in local.pkgMixins) {
 			if (!StructKeyExists(application[local.appKey].mixins, local.target)) {
 				application[local.appKey].mixins[local.target] = {};
 			}
 			for (local.methodName in local.pkgMixins[local.target]) {
 				if (StructKeyExists(application[local.appKey].mixins[local.target], local.methodName)) {
-					local.pluginName = StructKeyExists(local.pluginProviders, local.target)
-						&& StructKeyExists(local.pluginProviders[local.target], local.methodName)
-						? local.pluginProviders[local.target][local.methodName]
-						: "(unknown plugin)";
+					// Only treat this as a cross-system collision when the existing entry
+					// came from a known plugin. Without an attributable plugin provider
+					// the prior entry could be framework-internal or pre-seeded, and a
+					// "migrate the plugin" recommendation would be misleading.
+					local.pluginAttributable = StructKeyExists(local.pluginProviders, local.target)
+						&& StructKeyExists(local.pluginProviders[local.target], local.methodName);
+					if (!local.pluginAttributable) {
+						continue;
+					}
+					local.pluginName = local.pluginProviders[local.target][local.methodName];
 					local.pkgName = StructKeyExists(local.pkgProviders, local.target)
 						&& StructKeyExists(local.pkgProviders[local.target], local.methodName)
 						? local.pkgProviders[local.target][local.methodName]

--- a/vendor/wheels/PackageLoader.cfc
+++ b/vendor/wheels/PackageLoader.cfc
@@ -41,6 +41,11 @@ component output="false" {
 		variables.excludedPackages = {};
 		variables.loadOrder = [];
 		variables.lazyPackages = {};
+		variables.mixinCollisions = [];
+		// Tracks which package first registered each method per target so a
+		// later registration can be flagged as an overwrite. Keyed by target,
+		// then by method name, holding the originating package dir name.
+		variables.$methodProviders = {};
 
 		// The same mixin targets as Plugins.cfc
 		variables.mixableComponents = "application,dispatch,controller,mapper,model,base,sqlserver,mysql,postgresql,h2,test";
@@ -48,6 +53,7 @@ component output="false" {
 		// Initialize mixin containers
 		for (local.target in variables.mixableComponents) {
 			variables.mixins[local.target] = {};
+			variables.$methodProviders[local.target] = {};
 		}
 
 		// Run the loading pipeline
@@ -90,6 +96,26 @@ component output="false" {
 
 	public array function getLoadOrder() {
 		return variables.loadOrder;
+	}
+
+	/**
+	 * Returns mixin collision records — cases where a package registered a
+	 * method name for a target that another package had already claimed.
+	 * Each entry: {target, method, firstProvider, secondProvider, acknowledged}.
+	 * An `acknowledged` true means the overwriting package declared the method
+	 * in its `provides.overrides` list, which suppresses the warning log.
+	 */
+	public array function getMixinCollisions() {
+		return variables.mixinCollisions;
+	}
+
+	/**
+	 * Returns the per-target method→package-name mapping built during mixin
+	 * collection. Used by $loadPackages to name the package side of a
+	 * cross-system collision with a legacy plugin.
+	 */
+	public struct function $methodProviders() {
+		return variables.$methodProviders;
 	}
 
 	/**
@@ -387,7 +413,8 @@ component output="false" {
 
 		// Collect mixins if targets declared
 		if (arguments.mixinTargets != "none") {
-			$collectMixins(arguments.dirName, local.pkg, arguments.mixinTargets);
+			local.overrides = $resolveOverrides(arguments.provides);
+			$collectMixins(arguments.dirName, local.pkg, arguments.mixinTargets, local.overrides);
 		}
 
 		// Log success
@@ -432,12 +459,18 @@ component output="false" {
 
 	/**
 	 * Collects public methods from a package CFC and assigns them to mixin targets.
-	 * Follows the same pattern as Plugins.cfc $processMixins().
+	 * Follows the same pattern as Plugins.cfc $processMixins() but also records
+	 * collisions when two packages register the same method for the same target.
+	 *
+	 * @overrides Lowercase-keyed struct of method names the package deliberately
+	 *            overrides (from manifest provides.overrides). Suppresses the
+	 *            warning log but still records the collision as `acknowledged`.
 	 */
 	private void function $collectMixins(
 		required string pkgName,
 		required any pkg,
-		required string mixinTargets
+		required string mixinTargets,
+		struct overrides = {}
 	) {
 		local.methods = StructKeyList(arguments.pkg);
 		local.lifecycleHooks = "init,onPluginLoad,onPluginActivate,register,boot";
@@ -463,10 +496,80 @@ component output="false" {
 
 			for (local.target in variables.mixableComponents) {
 				if (local.effectiveTargets == "global" || ListFindNoCase(local.effectiveTargets, local.target)) {
+					// Collision check: another package already registered this method
+					// for this target. Record it and keep the later registration
+					// (current StructAppend-based merge semantics) so behaviour is
+					// unchanged, but make the overwrite visible.
+					if (StructKeyExists(variables.$methodProviders[local.target], local.methodName)) {
+						local.firstProvider = variables.$methodProviders[local.target][local.methodName];
+						local.acknowledged = StructKeyExists(arguments.overrides, LCase(local.methodName));
+						$recordCollision(
+							target = local.target,
+							method = local.methodName,
+							firstProvider = local.firstProvider,
+							secondProvider = arguments.pkgName,
+							acknowledged = local.acknowledged
+						);
+					}
 					variables.mixins[local.target][local.methodName] = arguments.pkg[local.methodName];
+					variables.$methodProviders[local.target][local.methodName] = arguments.pkgName;
 				}
 			}
 		}
+	}
+
+	/**
+	 * Records a mixin collision and emits a warning log unless the overwriting
+	 * package explicitly acknowledged the override via provides.overrides.
+	 */
+	private void function $recordCollision(
+		required string target,
+		required string method,
+		required string firstProvider,
+		required string secondProvider,
+		required boolean acknowledged
+	) {
+		ArrayAppend(variables.mixinCollisions, {
+			target = arguments.target,
+			method = arguments.method,
+			firstProvider = arguments.firstProvider,
+			secondProvider = arguments.secondProvider,
+			acknowledged = arguments.acknowledged,
+			source = "package"
+		});
+
+		if (arguments.acknowledged) {
+			WriteLog(
+				type = "information",
+				text = "[Wheels] Package '#arguments.secondProvider#' intentionally overrides method '#arguments.method#' on target '#arguments.target#' (previously provided by '#arguments.firstProvider#')",
+				file = "application"
+			);
+		} else {
+			WriteLog(
+				type = "warning",
+				text = "[Wheels] Mixin collision: method '#arguments.method#' on target '#arguments.target#' provided by package '#arguments.firstProvider#' is being overwritten by package '#arguments.secondProvider#'. Declare the method in the overwriting package's provides.overrides to acknowledge this.",
+				file = "application"
+			);
+		}
+	}
+
+	/**
+	 * Normalises provides.overrides into a lowercase-keyed struct for O(1) lookup.
+	 * Accepts an array of method names; any other shape is ignored.
+	 */
+	private struct function $resolveOverrides(required struct provides) {
+		local.result = {};
+		if (!StructKeyExists(arguments.provides, "overrides")) {
+			return local.result;
+		}
+		if (IsArray(arguments.provides.overrides)) {
+			for (local.name in arguments.provides.overrides) {
+				if (IsSimpleValue(local.name) && Len(Trim(local.name))) {
+					local.result[LCase(Trim(local.name))] = true;
+				}
+			}
+		}
+		return local.result;
 	}
 
 	// ---------------------------------------------------------------------------

--- a/vendor/wheels/PackageLoader.cfc
+++ b/vendor/wheels/PackageLoader.cfc
@@ -113,8 +113,12 @@ component output="false" {
 	 * Returns the per-target method→package-name mapping built during mixin
 	 * collection. Used by $loadPackages to name the package side of a
 	 * cross-system collision with a legacy plugin.
+	 *
+	 * Named getMethodProviders (not $methodProviders) to avoid shadowing the
+	 * variables.$methodProviders storage struct on Adobe CF, which stores
+	 * method declarations in the same `variables` scope keyed by name.
 	 */
-	public struct function $methodProviders() {
+	public struct function getMethodProviders() {
 		return variables.$methodProviders;
 	}
 

--- a/vendor/wheels/Plugins.cfc
+++ b/vendor/wheels/Plugins.cfc
@@ -706,10 +706,12 @@ component output="false" extends="wheels.Global"{
 			variables.$class.mixins[local.iMixableComponents] = {};
 		}
 
-		// track which plugin provided each method per mixin target for collision detection
-		local.methodProviders = {};
+		// track which plugin provided each method per mixin target for collision detection.
+		// Persisted on variables.$class so cross-system (package) collisions can identify the
+		// originating plugin by name when PackageLoader overlays its mixins.
+		variables.$class.methodProviders = {};
 		for (local.iMixableComponents in variables.$class.mixableComponents) {
-			local.methodProviders[local.iMixableComponents] = {};
+			variables.$class.methodProviders[local.iMixableComponents] = {};
 		}
 
 		// get a sorted list of plugins so that we run through them the same on
@@ -752,8 +754,8 @@ component output="false" extends="wheels.Global"{
 							for (local.iMixableComponent in variables.$class.mixableComponents) {
 								if (local.methodMixins == "global" || ListFindNoCase(local.methodMixins, local.iMixableComponent)) {
 									// detect collision: another plugin already provided this method for this target
-									if (StructKeyExists(local.methodProviders[local.iMixableComponent], local.iPluginMethods)) {
-										local.existingPlugin = local.methodProviders[local.iMixableComponent][local.iPluginMethods];
+									if (StructKeyExists(variables.$class.methodProviders[local.iMixableComponent], local.iPluginMethods)) {
+										local.existingPlugin = variables.$class.methodProviders[local.iMixableComponent][local.iPluginMethods];
 										ArrayAppend(variables.$class.mixinCollisions, {
 											method = local.iPluginMethods,
 											target = local.iMixableComponent,
@@ -763,7 +765,7 @@ component output="false" extends="wheels.Global"{
 									}
 									// cfformat-ignore-start
 									variables.$class.mixins[local.iMixableComponent][local.iPluginMethods] = local.plugin[local.iPluginMethods];
-									local.methodProviders[local.iMixableComponent][local.iPluginMethods] = local.iPlugin;
+									variables.$class.methodProviders[local.iMixableComponent][local.iPluginMethods] = local.iPlugin;
 									// cfformat-ignore-end
 								}
 							}
@@ -864,6 +866,18 @@ component output="false" extends="wheels.Global"{
 
 	public any function getMixinCollisions() {
 		return variables.$class.mixinCollisions;
+	}
+
+	/**
+	 * Returns the per-target method→plugin-name mapping built during $processMixins.
+	 * Used by $loadPackages to attribute cross-system collisions to the originating
+	 * plugin rather than a generic "(legacy plugin)" placeholder.
+	 */
+	public struct function getMethodProviders() {
+		if (!StructKeyExists(variables.$class, "methodProviders")) {
+			return {};
+		}
+		return variables.$class.methodProviders;
 	}
 
 	public array function getPluginMiddleware() {

--- a/vendor/wheels/tests/_assets/packages_collision/mixincolA/mixincolA.cfc
+++ b/vendor/wheels/tests/_assets/packages_collision/mixincolA/mixincolA.cfc
@@ -1,0 +1,10 @@
+component {
+	public any function init() {
+		this.version = "1.0.0";
+		return this;
+	}
+
+	public string function $sharedHelper() {
+		return "from-mixincolA";
+	}
+}

--- a/vendor/wheels/tests/_assets/packages_collision/mixincolA/package.json
+++ b/vendor/wheels/tests/_assets/packages_collision/mixincolA/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "wheels-mixincolA",
+	"version": "1.0.0",
+	"description": "Test fixture: defines $sharedHelper on controller",
+	"provides": {
+		"mixins": "controller"
+	}
+}

--- a/vendor/wheels/tests/_assets/packages_collision/mixincolB/mixincolB.cfc
+++ b/vendor/wheels/tests/_assets/packages_collision/mixincolB/mixincolB.cfc
@@ -1,0 +1,10 @@
+component {
+	public any function init() {
+		this.version = "1.0.0";
+		return this;
+	}
+
+	public string function $sharedHelper() {
+		return "from-mixincolB";
+	}
+}

--- a/vendor/wheels/tests/_assets/packages_collision/mixincolB/package.json
+++ b/vendor/wheels/tests/_assets/packages_collision/mixincolB/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "wheels-mixincolB",
+	"version": "1.0.0",
+	"description": "Test fixture: also defines $sharedHelper on controller (collides with mixincolA)",
+	"provides": {
+		"mixins": "controller"
+	}
+}

--- a/vendor/wheels/tests/_assets/packages_collision/mixincolOverride/mixincolOverride.cfc
+++ b/vendor/wheels/tests/_assets/packages_collision/mixincolOverride/mixincolOverride.cfc
@@ -1,0 +1,10 @@
+component {
+	public any function init() {
+		this.version = "1.0.0";
+		return this;
+	}
+
+	public string function $sharedHelper() {
+		return "from-mixincolOverride";
+	}
+}

--- a/vendor/wheels/tests/_assets/packages_collision/mixincolOverride/package.json
+++ b/vendor/wheels/tests/_assets/packages_collision/mixincolOverride/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "wheels-mixincolOverride",
+	"version": "1.0.0",
+	"description": "Test fixture: also defines $sharedHelper on controller but declares it as an acknowledged override",
+	"provides": {
+		"mixins": "controller",
+		"overrides": ["$sharedHelper"]
+	}
+}

--- a/vendor/wheels/tests/specs/PackageLoaderSpec.cfc
+++ b/vendor/wheels/tests/specs/PackageLoaderSpec.cfc
@@ -444,6 +444,96 @@ component extends="wheels.WheelsTest" {
 
 			});
 
+			describe("Mixin collisions", () => {
+
+				beforeEach(() => {
+					collisionFixturesPath = ExpandPath("/wheels/tests/_assets/packages_collision");
+					collisionPrefix = "wheels.tests._assets.packages_collision";
+				});
+
+				it("records no collisions when no method overlaps", () => {
+					// Default shared fixtures path — none of those fixtures collide
+					var loader = new wheels.PackageLoader(
+						vendorPath = fixturesPath,
+						componentPrefix = componentPrefix
+					);
+					expect(loader.getMixinCollisions()).toBeEmpty();
+				});
+
+				it("detects collisions when two packages provide the same method for the same target", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = collisionFixturesPath,
+						componentPrefix = collisionPrefix
+					);
+					var collisions = loader.getMixinCollisions();
+
+					// mixincolA, mixincolB, and mixincolOverride all provide $sharedHelper on controller.
+					// Sorted load order means two collisions are recorded (A→B, B→Override)
+					expect(ArrayLen(collisions)).toBeGTE(1);
+
+					var found = false;
+					for (var c in collisions) {
+						if (c.method == "$sharedHelper" && c.target == "controller") {
+							found = true;
+						}
+					}
+					expect(found).toBeTrue();
+				});
+
+				it("both packages still load — collision doesn't block loading", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = collisionFixturesPath,
+						componentPrefix = collisionPrefix
+					);
+					var pkgs = loader.getPackages();
+					expect(pkgs).toHaveKey("mixincolA");
+					expect(pkgs).toHaveKey("mixincolB");
+				});
+
+				it("marks collision as acknowledged when overriding package declares overrides", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = collisionFixturesPath,
+						componentPrefix = collisionPrefix
+					);
+					var collisions = loader.getMixinCollisions();
+
+					var acknowledgedFound = false;
+					for (var c in collisions) {
+						if (c.secondProvider == "mixincolOverride" && c.method == "$sharedHelper") {
+							expect(c.acknowledged).toBeTrue();
+							acknowledgedFound = true;
+						}
+					}
+					expect(acknowledgedFound).toBeTrue();
+				});
+
+				it("records source as 'package' for package-to-package collisions", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = collisionFixturesPath,
+						componentPrefix = collisionPrefix
+					);
+					var collisions = loader.getMixinCollisions();
+					expect(ArrayLen(collisions)).toBeGTE(1);
+					for (var c in collisions) {
+						expect(c.source).toBe("package");
+					}
+				});
+
+				it("records firstProvider and secondProvider correctly", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = collisionFixturesPath,
+						componentPrefix = collisionPrefix
+					);
+					var collisions = loader.getMixinCollisions();
+					for (var c in collisions) {
+						expect(Len(c.firstProvider)).toBeGT(0);
+						expect(Len(c.secondProvider)).toBeGT(0);
+						expect(c.firstProvider).notToBe(c.secondProvider);
+					}
+				});
+
+			});
+
 		});
 
 	}


### PR DESCRIPTION
## Summary
- Close [#2245](https://github.com/wheels-dev/wheels/issues/2245). `PackageLoader` now tracks which package registered each method per target and records a collision when another package or legacy plugin overwrites it — previously silent via `StructAppend`.
- New `provides.overrides` array in `package.json` lets a package declare intentional overrides; acknowledged overrides log at info level instead of warning.
- `Global.cfc.$loadPackages` stitches the runtime collisions (intra-package and cross-system) into `application.wheels.mixinCollisions` with a `source` tag so the existing `plugins.cfm` view + debug page surface both kinds.
- `wheels doctor` gains a static manifest+CFC scan (regex-based; runtime in `PackageLoader` remains authoritative) that surfaces collisions pre-boot.
- Follow-ups filed: [#2260](https://github.com/wheels-dev/wheels/issues/2260) (regex scan blind spots), [#2261](https://github.com/wheels-dev/wheels/issues/2261) (doctor `--verbose` dump).

## Test plan
- [x] `bash tools/test-local.sh` — Lucee 7 + SQLite, **3306 pass / 0 fail / 0 error** (+6 new `PackageLoader` mixin-collision specs)
- [x] `bash tools/test-cli-local.sh` — **388 pass / 0 fail** (+4 new `DoctorSpec` collision specs)
- [x] Manually verified fixture layout under `vendor/wheels/tests/_assets/packages_collision/` — isolated from the shared fixtures path so it doesn't pollute other PackageLoader specs.
- [ ] Recommended: re-run compat matrix (Adobe CF + Lucee 6) once CI picks up the branch — no engine-specific idioms were introduced but the private `$recordCollision` helper uses the same patterns already validated for Plugins.cfc.

### Acceptance against [#2245](https://github.com/wheels-dev/wheels/issues/2245)
- [x] Two packages both providing `$sharedHelper` → both load, warning logged, collision listed
- [x] Single package → no warnings (baseline regression guard)
- [x] Package + legacy plugin collision → tagged `source: "cross"` with both names
- [x] Acknowledged override via `provides.overrides` → `acknowledged: true`, info log instead of warning
- [x] Surfaced in `wheels doctor` output