### PR TITLE
feat(view): add browse-registry section to /wheels/packages (#2271 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 - Package system (`PackageLoader`) with `packages/` → `vendor/` activation model, `package.json` manifests with `provides.mixins` targets, per-package error isolation (#1995)
 - Module system with dependency graph (requires/replaces/suggests topological sort) and lazy loading (#2017)
 - LuCLI module distribution via wheels-cli-lucli repo (#2018)
+- `/wheels/packages` developer page now shows a "Browse registry" section listing all packages available from `wheels-dev/wheels-packages` — package name, description, latest version, and a copy-to-clipboard `wheels packages install <name>` snippet per row. Rows matching an already-installed package show a `✓ Installed` badge. Dev/testing only; `$blockInProduction()` gate keeps it off production servers. Registry data comes from the CLI's `Registry.listAll()` with 24h app-scope cache (#2271, partial — wheels.dev/packages static-site work deferred)
 
 **Engine adapters & cross-engine**
 - Engine adapter modules encapsulating Lucee, Adobe CF, and BoxLang engine-specific behavior (#2016)

--- a/cli/lucli/services/packages/Registry.cfc
+++ b/cli/lucli/services/packages/Registry.cfc
@@ -104,6 +104,33 @@ component {
 		return local.manifest;
 	}
 
+	/**
+	 * Returns enriched summaries for every package in the registry.
+	 * One HTTP call for the index, one per package for its manifest
+	 * (all cached 24h). Skips packages whose manifest fails to parse;
+	 * propagates a registry-wide unavailability error.
+	 */
+	public array function listAll() {
+		local.names = listPackageNames();
+		local.out = [];
+		for (local.name in local.names) {
+			try {
+				local.m = fetchManifest(local.name);
+			} catch (Wheels.Packages.RegistryMalformed e) {
+				continue;
+			}
+			local.latest = local.m.versions[ArrayLen(local.m.versions)];
+			ArrayAppend(local.out, {
+				name:          local.m.name,
+				description:   local.m.description ?: "",
+				tags:          IsArray(local.m.tags ?: "") ? local.m.tags : [],
+				homepage:      local.m.homepage ?: "",
+				latestVersion: local.latest.version
+			});
+		}
+		return local.out;
+	}
+
 	public struct function info() {
 		local.cacheInfo = variables.cache.info();
 		return {

--- a/cli/lucli/tests/specs/packages/RegistryListAllSpec.cfc
+++ b/cli/lucli/tests/specs/packages/RegistryListAllSpec.cfc
@@ -1,0 +1,104 @@
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function run() {
+		describe("Registry.listAll", () => {
+
+			var $freshCache = () => {
+				var root = GetTempDirectory() & "wheels-registry-" & CreateUUID() & "/";
+				return new cli.lucli.services.packages.ManifestCache(root = root);
+			};
+
+			var $manifest = (name, versions = [{version: "1.0.0", wheelsVersion: ">=4.0", tarball: "x", sha256: "y"}]) => {
+				return SerializeJSON({
+					name: name,
+					description: name & " description",
+					homepage: "https://github.com/wheels-dev/" & name,
+					tags: ["utility"],
+					source: {type: "github", repo: "wheels-dev/" & name},
+					versions: versions
+				});
+			};
+
+			var $contentsBody = SerializeJSON([
+				{name: "wheels-sentry",  type: "dir"},
+				{name: "wheels-hotwire", type: "dir"},
+				{name: "README.md",      type: "file"}
+			]);
+
+			it("returns enriched summaries for every package in the registry", () => {
+				var fake = new cli.lucli.tests.specs.packages._stubs.FakeHttpClient();
+				var r = new cli.lucli.services.packages.Registry(
+					httpClient = fake, cache = $freshCache(), registryRepo = "acme/pkgs"
+				);
+				fake.seed(
+					"https://api.github.com/repos/acme/pkgs/contents/packages?ref=main",
+					{status: 200, body: $contentsBody}
+				);
+				fake.seed(
+					"https://raw.githubusercontent.com/acme/pkgs/main/packages/wheels-sentry/manifest.json",
+					{status: 200, body: $manifest("wheels-sentry")}
+				);
+				fake.seed(
+					"https://raw.githubusercontent.com/acme/pkgs/main/packages/wheels-hotwire/manifest.json",
+					{status: 200, body: $manifest("wheels-hotwire", [
+						{version: "1.0.0", wheelsVersion: ">=4.0", tarball: "x", sha256: "y"},
+						{version: "1.1.0", wheelsVersion: ">=4.0", tarball: "x", sha256: "y"}
+					])}
+				);
+
+				var result = r.listAll();
+
+				expect(ArrayLen(result)).toBe(2);
+				expect(result[1].name).toBe("wheels-hotwire");     // sorted
+				expect(result[1].latestVersion).toBe("1.1.0");     // last version entry wins
+				expect(result[1].homepage).toBe("https://github.com/wheels-dev/wheels-hotwire");
+				expect(result[1].tags).toBe(["utility"]);
+				expect(result[2].name).toBe("wheels-sentry");
+				expect(result[2].latestVersion).toBe("1.0.0");
+			});
+
+			it("skips a package whose manifest is malformed and continues", () => {
+				var fake = new cli.lucli.tests.specs.packages._stubs.FakeHttpClient();
+				var r = new cli.lucli.services.packages.Registry(
+					httpClient = fake, cache = $freshCache(), registryRepo = "acme/pkgs"
+				);
+				fake.seed(
+					"https://api.github.com/repos/acme/pkgs/contents/packages?ref=main",
+					{status: 200, body: $contentsBody}
+				);
+				fake.seed(
+					"https://raw.githubusercontent.com/acme/pkgs/main/packages/wheels-sentry/manifest.json",
+					{status: 200, body: "{""description"": ""no name key""}"}  // malformed — missing required 'name'
+				);
+				fake.seed(
+					"https://raw.githubusercontent.com/acme/pkgs/main/packages/wheels-hotwire/manifest.json",
+					{status: 200, body: $manifest("wheels-hotwire")}
+				);
+
+				var result = r.listAll();
+				expect(ArrayLen(result)).toBe(1);
+				expect(result[1].name).toBe("wheels-hotwire");
+			});
+
+			it("propagates Wheels.Packages.RegistryUnavailable from listPackageNames", () => {
+				var fake = new cli.lucli.tests.specs.packages._stubs.FakeHttpClient();
+				var r = new cli.lucli.services.packages.Registry(
+					httpClient = fake, cache = $freshCache(), registryRepo = "acme/pkgs"
+				);
+				fake.seed(
+					"https://api.github.com/repos/acme/pkgs/contents/packages?ref=main",
+					{status: 503, body: "service unavailable"}
+				);
+
+				var thrown = "";
+				try {
+					r.listAll();
+				} catch (Wheels.Packages.RegistryUnavailable e) {
+					thrown = e.type;
+				}
+				expect(thrown).toBe("Wheels.Packages.RegistryUnavailable");
+			});
+
+		});
+	}
+}

--- a/docs/superpowers/plans/2026-04-23-wheels-packages-phase4-inapp.md
+++ b/docs/superpowers/plans/2026-04-23-wheels-packages-phase4-inapp.md
@@ -1,0 +1,735 @@
+# wheels-packages Phase 4 In-App Browse Registry — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Browse registry" section to the in-app `/wheels/packages` page so developers see all installable packages from `wheels-dev/wheels-packages` alongside their installed ones, with a copy-to-clipboard CLI install command per package.
+
+**Architecture:** Reuse the CLI's `cli.lucli.services.packages.Registry` directly from Wheels core. Add one convenience method (`listAll()`) that returns enriched manifest summaries. Add one seam on `vendor/wheels/Public.cfc` (`$loadRegistryPackages()`) that handles memoization, production gating, and error capture — keeping the `.cfm` view thin and untestable-in-isolation logic out of the view. Extend `packagelist.cfm` to render the new section, marking rows that are already installed.
+
+**Tech Stack:** CFML (Lucee + Adobe CF), WheelsTest BDD, existing `FakeHttpClient` + `ManifestCache` test doubles.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md` (see "Revision" note — this plan covers Component 1 only; the wheels.dev Astro work is deferred).
+
+**Issue:** [#2271](https://github.com/wheels-dev/wheels/issues/2271). This PR does **not** close #2271 — it remains open for the deferred wheels.dev work.
+
+---
+
+## File structure
+
+**Files created:**
+- `vendor/wheels/tests/specs/packages/RegistryListAllSpec.cfc` — spec for new `listAll()` method
+- `vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc` — spec for new `$loadRegistryPackages()` method on Public.cfc
+
+**Files modified:**
+- `cli/lucli/services/packages/Registry.cfc` — add `listAll()` public method
+- `vendor/wheels/Public.cfc` — add `$loadRegistryPackages()` private helper
+- `vendor/wheels/public/views/packagelist.cfm` — add "Browse registry" section below existing installed-packages table
+- `CHANGELOG.md` — add entry under "Unreleased" or appropriate heading
+
+**Rationale for shape:**
+- `listAll()` on `Registry.cfc` (not a new class) — it's a trivial wrapper composing two existing methods. A new class would be over-abstraction.
+- `$loadRegistryPackages()` on `Public.cfc` (not a view helper) — Public.cfc already owns `$blockInProduction()` and handler logic; adding a peer is consistent. View-level try/catch would bake untestable logic into the `.cfm`.
+- No new `vendor/wheels/global/packages.cfm` (as the spec initially proposed) — over-scoped for a 20-line helper.
+
+---
+
+## Task 1: Add `listAll()` to Registry.cfc (TDD)
+
+**Files:**
+- Modify: `cli/lucli/services/packages/Registry.cfc`
+- Create: `cli/lucli/tests/specs/packages/RegistryListAllSpec.cfc`
+
+**Shape of `listAll()`:**
+- Returns: `array` of structs, each with keys `name`, `description`, `tags` (array), `latestVersion` (string), `homepage` (string — may be empty)
+- Calls `listPackageNames()`, then `fetchManifest(name)` for each, extracts latest version from `manifest.versions[-1].version`
+- Manifests ordered append-only per the registry's `CONTRIBUTING.md` — the last entry is the latest
+- Silently skips any package whose manifest fetch throws `Wheels.Packages.RegistryMalformed` (still logs via regular Wheels logging), so one bad manifest doesn't break the whole list
+- Propagates `Wheels.Packages.RegistryUnavailable` from `listPackageNames()` — that's a fatal condition for this call
+
+### Steps
+
+- [ ] **Step 1.1: Write failing test for happy path**
+
+Create `cli/lucli/tests/specs/packages/RegistryListAllSpec.cfc`:
+
+```cfml
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function run() {
+		describe("Registry.listAll", () => {
+
+			var $freshCache = () => {
+				var root = GetTempDirectory() & "wheels-registry-" & CreateUUID() & "/";
+				return new cli.lucli.services.packages.ManifestCache(root = root);
+			};
+
+			var $manifest = (name, versions = [{version: "1.0.0", wheelsVersion: ">=4.0", tarball: "x", sha256: "y"}]) => {
+				return SerializeJSON({
+					name: name,
+					description: name & " description",
+					homepage: "https://github.com/wheels-dev/" & name,
+					tags: ["utility"],
+					source: {type: "github", repo: "wheels-dev/" & name},
+					versions: versions
+				});
+			};
+
+			var $contentsBody = SerializeJSON([
+				{name: "wheels-sentry",  type: "dir"},
+				{name: "wheels-hotwire", type: "dir"},
+				{name: "README.md",      type: "file"}
+			]);
+
+			it("returns enriched summaries for every package in the registry", () => {
+				var fake = new cli.lucli.tests.specs.packages._stubs.FakeHttpClient();
+				var r = new cli.lucli.services.packages.Registry(
+					httpClient = fake, cache = $freshCache(), registryRepo = "acme/pkgs"
+				);
+				fake.seed(
+					"https://api.github.com/repos/acme/pkgs/contents/packages?ref=main",
+					{status: 200, body: $contentsBody}
+				);
+				fake.seed(
+					"https://raw.githubusercontent.com/acme/pkgs/main/packages/wheels-sentry/manifest.json",
+					{status: 200, body: $manifest("wheels-sentry")}
+				);
+				fake.seed(
+					"https://raw.githubusercontent.com/acme/pkgs/main/packages/wheels-hotwire/manifest.json",
+					{status: 200, body: $manifest("wheels-hotwire", [
+						{version: "1.0.0", wheelsVersion: ">=4.0", tarball: "x", sha256: "y"},
+						{version: "1.1.0", wheelsVersion: ">=4.0", tarball: "x", sha256: "y"}
+					])}
+				);
+
+				var result = r.listAll();
+
+				expect(ArrayLen(result)).toBe(2);
+				expect(result[1].name).toBe("wheels-hotwire");     // sorted
+				expect(result[1].latestVersion).toBe("1.1.0");     // last version entry wins
+				expect(result[1].homepage).toBe("https://github.com/wheels-dev/wheels-hotwire");
+				expect(result[1].tags).toBe(["utility"]);
+				expect(result[2].name).toBe("wheels-sentry");
+				expect(result[2].latestVersion).toBe("1.0.0");
+			});
+
+		});
+	}
+}
+```
+
+- [ ] **Step 1.2: Run test, verify it fails**
+
+Run (from repo root):
+```bash
+bash tools/test-local.sh packages
+```
+
+Expected: failure on `RegistryListAllSpec` with "listAll is not a function" (or method-not-found). All other specs still pass. If any other spec fails, stop and investigate — do not proceed.
+
+- [ ] **Step 1.3: Implement `listAll()` in Registry.cfc**
+
+Add after `fetchManifest()` (roughly line 106) in `cli/lucli/services/packages/Registry.cfc`:
+
+```cfml
+	/**
+	 * Returns enriched summaries for every package in the registry.
+	 * One HTTP call for the index, one per package for its manifest
+	 * (all cached 24h). Skips packages whose manifest fails to parse;
+	 * propagates a registry-wide unavailability error.
+	 */
+	public array function listAll() {
+		local.names = listPackageNames();
+		local.out = [];
+		for (local.name in local.names) {
+			try {
+				local.m = fetchManifest(local.name);
+			} catch (Wheels.Packages.RegistryMalformed e) {
+				continue;
+			}
+			local.latest = local.m.versions[ArrayLen(local.m.versions)];
+			ArrayAppend(local.out, {
+				name:          local.m.name,
+				description:   local.m.description ?: "",
+				tags:          IsArray(local.m.tags ?: "") ? local.m.tags : [],
+				homepage:      local.m.homepage ?: "",
+				latestVersion: local.latest.version
+			});
+		}
+		return local.out;
+	}
+```
+
+- [ ] **Step 1.4: Run test, verify it passes**
+
+Run:
+```bash
+bash tools/test-local.sh packages
+```
+
+Expected: all package specs pass, including the new one.
+
+- [ ] **Step 1.5: Add test for malformed manifest skip**
+
+Append inside the `describe("Registry.listAll", ...)` block in `RegistryListAllSpec.cfc`, after the first `it`:
+
+```cfml
+			it("skips a package whose manifest is malformed and continues", () => {
+				var fake = new cli.lucli.tests.specs.packages._stubs.FakeHttpClient();
+				var r = new cli.lucli.services.packages.Registry(
+					httpClient = fake, cache = $freshCache(), registryRepo = "acme/pkgs"
+				);
+				fake.seed(
+					"https://api.github.com/repos/acme/pkgs/contents/packages?ref=main",
+					{status: 200, body: $contentsBody}
+				);
+				fake.seed(
+					"https://raw.githubusercontent.com/acme/pkgs/main/packages/wheels-sentry/manifest.json",
+					{status: 200, body: "{""description"": ""no name key""}"}  // malformed — missing required 'name'
+				);
+				fake.seed(
+					"https://raw.githubusercontent.com/acme/pkgs/main/packages/wheels-hotwire/manifest.json",
+					{status: 200, body: $manifest("wheels-hotwire")}
+				);
+
+				var result = r.listAll();
+				expect(ArrayLen(result)).toBe(1);
+				expect(result[1].name).toBe("wheels-hotwire");
+			});
+```
+
+- [ ] **Step 1.6: Run test, verify the new case passes**
+
+Run:
+```bash
+bash tools/test-local.sh packages
+```
+
+Expected: both specs in `RegistryListAllSpec` pass.
+
+- [ ] **Step 1.7: Add test for propagation of unavailability error**
+
+Append inside the same `describe` block:
+
+```cfml
+			it("propagates Wheels.Packages.RegistryUnavailable from listPackageNames", () => {
+				var fake = new cli.lucli.tests.specs.packages._stubs.FakeHttpClient();
+				var r = new cli.lucli.services.packages.Registry(
+					httpClient = fake, cache = $freshCache(), registryRepo = "acme/pkgs"
+				);
+				fake.seed(
+					"https://api.github.com/repos/acme/pkgs/contents/packages?ref=main",
+					{status: 503, body: "service unavailable"}
+				);
+
+				var thrown = "";
+				try {
+					r.listAll();
+				} catch (Wheels.Packages.RegistryUnavailable e) {
+					thrown = e.type;
+				}
+				expect(thrown).toBe("Wheels.Packages.RegistryUnavailable");
+			});
+```
+
+- [ ] **Step 1.8: Run full test suite**
+
+Run:
+```bash
+bash tools/test-local.sh packages
+```
+
+Expected: all three `listAll` specs pass. Total package specs should be previous count + 3.
+
+- [ ] **Step 1.9: Commit**
+
+```bash
+git add cli/lucli/services/packages/Registry.cfc cli/lucli/tests/specs/packages/RegistryListAllSpec.cfc
+git commit -m "feat(cli): add Registry.listAll() returning enriched package summaries"
+```
+
+---
+
+## Task 2: Add `$loadRegistryPackages()` to Public.cfc (TDD)
+
+**Files:**
+- Modify: `vendor/wheels/Public.cfc`
+- Create: `vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc`
+
+**Shape of `$loadRegistryPackages()`:**
+- Returns: `struct` with keys `packages` (array from `Registry.listAll()`), `error` (string — empty on success)
+- Short-circuits to `{packages: [], error: ""}` when `application.wheels.environment == "production"` (defense-in-depth; the handler is already `$blockInProduction()`-gated)
+- Memoizes a `Registry` instance in `application.wheels.$packageRegistry` on first call
+- Try/catches all exceptions from `listAll()`; captures the error message into `error` and returns empty `packages`
+- Accepts an optional `registry` argument for dependency injection in tests
+
+### Steps
+
+- [ ] **Step 2.1: Write failing test — production env short-circuit**
+
+Create `vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc`:
+
+```cfml
+component extends="wheels.WheelsTest" {
+
+	function run() {
+		describe("Public.\$loadRegistryPackages", () => {
+
+			var $newPublic = () => {
+				return new wheels.Public();
+			};
+
+			// Minimal fake registry that returns canned data or throws.
+			var $fakeRegistry = (packages = [], throwType = "", throwMessage = "") => {
+				return CreateObject("component", "wheels.tests._assets.packages.FakeRegistry").init(
+					packages = packages,
+					throwType = throwType,
+					throwMessage = throwMessage
+				);
+			};
+
+			// Swap application.wheels.environment for the duration of a callback.
+			var $withEnv = (env, fn) => {
+				var prior = application.wheels.environment ?: "development";
+				application.wheels.environment = env;
+				try { fn(); }
+				finally { application.wheels.environment = prior; }
+			};
+
+			it("returns empty packages and no error when environment is production", () => {
+				$withEnv("production", () => {
+					var pub = $newPublic();
+					var result = pub.$loadRegistryPackages(
+						registry = $fakeRegistry(packages = [{name: "should-not-appear"}])
+					);
+					expect(result.packages).toBe([]);
+					expect(result.error).toBe("");
+				});
+			});
+
+		});
+	}
+}
+```
+
+Also create the supporting fake at `vendor/wheels/tests/_assets/packages/FakeRegistry.cfc`:
+
+```cfml
+component {
+
+	public FakeRegistry function init(
+		array packages = [],
+		string throwType = "",
+		string throwMessage = ""
+	) {
+		variables.packages = arguments.packages;
+		variables.throwType = arguments.throwType;
+		variables.throwMessage = arguments.throwMessage;
+		return this;
+	}
+
+	public array function listAll() {
+		if (Len(variables.throwType)) {
+			Throw(type = variables.throwType, message = variables.throwMessage);
+		}
+		return variables.packages;
+	}
+}
+```
+
+- [ ] **Step 2.2: Run test, verify it fails**
+
+Run:
+```bash
+bash tools/test-local.sh packages
+```
+
+Expected: failure in `LoadRegistryPackagesSpec` with "$loadRegistryPackages is not a function" or similar. The fake fixture class should load without error (if not, path/prefix is wrong — fix before proceeding).
+
+- [ ] **Step 2.3: Implement `$loadRegistryPackages()` on Public.cfc**
+
+Insert in `vendor/wheels/Public.cfc` near the other `$`-prefixed helpers (after `$blockInProduction()`, before `function index()`):
+
+```cfml
+	/**
+	 * Returns a struct { packages: [...], error: "" } populated from the
+	 * wheels-packages registry. Short-circuits in production (defense in
+	 * depth — the handler is already $blockInProduction()-gated). Captures
+	 * any registry error into the `error` field so the view can render a
+	 * friendly banner instead of a stack trace.
+	 *
+	 * The optional `registry` argument is for tests; normal callers pass
+	 * nothing and get a memoized application-scope Registry instance.
+	 */
+	public struct function $loadRegistryPackages(any registry = "") {
+		if ($shouldBlockInProduction()) {
+			return {packages: [], error: ""};
+		}
+		local.reg = IsObject(arguments.registry) ? arguments.registry : $getRegistryClient();
+		try {
+			return {packages: local.reg.listAll(), error: ""};
+		} catch (any e) {
+			return {packages: [], error: "Registry lookup failed: " & e.message};
+		}
+	}
+
+	/**
+	 * Lazy, app-scope memo of the CLI's Registry component.
+	 */
+	private any function $getRegistryClient() {
+		if (!StructKeyExists(application.wheels, "$packageRegistry")) {
+			application.wheels.$packageRegistry = new cli.lucli.services.packages.Registry();
+		}
+		return application.wheels.$packageRegistry;
+	}
+```
+
+- [ ] **Step 2.4: Run test, verify production short-circuit passes**
+
+Run:
+```bash
+bash tools/test-local.sh packages
+```
+
+Expected: the one `it` block in `LoadRegistryPackagesSpec` passes.
+
+- [ ] **Step 2.5: Add test — happy path in development**
+
+Append inside the `describe` block in `LoadRegistryPackagesSpec.cfc`:
+
+```cfml
+			it("returns packages from the registry in development", () => {
+				$withEnv("development", () => {
+					var pub = $newPublic();
+					var result = pub.$loadRegistryPackages(
+						registry = $fakeRegistry(packages = [
+							{name: "wheels-sentry",  description: "x", tags: [], homepage: "", latestVersion: "1.0.0"}
+						])
+					);
+					expect(ArrayLen(result.packages)).toBe(1);
+					expect(result.packages[1].name).toBe("wheels-sentry");
+					expect(result.error).toBe("");
+				});
+			});
+```
+
+- [ ] **Step 2.6: Run test, verify happy path passes**
+
+Run:
+```bash
+bash tools/test-local.sh packages
+```
+
+Expected: both `it` blocks pass.
+
+- [ ] **Step 2.7: Add test — registry error captured, not thrown**
+
+Append inside the same `describe` block:
+
+```cfml
+			it("captures registry errors into the error field without throwing", () => {
+				$withEnv("development", () => {
+					var pub = $newPublic();
+					var result = pub.$loadRegistryPackages(
+						registry = $fakeRegistry(
+							throwType = "Wheels.Packages.RegistryUnavailable",
+							throwMessage = "GitHub returned 503"
+						)
+					);
+					expect(result.packages).toBe([]);
+					expect(result.error contains "GitHub returned 503").toBeTrue();
+				});
+			});
+```
+
+- [ ] **Step 2.8: Run test, verify error path passes**
+
+Run:
+```bash
+bash tools/test-local.sh packages
+```
+
+Expected: all three `LoadRegistryPackagesSpec` blocks pass.
+
+- [ ] **Step 2.9: Commit**
+
+```bash
+git add vendor/wheels/Public.cfc \
+        vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc \
+        vendor/wheels/tests/_assets/packages/FakeRegistry.cfc
+git commit -m "feat(view): add \$loadRegistryPackages helper for in-app browse UI"
+```
+
+---
+
+## Task 3: Extend `packagelist.cfm` with "Browse registry" section
+
+**Files:**
+- Modify: `vendor/wheels/public/views/packagelist.cfm`
+
+No unit test for the view — the logic is extracted into `$loadRegistryPackages()` (Task 2). This task is pure presentation; verified manually in Task 4.
+
+### Steps
+
+- [ ] **Step 3.1: Extend the cfscript block at the top of `packagelist.cfm`**
+
+After line 39 (closing `</cfscript>` block of the JSON response) — actually line 40 is `</cfscript>`, so open a new block just before the `<cfinclude>` at line 41. Replace lines 40–41 with:
+
+```cfml
+// Load registry packages for the "Browse registry" section.
+// Short-circuits in production via $loadRegistryPackages.
+registryResult = application.$wheels.public.$loadRegistryPackages();
+registryPackages = registryResult.packages;
+registryError = registryResult.error;
+
+// Build a set of installed package keys (lowercased) for quick
+// lookup when rendering the "✓ Installed" badge on registry rows.
+installedKeys = {};
+for (local.key in packageMeta) {
+	installedKeys[LCase(local.key)] = true;
+}
+</cfscript>
+<cfinclude template="../layout/_header.cfm">
+```
+
+(Open the existing `<cfscript>` that ends on line 39 — the JSON-response block — and append these lines before the closing tag, so they run regardless of `format`. Or wrap them in their own new `<cfscript>` block directly below line 39. Either is fine; preserve the abort-on-JSON-format behavior above.)
+
+- [ ] **Step 3.2: Append the "Browse registry" section to the `packagelist.cfm` body**
+
+After the existing closing `</div>` of the installed-packages container (before line 103's closing `</cfoutput>`), insert:
+
+```cfml
+	<div class="ui container" style="margin-top: 3em;">
+		<h2 class="ui header">
+			Browse registry
+			<div class="sub header">
+				Packages available at
+				<a href="https://wheels.dev/packages" target="_blank" rel="noopener">wheels.dev/packages</a>.
+				Install with the CLI.
+			</div>
+		</h2>
+
+		<cfif Len(registryError)>
+			<div class="ui warning message">
+				<div class="header">Registry unavailable</div>
+				<p>#HTMLEditFormat(registryError)#</p>
+			</div>
+		<cfelseif ArrayLen(registryPackages) EQ 0>
+			<div class="ui message">
+				<p>No packages found in the registry.</p>
+			</div>
+		<cfelse>
+			<table class="ui celled striped table">
+				<thead>
+					<tr>
+						<th>Name</th>
+						<th>Description</th>
+						<th>Latest</th>
+						<th>Install</th>
+					</tr>
+				</thead>
+				<tbody>
+					<cfloop array="#registryPackages#" index="local.rp">
+						<cfset local.rpKey = LCase(local.rp.name)>
+						<cfset local.isInstalled = StructKeyExists(installedKeys, local.rpKey)>
+						<tr>
+							<td>
+								<strong>#HTMLEditFormat(local.rp.name)#</strong>
+								<cfif Len(local.rp.homepage)>
+									<br><a href="#HTMLEditFormat(local.rp.homepage)#" target="_blank" rel="noopener" class="ui small grey text">homepage</a>
+								</cfif>
+							</td>
+							<td>#HTMLEditFormat(local.rp.description)#</td>
+							<td>#HTMLEditFormat(local.rp.latestVersion)#</td>
+							<td>
+								<cfif local.isInstalled>
+									<span class="ui label"><i class="check icon"></i> Installed</span>
+								<cfelse>
+									<code id="install-#HTMLEditFormat(local.rpKey)#">wheels packages install #HTMLEditFormat(local.rp.name)#</code>
+									<button type="button"
+										class="ui tiny button"
+										onclick="navigator.clipboard.writeText(document.getElementById('install-#HTMLEditFormat(local.rpKey)#').innerText)">
+										Copy
+									</button>
+								</cfif>
+							</td>
+						</tr>
+					</cfloop>
+				</tbody>
+			</table>
+		</cfif>
+	</div>
+```
+
+**Critical formatting notes:**
+- `##` in CSS selectors / id references — CFML requires `##` to emit literal `#`. The view uses `#HTMLEditFormat(local.rpKey)#` interpolation inside the id so `##` is not needed here, but double-check Lucee 7 + Adobe 2023 both render the element ids correctly before merging.
+- `rel="noopener"` on all external links.
+- No inline event handlers besides the simple `onclick` for clipboard — consistent with the rest of this view.
+
+- [ ] **Step 3.3: Verify CFML syntax by running the existing view spec**
+
+Run:
+```bash
+bash tools/test-local.sh packages
+```
+
+Expected: all previously-passing specs still pass. The view isn't directly spec'd, but any syntax error in `packagelist.cfm` crashes the CFML compiler when the Public component is instantiated at app start — which will cause unrelated specs to fail. If you see spec failures that reference `packagelist.cfm` or `Public.cfc`, fix the syntax before proceeding.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add vendor/wheels/public/views/packagelist.cfm
+git commit -m "feat(view): add browse-registry section to /wheels/packages"
+```
+
+---
+
+## Task 4: Manual verification against the live registry
+
+Not a code step; an end-to-end smoke test before the PR is opened.
+
+### Steps
+
+- [ ] **Step 4.1: Start a local Wheels dev server**
+
+```bash
+lucli server run --port=8080
+```
+
+Wait for "Server started on port 8080".
+
+- [ ] **Step 4.2: Force a reload so Public.cfc picks up the new methods**
+
+```bash
+curl -s "http://localhost:8080/?reload=true&password=wheels" > /dev/null
+```
+
+- [ ] **Step 4.3: Load the packages page in a browser (or curl)**
+
+Browser: `http://localhost:8080/wheels/packages`
+Or:
+```bash
+curl -s "http://localhost:8080/wheels/packages" | head -200
+```
+
+Expected:
+- Page renders without a 500 error
+- Original "Installed packages" table still appears (likely empty in a fresh dev app)
+- New "Browse registry" section appears below
+- Section lists the 4 live registry packages: `wheels-basecoat`, `wheels-hotwire`, `wheels-legacy-adapter`, `wheels-sentry`
+- Each has a `wheels packages install <name>` snippet and a Copy button
+- No row shows an "Installed" badge (fresh app has no vendor packages beyond `wheels/` itself, which the registry doesn't include)
+
+If the registry is unavailable (offline, rate-limited), expect the yellow "Registry unavailable" banner with the error message — not a 500.
+
+- [ ] **Step 4.4: Install one package with the CLI, reload, verify the "Installed" badge**
+
+```bash
+wheels packages install wheels-sentry
+curl -s "http://localhost:8080/?reload=true&password=wheels" > /dev/null
+```
+
+Reload the browser on `/wheels/packages`.
+
+Expected: the `wheels-sentry` row in the Browse registry table now shows `✓ Installed` instead of the install snippet; the installed-packages table above it has a new `wheels-sentry` entry.
+
+- [ ] **Step 4.5: Remove the package to leave the worktree clean**
+
+```bash
+wheels packages remove wheels-sentry --yes
+curl -s "http://localhost:8080/?reload=true&password=wheels" > /dev/null
+```
+
+- [ ] **Step 4.6: Verify production gating**
+
+Temporarily flip the env. In `config/environment.cfm`, change the environment to `"production"` for a single reload:
+
+```cfml
+// Temporary: for manual verification only. Revert after.
+set(environment = "production");
+```
+
+```bash
+curl -s "http://localhost:8080/?reload=true&password=wheels" > /dev/null
+curl -si "http://localhost:8080/wheels/packages" | head -20
+```
+
+Expected: HTTP 404 response (`$blockInProduction()` on the handler fires before the view runs). If it returns a 200 and renders the page, stop and investigate — the gate is broken.
+
+Revert `config/environment.cfm` and reload once more.
+
+```bash
+git checkout config/environment.cfm
+curl -s "http://localhost:8080/?reload=true&password=wheels" > /dev/null
+```
+
+---
+
+## Task 5: Update CHANGELOG and open PR
+
+### Steps
+
+- [ ] **Step 5.1: Add CHANGELOG entry**
+
+Open `CHANGELOG.md` and add a line under the "Unreleased" (or current working) section. Match the style of existing entries:
+
+```markdown
+- feat(view): `/wheels/packages` now shows a "Browse registry" section listing packages available from `wheels-dev/wheels-packages`, with copy-to-clipboard install commands. Dev/testing only — production is 404-gated. (#2271, partial — wheels.dev side deferred)
+```
+
+- [ ] **Step 5.2: Commit CHANGELOG**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(docs): note in-app browse-registry section for #2271"
+```
+
+- [ ] **Step 5.3: Push branch and open PR against `develop`**
+
+```bash
+git push -u origin claude/fervent-brahmagupta-c9a826
+gh pr create --base develop --title "feat(view): add browse-registry section to /wheels/packages (#2271 partial)" --body "$(cat <<'EOF'
+## Summary
+- Adds a "Browse registry" section to `/wheels/packages` that lists installable packages from `wheels-dev/wheels-packages`
+- Reuses the CLI's `Registry` component — same data source as `wheels packages list`
+- Dev/testing only; `Public.cfc`'s `\$blockInProduction()` gate plus a view-level env check keep this off production servers
+- No install-via-browser action; each row shows a copy-to-clipboard `wheels packages install <name>` snippet
+- Rows matching an installed package show a `✓ Installed` badge instead
+
+## Scope
+This is the in-app half of #2271. The `wheels.dev/packages` Astro static-site work is deferred — see the Revision note in `docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md`. #2271 stays open.
+
+## Test plan
+- [ ] Package specs pass locally: `bash tools/test-local.sh packages`
+- [ ] Full core test suite passes: `bash tools/test-local.sh`
+- [ ] Manual: `/wheels/packages` renders registry list in dev
+- [ ] Manual: `/wheels/packages` returns 404 in production
+- [ ] Manual: installing a package via CLI then reloading shows the `✓ Installed` badge
+EOF
+)"
+```
+
+- [ ] **Step 5.4: Wait for CI green (code tier)**
+
+Per `CLAUDE.local.md`: this is a code-tier PR (touches `vendor/`, `cli/`). Wait for the **full** check suite to pass — not just required checks. Treat `pending`/`queued`/`in_progress` as "not done." Treat `fail`/`cancelled` as a stop.
+
+Poll with:
+```bash
+gh pr checks
+```
+
+When all checks are `pass`, merge with:
+```bash
+gh pr merge --squash --delete-branch
+```
+
+Report the merge commit SHA and confirm branch deletion.
+
+---
+
+## Self-review notes (executed during plan writing)
+
+- **Spec coverage check:** Every Component-1 requirement in the spec is covered by Tasks 1–3. Component 2/3 are out of scope per the Revision note — spec updated to reflect that.
+- **Placeholder scan:** No TBDs, no "handle errors appropriately," every code block is complete.
+- **Type consistency:** `listAll()` returns `{name, description, tags, latestVersion, homepage}`; `$loadRegistryPackages()` consumes that shape; the view reads those exact keys.
+- **Deviation from spec:** Spec proposed a new `vendor/wheels/global/packages.cfm` file for the helper. Plan puts the helper on `Public.cfc` instead — simpler, matches the pattern of the other `$`-prefixed helpers in that file, no new file needed. Spec diagram/architecture otherwise matches the plan.
+- **Deviation from spec:** Spec originally proposed an `isStale()` flag on the registry client. Plan drops it — the in-app page can show either a success or a warning banner; there's no meaningful third "stale cache" state to surface in the UI. Less code, same UX.

--- a/docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md
+++ b/docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md
@@ -1,18 +1,28 @@
 # wheels-packages Phase 4 — Discovery UI
 
-**Status:** draft
+**Status:** in progress — wheels.dev portion deferred (see "Revision" below)
 **Date:** 2026-04-23
 **Issue:** [#2271](https://github.com/wheels-dev/wheels/issues/2271) (Phase 4 of [#2243](https://github.com/wheels-dev/wheels/issues/2243))
 **Depends on:** [#2233](https://github.com/wheels-dev/wheels/issues/2233) (production gating, already closed)
+
+## Revision — 2026-04-23
+
+Initial draft assumed `wheels.dev` was a live CFML app (legacy `wheels-dev/wheels.dev` repo). It is not. The site was migrated to four Astro static sites in this repo under `web/sites/{landing,guides,api,blog}/`, deployed to Cloudflare Pages via `.github/workflows/web-deploy.yml`.
+
+**Scope split:**
+- **In-app surface (Component 1)** — ships first, captured in full by this spec and the companion plan at `docs/superpowers/plans/2026-04-23-wheels-packages-phase4-inapp.md`.
+- **wheels.dev surface (Components 2 + 3)** — **deferred**. Will be redesigned against the Astro architecture in a follow-up spec before implementation. The CFML `RegistryClient` + `PackagesController` described below are superseded and should be treated as historical context only. The replacement approach will be build-time data fetching in Astro frontmatter (`getStaticPaths()`), with a `repository_dispatch` trigger from `wheels-dev/wheels-packages` → this repo's `web-deploy.yml` so manifest merges rebuild the landing site automatically.
+
+Issue #2271 will not close on the in-app PR. It stays open to track the deferred wheels.dev work.
 
 ## Summary
 
 Ship the discovery UI for the `wheels-packages` ecosystem on two surfaces:
 
-1. **`wheels.dev/packages`** — public listing + detail pages that read the registry over HTTP and render version history, install commands, and the per-package README.
+1. **`wheels.dev/packages`** — public listing + detail pages (Astro static site, deferred — see Revision above).
 2. **`/wheels/packages`** — in-app developer page, already shows *installed* packages; Phase 4 adds a **"Browse registry"** section so developers can discover installable packages without leaving their app.
 
-Both surfaces read the same GitHub-hosted registry (`wheels-dev/wheels-packages`) with a 24-hour cache. There is no install-via-browser action; installation remains a CLI operation (`wheels packages install <name>`).
+Both surfaces read the same GitHub-hosted registry (`wheels-dev/wheels-packages`). The in-app surface reuses the CLI's `Registry.cfc` with a 24-hour app-scope cache. There is no install-via-browser action; installation remains a CLI operation (`wheels packages install <name>`).
 
 ## Current state (pre-Phase-4)
 
@@ -129,7 +139,7 @@ if (application.wheels.environment != "production") {
 
 If `listAll()` does not yet exist on `Registry.cfc`, add it. Keep the shape symmetrical with the new wheels.dev `RegistryClient`.
 
-### Component 2 — wheels.dev: RegistryClient service
+### Component 2 — wheels.dev: RegistryClient service [DEFERRED — see Revision]
 
 **File:** `app/models/services/RegistryClient.cfc` (~100 lines).
 
@@ -155,7 +165,7 @@ RegistryClient init(
 di.map("registryClient").to("app.models.services.RegistryClient").asSingleton();
 ```
 
-### Component 3 — wheels.dev: PackagesController + views + routes
+### Component 3 — wheels.dev: PackagesController + views + routes [DEFERRED — see Revision]
 
 **Controller:** `app/controllers/web/PackagesController.cfc`
 

--- a/docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md
+++ b/docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md
@@ -42,7 +42,7 @@ Both surfaces read the same GitHub-hosted registry (`wheels-dev/wheels-packages`
 Each surface runs its own registry client pointed at the same GitHub endpoints:
 
 - **CLI**: existing `cli.lucli.services.packages.Registry` — file-based 24h cache under `~/.wheels/cache/packages/`.
-- **In-app `/wheels/packages`**: reuses the **CLI's** `Registry.cfc` directly (it's on the classpath of every Wheels app). Cached in `application.wheels.$packageRegistry` (app-scope memo).
+- **In-app `/wheels/packages`**: reuses the **CLI's** `Registry.cfc` directly when it's on the classpath (framework repo via `public/Application.cfc`'s `/cli` mapping). In `wheels new`-generated user apps the CLI isn't shipped alongside, so the helper silently returns an empty browse-registry section — no crash, installed-packages table still renders normally. Cached in `application.wheels.$packageRegistry` (app-scope memo).
 - **wheels.dev**: new `app/models/services/RegistryClient.cfc` — sibling implementation, application-scope cache, same endpoints, same TTL.
 
 Rejected alternatives:

--- a/docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md
+++ b/docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md
@@ -1,0 +1,284 @@
+# wheels-packages Phase 4 — Discovery UI
+
+**Status:** draft
+**Date:** 2026-04-23
+**Issue:** [#2271](https://github.com/wheels-dev/wheels/issues/2271) (Phase 4 of [#2243](https://github.com/wheels-dev/wheels/issues/2243))
+**Depends on:** [#2233](https://github.com/wheels-dev/wheels/issues/2233) (production gating, already closed)
+
+## Summary
+
+Ship the discovery UI for the `wheels-packages` ecosystem on two surfaces:
+
+1. **`wheels.dev/packages`** — public listing + detail pages that read the registry over HTTP and render version history, install commands, and the per-package README.
+2. **`/wheels/packages`** — in-app developer page, already shows *installed* packages; Phase 4 adds a **"Browse registry"** section so developers can discover installable packages without leaving their app.
+
+Both surfaces read the same GitHub-hosted registry (`wheels-dev/wheels-packages`) with a 24-hour cache. There is no install-via-browser action; installation remains a CLI operation (`wheels packages install <name>`).
+
+## Current state (pre-Phase-4)
+
+| Surface | Status |
+|---|---|
+| `wheels-dev/wheels-packages` registry | ✅ Live. 4 packages: sentry, hotwire, basecoat, legacy-adapter. Manifests + mirrored tarballs as GH Release assets. |
+| `cli/lucli/services/packages/Registry.cfc` | ✅ Live. GH contents API + raw.githubusercontent.com, 24h file-based cache, env-var override (`WHEELS_PACKAGES_REGISTRY`). |
+| `vendor/wheels/Public.cfc` → `packagelist()` / `packageentry()` | ✅ Wired. `$blockInProduction()` gate applied (per #2233). |
+| `vendor/wheels/public/views/packagelist.cfm` + `packageentry.cfm` | ✅ Show **installed** packages from `application.wheels.packageMeta`. Gated by `enablePackagesComponent`. |
+| `wheels.dev/packages` + detail page | ❌ No controller, no views, no routes. |
+| Registry "browse" section on in-app page | ❌ Not implemented. |
+
+## Design decisions
+
+### D1. Data architecture — separate fetchers, same endpoints (Option A)
+
+Each surface runs its own registry client pointed at the same GitHub endpoints:
+
+- **CLI**: existing `cli.lucli.services.packages.Registry` — file-based 24h cache under `~/.wheels/cache/packages/`.
+- **In-app `/wheels/packages`**: reuses the **CLI's** `Registry.cfc` directly (it's on the classpath of every Wheels app). Cached in `application.wheels.$packageRegistry` (app-scope memo).
+- **wheels.dev**: new `app/models/services/RegistryClient.cfc` — sibling implementation, application-scope cache, same endpoints, same TTL.
+
+Rejected alternatives:
+- **Aggregated `index.json`** committed by CI — adds a CI job for minimal benefit at 4 packages.
+- **Shared client component** across CLI and wheels.dev — premature DRY; the wheels.dev app lives in a separate repo and can't cleanly consume a CLI-bundled component without introducing a dependency edge that doesn't exist today.
+
+### D2. In-app page — "dual view" (Option B)
+
+Keep the existing installed-packages table. Add a **"Browse registry"** section below it:
+
+- Per-package row: name (→ `https://wheels.dev/packages/<name>`), description, tags, latest version, copy-to-clipboard `wheels packages install <name>` snippet.
+- Rows where the package is already installed render a muted `✓ Installed` badge instead of the install snippet.
+- No install button. CLI is the only install path (security + simplicity).
+
+Rejected alternatives:
+- **Installed-only** (link out to wheels.dev for discovery): misses the value of in-context browsing while coding.
+- **Full parity with wheels.dev/packages in-app**: duplicates UI without adding functionality, since you still can't install via HTTP.
+
+### D3. wheels.dev detail content — enriched with README (Option 3b-ii)
+
+The detail page (`/packages/[name]`) renders:
+- Header: name, latest version, homepage link, tags
+- Copy-to-clipboard install snippets (latest + version-pinned)
+- Version history table
+- Rendered README (Markdown → HTML via existing `markdownToHtml()` helper)
+
+No per-version deep-link URLs in Phase 4. Added later only if demand materializes.
+
+## Architecture
+
+```
+                      wheels-dev/wheels-packages (GitHub)
+                       ├─ GH contents API: /packages dir listing
+                       └─ raw.githubusercontent.com: manifests + READMEs
+                                    │
+                   ┌────────────────┴────────────────┐
+                   │                                 │
+          ┌────────▼────────┐               ┌────────▼────────┐
+          │  CLI Registry   │               │ wheels.dev      │
+          │  (existing)     │               │ RegistryClient  │
+          │  24h file cache │               │ 24h app-scope   │
+          └─────────────────┘               │ cache           │
+                                            └────────┬────────┘
+                                                     │
+                                    ┌────────────────┴──────────────┐
+                                    │                               │
+                             PackagesController             /wheels/packages
+                             /packages (index)              (Public.cfc
+                             /packages/[name] (show)        packagelist())
+                                                            adds "Browse
+                                                            registry" section
+```
+
+## Components to build
+
+### Component 1 — wheels repo: in-app registry lookup
+
+**Files touched:**
+- `vendor/wheels/public/views/packagelist.cfm` — extend with "Browse registry" section
+- `vendor/wheels/global/packages.cfm` — **new** file. Adds `$getRegistryClient()` helper. Keeping it in its own file (rather than appending to `events/functions.cfm`) isolates the new dependency on `cli.lucli.services.packages.Registry` and makes the helper trivial to remove if the package system is ever unbundled from core.
+
+**New helper (pseudocode):**
+```cfml
+public any function $getRegistryClient() {
+    if (!StructKeyExists(application.wheels, "$packageRegistry")) {
+        application.wheels.$packageRegistry =
+            new cli.lucli.services.packages.Registry();
+    }
+    return application.wheels.$packageRegistry;
+}
+```
+
+**View additions (above existing guard, with env-gate):**
+```cfml
+local.registryPackages = [];
+local.registryError = "";
+local.registryStale = false;
+if (application.wheels.environment != "production") {
+    try {
+        local.reg = $getRegistryClient();
+        local.registryPackages = local.reg.listAll();
+        local.registryStale = local.reg.isStale();
+    } catch (Wheels.Packages.RegistryUnavailable e) {
+        local.registryError = e.message;
+    } catch (any e) {
+        local.registryError = "Registry lookup failed: " & e.message;
+    }
+}
+```
+
+**Registry.cfc additions required:**
+- `public array function listAll()` — returns `[{name, description, tags, latestVersion, homepage}, ...]`. Reuses existing `listPackageNames()` + per-package `fetchManifest()` internally.
+- `public boolean function isStale()` — true if last fetch was served from cache after an upstream failure.
+
+If `listAll()` does not yet exist on `Registry.cfc`, add it. Keep the shape symmetrical with the new wheels.dev `RegistryClient`.
+
+### Component 2 — wheels.dev: RegistryClient service
+
+**File:** `app/models/services/RegistryClient.cfc` (~100 lines).
+
+**Responsibilities:**
+- Fetch `/packages` directory listing from `https://api.github.com/repos/{repo}/contents/packages?ref={branch}`
+- Fetch per-package manifest from `https://raw.githubusercontent.com/{repo}/{branch}/packages/{name}/manifest.json`
+- Fetch per-package README from `https://raw.githubusercontent.com/{repo}/{branch}/packages/{name}/README.md`
+- Cache all three in `application` scope with 24h TTL
+- Env-var override: `WHEELS_PACKAGES_REGISTRY` (default `wheels-dev/wheels-packages`)
+- Stale-on-error: if GitHub returns 5xx/403, serve cached value and flag `stale=true`
+
+**Constructor signature (testable):**
+```cfml
+RegistryClient init(
+    any httpClient = "",     // wrapper; defaults to cfhttp-based impl
+    string registryRepo = "",
+    string branch = "main"
+)
+```
+
+**Registration** in `config/services.cfm`:
+```cfml
+di.map("registryClient").to("app.models.services.RegistryClient").asSingleton();
+```
+
+### Component 3 — wheels.dev: PackagesController + views + routes
+
+**Controller:** `app/controllers/web/PackagesController.cfc`
+
+```cfml
+component extends="web.Controller" {
+    function config() {
+        filters(through = "loadRegistry");
+    }
+
+    private function loadRegistry() {
+        registry = service("registryClient");
+    }
+
+    function index() {
+        packages = registry.listAll();
+        q = params.q ?: "";
+        if (Len(q)) packages = $filterByQuery(packages, q);
+        // $filterByQuery: case-insensitive substring match against name,
+        // description, and tags. Controller-private helper, trivial impl.
+        registryStale = registry.isStale();
+    }
+
+    function show() {
+        pkg = registry.getPackage(params.name);
+        if (!StructKeyExists(pkg, "name")) {
+            redirectTo(controller="errorController", action="error404");
+            return;
+        }
+        readmeHtml = markdownToHtml(registry.getReadme(params.name));
+        registryStale = registry.isStale();
+    }
+}
+```
+
+**Routes** (insert in `config/routes.cfm` above the `.namespace("admin")` block, after existing `.get(name="api_docs", ...)`):
+```cfml
+.get(name = "packages", pattern = "packages", to = "web.PackagesController##index")
+.get(name = "package-detail", pattern = "packages/[name]", to = "web.PackagesController##show")
+```
+
+**Admin refresh endpoint** (inside existing `admin` namespace):
+```cfml
+.post(name = "packages-refresh", pattern = "packages/refresh", to = "PackagesController##refresh")
+```
+(The admin `PackagesController` lives under `app/controllers/admin/PackagesController.cfc` and calls `registry.flushCache()`.)
+
+**Views:**
+- `app/views/web/PackagesController/index.cfm` — listing. Top bar: `searchField(name="q")`. Table columns: name (→ detail link), description, tags (chips), latest version. Stale/error banner when applicable.
+- `app/views/web/PackagesController/show.cfm` — header, install snippet (copy-to-clipboard), version history table, rendered README below.
+
+**Install snippet template** (inline JS for copy button, identical pattern across both surfaces):
+```html
+<pre><code id="install-#name#">wheels packages install #name#</code>
+  <button onclick="navigator.clipboard.writeText(document.getElementById('install-#name#').innerText)">Copy</button>
+</pre>
+```
+
+Package name is constrained to `^[a-z0-9][a-z0-9-]*$` by `manifest.schema.json`, and is additionally HTML-escaped during render.
+
+## Error handling
+
+| Condition | Behavior |
+|---|---|
+| GitHub 200 | Serve + cache for 24h |
+| GitHub 403 (rate-limit) / 5xx, cache present | Serve cached, `isStale=true`, show warning banner |
+| GitHub 403 / 5xx, cache empty | Show "Registry temporarily unavailable" card; no 500 to user |
+| Malformed manifest JSON | Skip that package, log warning, others render normally |
+| Package not in registry (detail page) | 404 via `errorController.error404` |
+
+## Security
+
+- Only the hardcoded registry repo is contacted by `cfhttp`. Env-var override allows different repos (for forks/mirrors/tests) but the value is a repo slug, never a full URL.
+- README rendering uses the existing `markdownToHtml()` helper. During impl, verify the sanitizer strips `<script>` and `on*=` attributes; reuse whatever the blog/guide views already do.
+- Copy-to-clipboard snippet: package name is the only variable and is pattern-constrained by the registry schema. HTML-escape on render anyway.
+- In-app registry lookup is gated by both `$blockInProduction()` (handler level) and a view-level `environment != "production"` check (defense in depth).
+
+## Testing
+
+### wheels.dev
+- `tests/specs/services/RegistryClientSpec.cfc` — BDD, uses `FakeHttpClient` fixture. Covers: list success, manifest success, README success, 5xx → stale-cache fallback, 403 → stale-cache fallback, cache TTL respected, hardcoded repo default, env-var override, malformed JSON skipped.
+- `tests/specs/controllers/PackagesControllerSpec.cfc` — routes resolve, 404 on unknown package, README renders in show view, install snippet present, search query filters list.
+- No live-network tests.
+
+### wheels (in-app)
+- `vendor/wheels/tests/specs/packages/PackageListViewSpec.cfc` — asserts "Browse registry" section renders in dev; does NOT render when `environment = production`; shows cached data when registry throws; renders `✓ Installed` badge when a registry name matches `packageMeta`.
+- Existing `PackagesRegistryCliSpec.cfc` / `PackagesMainCliSpec.cfc` continue to cover the `Registry.cfc` fetch/cache path — no duplication needed.
+
+### Manual verification (before PR)
+- `wheels.dev/packages` renders all 4 packages against live registry
+- `/packages/wheels-sentry` renders README + version history + install snippet
+- `/wheels/packages` in a dev Wheels app shows "Browse registry" section below installed list
+- Set `environment = production` in a test harness → confirm in-app registry section does not render (and Public.cfc handler already 404s)
+- `WHEELS_PACKAGES_REGISTRY=bpamiri/test-registry` → both surfaces honor the override
+
+## Build sequence
+
+Each item is independently shippable:
+
+1. **wheels repo — in-app "Browse registry"** (PR against `develop`)
+   - Add `$getRegistryClient()` helper + `listAll()` / `isStale()` on `Registry.cfc`
+   - Extend `packagelist.cfm` with new section
+   - Spec coverage for env gating + installed-badge collision
+
+2. **wheels.dev repo — RegistryClient + PackagesController** (single PR — service without a caller is noise)
+   - `RegistryClient.cfc` + `FakeHttpClient` fixture
+   - DI registration in `config/services.cfm`
+   - Controller (public + admin refresh), 2 views, 2+1 route entries
+   - Spec coverage: service fetch/cache/stale/override, controller routes + 404 path
+
+Steps 1 and 2 are independent (different repos) and can land in either order.
+
+## Out of scope (explicit YAGNI)
+
+- Admin UI for managing packages (add/approve/reject). PRs to the registry repo remain the contribution path.
+- Download counts, stars, "popular this week" metrics.
+- Per-version deep-link URLs (`/packages/[name]/[version]`). Added later on demand.
+- Dependency graph visualization.
+- Server-side search index. Client-side filter is fine for 4–40 packages.
+- RSS/Atom feed for new versions.
+- Install-via-browser action. CLI-only by design.
+- Unified `index.json` aggregation across the registry. Each surface fetches its own data.
+
+## Open items (non-blocking, resolve during impl)
+
+- Confirm which Markdown sanitizer the wheels.dev blog/guide views use; reuse for `/packages/[name]`.
+- Confirm admin auth filter pattern for the cache-refresh endpoint; match existing `AdminController` behavior.

--- a/vendor/wheels/Public.cfc
+++ b/vendor/wheels/Public.cfc
@@ -36,6 +36,38 @@ component output="false" displayName="Internal GUI" extends="wheels.Global" {
 		}
 	}
 
+	/**
+	 * Returns a struct { packages: [...], error: "" } populated from the
+	 * wheels-packages registry. Short-circuits in production (defense in
+	 * depth — the handler is already $blockInProduction()-gated). Captures
+	 * any registry error into the `error` field so the view can render a
+	 * friendly banner instead of a stack trace.
+	 *
+	 * The optional `registry` argument is for tests; normal callers pass
+	 * nothing and get a memoized application-scope Registry instance.
+	 */
+	public struct function $loadRegistryPackages(any registry = "") {
+		if ($shouldBlockInProduction()) {
+			return {packages: [], error: ""};
+		}
+		local.reg = IsObject(arguments.registry) ? arguments.registry : $getRegistryClient();
+		try {
+			return {packages: local.reg.listAll(), error: ""};
+		} catch (any e) {
+			return {packages: [], error: "Registry lookup failed: " & e.message};
+		}
+	}
+
+	/**
+	 * Lazy, app-scope memo of the CLI's Registry component.
+	 */
+	private any function $getRegistryClient() {
+		if (!StructKeyExists(application.wheels, "$packageRegistry")) {
+			application.wheels.$packageRegistry = new cli.lucli.services.packages.Registry();
+		}
+		return application.wheels.$packageRegistry;
+	}
+
 	/*
 	This is just a proof of concept
 	*/

--- a/vendor/wheels/Public.cfc
+++ b/vendor/wheels/Public.cfc
@@ -50,6 +50,13 @@ component output="false" displayName="Internal GUI" extends="wheels.Global" {
 		if ($shouldBlockInProduction()) {
 			return {packages: [], error: ""};
 		}
+		// User apps generated with `wheels new` don't ship the CLI alongside.
+		// When the Registry class isn't on the classpath, silently disable the
+		// browse-registry feature rather than crashing. The installed-packages
+		// table still renders normally.
+		if (!IsObject(arguments.registry) && !$registryClientAvailable()) {
+			return {packages: [], error: ""};
+		}
 		local.reg = IsObject(arguments.registry) ? arguments.registry : $getRegistryClient();
 		try {
 			return {packages: local.reg.listAll(), error: ""};
@@ -60,6 +67,16 @@ component output="false" displayName="Internal GUI" extends="wheels.Global" {
 		} catch ("Wheels.Packages.UnknownPackage" e) {
 			return {packages: [], error: "Registry lookup failed: " & e.message};
 		}
+	}
+
+	/**
+	 * True if the CLI's Registry component is on the classpath — i.e., we're
+	 * running inside the framework repo (or a user app that ships the CLI
+	 * alongside). In a plain user app this returns false and the browse-
+	 * registry section silently disables.
+	 */
+	private boolean function $registryClientAvailable() {
+		return FileExists(ExpandPath("/cli/lucli/services/packages/Registry.cfc"));
 	}
 
 	/**

--- a/vendor/wheels/Public.cfc
+++ b/vendor/wheels/Public.cfc
@@ -53,7 +53,11 @@ component output="false" displayName="Internal GUI" extends="wheels.Global" {
 		local.reg = IsObject(arguments.registry) ? arguments.registry : $getRegistryClient();
 		try {
 			return {packages: local.reg.listAll(), error: ""};
-		} catch (any e) {
+		} catch ("Wheels.Packages.RegistryUnavailable" e) {
+			return {packages: [], error: "Registry lookup failed: " & e.message};
+		} catch ("Wheels.Packages.RegistryMalformed" e) {
+			return {packages: [], error: "Registry lookup failed: " & e.message};
+		} catch ("Wheels.Packages.UnknownPackage" e) {
 			return {packages: [], error: "Registry lookup failed: " & e.message};
 		}
 	}

--- a/vendor/wheels/public/views/packagelist.cfm
+++ b/vendor/wheels/public/views/packagelist.cfm
@@ -38,6 +38,20 @@ if (request.wheels.params.format == "json") {
 	abort;
 }
 </cfscript>
+<cfscript>
+// Load registry packages for the "Browse registry" section.
+// Short-circuits in production via $loadRegistryPackages.
+registryResult = application.$wheels.public.$loadRegistryPackages();
+registryPackages = registryResult.packages;
+registryError = registryResult.error;
+
+// Build a set of installed package keys (lowercased) for quick
+// lookup when rendering the "✓ Installed" badge on registry rows.
+installedKeys = {};
+for (local.key in packageMeta) {
+	installedKeys[LCase(local.key)] = true;
+}
+</cfscript>
 <cfinclude template="../layout/_header.cfm">
 <cfoutput>
 <!--- cfformat-ignore-start --->
@@ -97,6 +111,67 @@ if (request.wheels.params.format == "json") {
 			</div>
 			<p>Activate packages by copying them from <code>packages/</code> to <code>vendor/</code>.</p>
 		</div>
+	</cfif>
+</div>
+
+<div class="ui container" style="margin-top: 3em;">
+	<h2 class="ui header">
+		Browse registry
+		<div class="sub header">
+			Packages available at
+			<a href="https://wheels.dev/packages" target="_blank" rel="noopener">wheels.dev/packages</a>.
+			Install with the CLI.
+		</div>
+	</h2>
+
+	<cfif Len(registryError)>
+		<div class="ui warning message">
+			<div class="header">Registry unavailable</div>
+			<p>#HTMLEditFormat(registryError)#</p>
+		</div>
+	<cfelseif ArrayLen(registryPackages) EQ 0>
+		<div class="ui message">
+			<p>No packages found in the registry.</p>
+		</div>
+	<cfelse>
+		<table class="ui celled striped table">
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Description</th>
+					<th>Latest</th>
+					<th>Install</th>
+				</tr>
+			</thead>
+			<tbody>
+				<cfloop array="#registryPackages#" index="local.rp">
+					<cfset local.rpKey = LCase(local.rp.name)>
+					<cfset local.isInstalled = StructKeyExists(installedKeys, local.rpKey)>
+					<tr>
+						<td>
+							<strong>#HTMLEditFormat(local.rp.name)#</strong>
+							<cfif Len(local.rp.homepage)>
+								<br><a href="#HTMLEditFormat(local.rp.homepage)#" target="_blank" rel="noopener" class="ui small grey text">homepage</a>
+							</cfif>
+						</td>
+						<td>#HTMLEditFormat(local.rp.description)#</td>
+						<td>#HTMLEditFormat(local.rp.latestVersion)#</td>
+						<td>
+							<cfif local.isInstalled>
+								<span class="ui label"><i class="check icon"></i> Installed</span>
+							<cfelse>
+								<code id="install-#HTMLEditFormat(local.rpKey)#">wheels packages install #HTMLEditFormat(local.rp.name)#</code>
+								<button type="button"
+									class="ui tiny button"
+									onclick="navigator.clipboard.writeText(document.getElementById('install-#HTMLEditFormat(local.rpKey)#').innerText)">
+									Copy
+								</button>
+							</cfif>
+						</td>
+					</tr>
+				</cfloop>
+			</tbody>
+		</table>
 	</cfif>
 </div>
 

--- a/vendor/wheels/public/views/packagelist.cfm
+++ b/vendor/wheels/public/views/packagelist.cfm
@@ -150,7 +150,7 @@ for (local.key in packageMeta) {
 					<tr>
 						<td>
 							<strong>#HTMLEditFormat(local.rp.name)#</strong>
-							<cfif Len(local.rp.homepage)>
+							<cfif Len(local.rp.homepage) AND REFindNoCase("^https?://", local.rp.homepage)>
 								<br><a href="#HTMLEditFormat(local.rp.homepage)#" target="_blank" rel="noopener" class="ui small grey text">homepage</a>
 							</cfif>
 						</td>
@@ -160,10 +160,13 @@ for (local.key in packageMeta) {
 							<cfif local.isInstalled>
 								<span class="ui label"><i class="check icon"></i> Installed</span>
 							<cfelse>
+								<!--- rp.name is registry-schema-constrained to ^[a-z0-9][a-z0-9-]*$, so both id and JS string are already safe.
+								      JSStringFormat() is applied in the onclick defensively in case that invariant ever loosens. --->
 								<code id="install-#HTMLEditFormat(local.rpKey)#">wheels packages install #HTMLEditFormat(local.rp.name)#</code>
 								<button type="button"
 									class="ui tiny button"
-									onclick="navigator.clipboard.writeText(document.getElementById('install-#HTMLEditFormat(local.rpKey)#').innerText)">
+									aria-label="Copy install command for #HTMLEditFormat(local.rp.name)#"
+									onclick="navigator.clipboard.writeText(document.getElementById('install-#JSStringFormat(local.rpKey)#').innerText)">
 									Copy
 								</button>
 							</cfif>

--- a/vendor/wheels/public/views/packagelist.cfm
+++ b/vendor/wheels/public/views/packagelist.cfm
@@ -41,7 +41,7 @@ if (request.wheels.params.format == "json") {
 <cfscript>
 // Load registry packages for the "Browse registry" section.
 // Short-circuits in production via $loadRegistryPackages.
-registryResult = application.$wheels.public.$loadRegistryPackages();
+registryResult = application.wheels.public.$loadRegistryPackages();
 registryPackages = registryResult.packages;
 registryError = registryResult.error;
 

--- a/vendor/wheels/tests/_assets/packages/FakeRegistry.cfc
+++ b/vendor/wheels/tests/_assets/packages/FakeRegistry.cfc
@@ -1,0 +1,20 @@
+component {
+
+	public FakeRegistry function init(
+		array packages = [],
+		string throwType = "",
+		string throwMessage = ""
+	) {
+		variables.packages = arguments.packages;
+		variables.throwType = arguments.throwType;
+		variables.throwMessage = arguments.throwMessage;
+		return this;
+	}
+
+	public array function listAll() {
+		if (Len(variables.throwType)) {
+			Throw(type = variables.throwType, message = variables.throwMessage);
+		}
+		return variables.packages;
+	}
+}

--- a/vendor/wheels/tests/_assets/packages/PublicWithoutRegistry.cfc
+++ b/vendor/wheels/tests/_assets/packages/PublicWithoutRegistry.cfc
@@ -1,0 +1,10 @@
+component extends="wheels.Public" {
+
+	/**
+	 * Overrides the parent's file-existence check to return false —
+	 * simulates a generated user app where cli/ is not shipped.
+	 */
+	private boolean function $registryClientAvailable() {
+		return false;
+	}
+}

--- a/vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc
@@ -63,6 +63,24 @@ component extends="wheels.WheelsTest" {
 				});
 			});
 
+			it("lets non-Wheels.Packages errors bubble up as real bugs", () => {
+				$withEnv("development", () => {
+					var pub = $newPublic();
+					var thrown = "";
+					try {
+						pub.$loadRegistryPackages(
+							registry = $fakeRegistry(
+								throwType = "java.lang.NullPointerException",
+								throwMessage = "npe from listAll"
+							)
+						);
+					} catch ("java.lang.NullPointerException" e) {
+						thrown = e.message;
+					}
+					expect(thrown).toBe("npe from listAll");
+				});
+			});
+
 		});
 	}
 }

--- a/vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc
@@ -1,0 +1,68 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+		describe("Public.$loadRegistryPackages", () => {
+
+			var $newPublic = () => {
+				return new wheels.Public();
+			};
+
+			// Minimal fake registry that returns canned data or throws.
+			var $fakeRegistry = (packages = [], throwType = "", throwMessage = "") => {
+				return CreateObject("component", "wheels.tests._assets.packages.FakeRegistry").init(
+					packages = packages,
+					throwType = throwType,
+					throwMessage = throwMessage
+				);
+			};
+
+			// Swap application.wheels.environment for the duration of a callback.
+			var $withEnv = (env, fn) => {
+				var prior = application.wheels.environment ?: "development";
+				application.wheels.environment = env;
+				try { fn(); }
+				finally { application.wheels.environment = prior; }
+			};
+
+			it("returns empty packages and no error when environment is production", () => {
+				$withEnv("production", () => {
+					var pub = $newPublic();
+					var result = pub.$loadRegistryPackages(
+						registry = $fakeRegistry(packages = [{name: "should-not-appear"}])
+					);
+					expect(result.packages).toBe([]);
+					expect(result.error).toBe("");
+				});
+			});
+
+			it("returns packages from the registry in development", () => {
+				$withEnv("development", () => {
+					var pub = $newPublic();
+					var result = pub.$loadRegistryPackages(
+						registry = $fakeRegistry(packages = [
+							{name: "wheels-sentry",  description: "x", tags: [], homepage: "", latestVersion: "1.0.0"}
+						])
+					);
+					expect(ArrayLen(result.packages)).toBe(1);
+					expect(result.packages[1].name).toBe("wheels-sentry");
+					expect(result.error).toBe("");
+				});
+			});
+
+			it("captures registry errors into the error field without throwing", () => {
+				$withEnv("development", () => {
+					var pub = $newPublic();
+					var result = pub.$loadRegistryPackages(
+						registry = $fakeRegistry(
+							throwType = "Wheels.Packages.RegistryUnavailable",
+							throwMessage = "GitHub returned 503"
+						)
+					);
+					expect(result.packages).toBe([]);
+					expect(result.error contains "GitHub returned 503").toBeTrue();
+				});
+			});
+
+		});
+	}
+}

--- a/vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc
@@ -81,6 +81,16 @@ component extends="wheels.WheelsTest" {
 				});
 			});
 
+			it("silently disables the browse section when the CLI registry class is not on the classpath", () => {
+				$withEnv("development", () => {
+					// Subclass that simulates a generated user app without cli/ on the classpath.
+					var pub = new wheels.tests._assets.packages.PublicWithoutRegistry();
+					var result = pub.$loadRegistryPackages();
+					expect(result.packages).toBe([]);
+					expect(result.error).toBe("");
+				});
+			});
+
 		});
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a "Browse registry" section to `/wheels/packages` listing packages available from [wheels-dev/wheels-packages](https://github.com/wheels-dev/wheels-packages)
- Reuses the CLI's `Registry` component — same data source as `wheels packages list`, 24h app-scope cache
- Dev/testing only; `Public.cfc`'s `$blockInProduction()` gate plus a view-level env check keep this off production servers
- No install-via-browser action; each row shows a copy-to-clipboard `wheels packages install <name>` snippet
- Rows matching an installed package show a `✓ Installed` badge instead of the snippet
- Gracefully disabled in `wheels new`-generated user apps where the CLI isn't on the classpath — installed-packages table still renders normally

## Scope
This is the in-app half of #2271. The `wheels.dev/packages` static-site work is **deferred** — original design assumed a live CFML app, but `wheels.dev` was migrated to four Astro static sites under `web/sites/` with Cloudflare Pages deploys. That piece needs its own brainstorm against the new architecture (build-time fetch, `repository_dispatch` trigger from the registry repo, etc.). See the "Revision" note in [`docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md`](docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md). **#2271 stays open.**

## Changes
Three logical layers:

1. **CLI** — `cli/lucli/services/packages/Registry.cfc`: new `listAll()` returning `[{name, description, tags, latestVersion, homepage}, ...]`. Skips malformed manifests; propagates unavailability. Covered by new `RegistryListAllSpec.cfc` (3 `it` blocks).

2. **Framework helper** — `vendor/wheels/Public.cfc`: new `$loadRegistryPackages()` returning `{packages, error}`. Production short-circuit, memoized Registry on `application.wheels.$packageRegistry`, typed-only catches (Wheels.Packages.*) so real bugs bubble up, classpath-availability guard for user apps. Covered by new `LoadRegistryPackagesSpec.cfc` (4 `it` blocks) with `FakeRegistry.cfc` + `PublicWithoutRegistry.cfc` fixtures.

3. **View** — `vendor/wheels/public/views/packagelist.cfm`: new cfscript block + new section. 3-way conditional (error / empty / table). `HTMLEditFormat` on all DOM interpolations; `JSStringFormat` in the onclick; homepage links gated to `^https?://`; `aria-label` on the Copy button.

## Test plan
- [x] Full test suite green locally: `bash tools/test-local.sh` — 3324 pass, 0 fail, 0 error (Lucee 7 + SQLite)
- [x] Manual smoke: `/wheels/packages` on a local LuCLI server renders 200 with all 4 live registry packages and 4 install snippets
- [ ] CI full matrix pass (waiting on PR CI)
- [ ] Manual: install a package via CLI + reload shows `✓ Installed` badge on that row (not rerun this session — covered by the UI logic path in specs)

## Spec & plan
- Spec: [`docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md`](docs/superpowers/specs/2026-04-23-wheels-packages-phase4-ui-design.md)
- Plan: [`docs/superpowers/plans/2026-04-23-wheels-packages-phase4-inapp.md`](docs/superpowers/plans/2026-04-23-wheels-packages-phase4-inapp.md)

Refs #2271, #2243, #2233