### PR TITLE
fix(view): homepage version and CLI detection (closes #2255, #2259)

### DIFF
--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -2753,7 +2753,7 @@ return local.$wheels;
 		return local.rv;
 	}
 
-	public string function $readFrameworkVersion(string boxJsonPath = "") {
+	public string function $readFrameworkVersion(string boxJsonPath = "", string rootBoxJsonPath = "") {
 		local.path = Len(arguments.boxJsonPath)
 			? arguments.boxJsonPath
 			: GetDirectoryFromPath(GetCurrentTemplatePath()) & "box.json";
@@ -2782,6 +2782,33 @@ return local.$wheels;
 			);
 		}
 		if (local.box.version == "@build.version@") {
+			// Dev checkout. Try to synthesize a more useful version by reading the
+			// enclosing repo's root box.json — when that box.json identifies itself as
+			// the wheels-dev/wheels monorepo, report "<rootversion>-dev" so the
+			// homepage shows the upcoming version rather than a blank placeholder.
+			local.rootPath = Len(arguments.rootBoxJsonPath)
+				? arguments.rootBoxJsonPath
+				: GetDirectoryFromPath(GetCurrentTemplatePath()) & "../box.json";
+			try {
+				if (FileExists(local.rootPath)) {
+					local.rootBox = DeserializeJSON(FileRead(local.rootPath));
+					local.isWheelsRepo = IsStruct(local.rootBox)
+						&& (
+							(StructKeyExists(local.rootBox, "slug") && local.rootBox.slug == "wheels")
+							|| (StructKeyExists(local.rootBox, "name") && local.rootBox.name == "Wheels.fw")
+						);
+					if (
+						local.isWheelsRepo
+						&& StructKeyExists(local.rootBox, "version")
+						&& Len(local.rootBox.version)
+						&& local.rootBox.version != "@build.version@"
+					) {
+						return local.rootBox.version & "-dev";
+					}
+				}
+			} catch (any e) {
+				// fall through to the plain dev sentinel
+			}
 			return "0.0.0-dev";
 		}
 		return local.box.version;

--- a/vendor/wheels/public/views/congratulations.cfm
+++ b/vendor/wheels/public/views/congratulations.cfm
@@ -11,8 +11,23 @@
 	local.dbName = application.wheels.dataSourceName;
 	local.environment = get("environment");
 
-	// CLI detection
+	// CLI detection — best-effort across install vectors:
+	//   1. Monorepo dev checkout (CLI source is in-tree)
+	//   2. CommandBox module install (`box install wheels-cli`)
+	//   3. LuCLI install (Homebrew, Chocolatey, or direct download)
 	local.hasCLI = FileExists(ExpandPath("/cli/lucli/Module.cfc"));
+	if (!local.hasCLI) {
+		try {
+			local.userHome = CreateObject("java", "java.lang.System").getProperty("user.home");
+			local.hasCLI = Len(local.userHome) && (
+				FileExists(local.userHome & "/.CommandBox/cfml/modules/wheels-cli/ModuleConfig.cfc")
+				|| FileExists(local.userHome & "/.lucli/lucli")
+				|| FileExists(local.userHome & "/.lucli/bin/lucli")
+			);
+		} catch (any e) {
+			// best-effort — if home dir is unavailable, fall back to "not detected"
+		}
+	}
 
 	// OS detection for install tab pre-selection
 	local.osName = server.os.name;

--- a/vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc
+++ b/vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc
@@ -35,6 +35,56 @@ component extends="wheels.WheelsTest" {
 				}
 			});
 
+			it("$readFrameworkVersion synthesizes <rootversion>-dev when placeholder is detected inside the wheels monorepo", () => {
+				var fwTmp = getTempDirectory() & "wheels-version-fw-#CreateUUID()#.json";
+				var rootTmp = getTempDirectory() & "wheels-version-root-#CreateUUID()#.json";
+				fileWrite(fwTmp, '{"version":"@build.version@"}');
+				fileWrite(rootTmp, '{"name":"Wheels.fw","slug":"wheels","version":"4.0.0"}');
+				try {
+					expect(g.$readFrameworkVersion(fwTmp, rootTmp)).toBe("4.0.0-dev");
+				} finally {
+					fileDelete(fwTmp);
+					fileDelete(rootTmp);
+				}
+			});
+
+			it("$readFrameworkVersion falls back to 0.0.0-dev when the enclosing box.json is not the wheels monorepo (vendored install)", () => {
+				var fwTmp = getTempDirectory() & "wheels-version-fw-#CreateUUID()#.json";
+				var rootTmp = getTempDirectory() & "wheels-version-root-#CreateUUID()#.json";
+				fileWrite(fwTmp, '{"version":"@build.version@"}');
+				fileWrite(rootTmp, '{"name":"SomeUserApp","slug":"user-app","version":"2.1.0"}');
+				try {
+					expect(g.$readFrameworkVersion(fwTmp, rootTmp)).toBe("0.0.0-dev");
+				} finally {
+					fileDelete(fwTmp);
+					fileDelete(rootTmp);
+				}
+			});
+
+			it("$readFrameworkVersion falls back to 0.0.0-dev when the enclosing box.json is also unreplaced", () => {
+				var fwTmp = getTempDirectory() & "wheels-version-fw-#CreateUUID()#.json";
+				var rootTmp = getTempDirectory() & "wheels-version-root-#CreateUUID()#.json";
+				fileWrite(fwTmp, '{"version":"@build.version@"}');
+				fileWrite(rootTmp, '{"name":"Wheels.fw","slug":"wheels","version":"@build.version@"}');
+				try {
+					expect(g.$readFrameworkVersion(fwTmp, rootTmp)).toBe("0.0.0-dev");
+				} finally {
+					fileDelete(fwTmp);
+					fileDelete(rootTmp);
+				}
+			});
+
+			it("$readFrameworkVersion falls back to 0.0.0-dev when the enclosing box.json is missing", () => {
+				var fwTmp = getTempDirectory() & "wheels-version-fw-#CreateUUID()#.json";
+				var missingRoot = getTempDirectory() & "wheels-version-missing-#CreateUUID()#.json";
+				fileWrite(fwTmp, '{"version":"@build.version@"}');
+				try {
+					expect(g.$readFrameworkVersion(fwTmp, missingRoot)).toBe("0.0.0-dev");
+				} finally {
+					fileDelete(fwTmp);
+				}
+			});
+
 			it("$readFrameworkVersion throws Wheels.VersionReadFailed when the file is missing", () => {
 				var missing = getTempDirectory() & "wheels-version-missing-#CreateUUID()#.json";
 				var threw = false;


### PR DESCRIPTION
## Summary

- **#2255** — \`\$readFrameworkVersion()\` in dev checkouts now returns \`<rootversion>-dev\` (e.g. \`4.0.0-dev\`) when it detects the wheels-dev/wheels monorepo via root box.json slug/name. Vendored installs and third-party contexts still get \`0.0.0-dev\`.
- **#2259** — homepage CLI detection additionally probes CommandBox module and LuCLI install paths so apps with \`wheels-cli\` (CommandBox) or \`lucli\`/\`wheels\` (Homebrew / Chocolatey / direct) installed show "CLI detected" instead of "Install the Wheels CLI".

Both issues turned out to be **not regressions** from the Theme A batch — the version helper was working as designed per its #2240 commit message, and the CLI path check has been hardcoded since the v4.0 congratulations redesign (#2098). Triage notes in the original brief.

## Changes

- \`vendor/wheels/Global.cfc\` — \`\$readFrameworkVersion()\` gains an optional \`rootBoxJsonPath\` arg; when the framework box.json contains \`@build.version@\`, the helper consults the enclosing box.json and, if it identifies the wheels monorepo, returns \`<rootversion>-dev\`.
- \`vendor/wheels/public/views/congratulations.cfm\` — CLI detection now falls through to \`~/.CommandBox/cfml/modules/wheels-cli/ModuleConfig.cfc\`, \`~/.lucli/lucli\`, and \`~/.lucli/bin/lucli\`. FileExists-only; no \`cfexecute\`.
- \`vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc\` — four new specs for the dev-fallback branch (monorepo match, vendored-install, both-placeholder, missing-root).

## Test plan

- [x] Full core suite green locally: **3306 pass, 0 fail, 0 error, 16 skip** (Lucee 7 + SQLite via LuCLI)
- [ ] CI: PR fast-gate green across its matrix
- [ ] Manual smoke: load \`/\` on the wheels-dev/wheels dev server — expect \`4.0.0-dev\` (instead of \`0.0.0-dev\`)
- [ ] Manual smoke: install \`wheels-cli\` via CommandBox in a separate app, load \`/\` — expect "Wheels CLI detected"

Closes #2255
Closes #2259

🤖 Generated with [Claude Code](https://claude.com/claude-code)