### PR TITLE
docs(docs): record lazy-loading decision + add defensive spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 - CI engine testing restructured: 42 jobs reduced to 8 via engine-grouped testing (#1939)
 - `wheels mcp wheels` MCP surface curated — 7 CLI-only commands (`mcp`, `d`, `new`, `console`, `start`, `stop`, `browser`) hidden from MCP `tools/list` via the `mcpHiddenTools()` convention (requires LuCLI 0.3.4+). All remain reachable as CLI subcommands. Tool count drops from 23 to 16 for agent consumers.
 - LuCLI stdio MCP (`wheels mcp wheels`) is now the canonical AI-agent surface for Wheels. `wheels mcp setup` generates `.mcp.json` and `.opencode.json` pointing at the stdio transport. No port or running dev server required. Updated templates: `cli/src/templates/McpConfig.json`, `app/snippets/McpConfig.json`, `tools/build/base/.mcp.json`, `tools/build/base/.opencode.json`.
+- Package lazy-loading (`"lazy": true` in `package.json`) retained and documented in the [Packages](web/sites/guides/src/content/docs/v4-0-0-snapshot/digging-deeper/packages.mdx) guide. Audit of all six first-party packages (`wheels-sentry`, `wheels-hotwire`, `wheels-basecoat`, `wheels-legacy-adapter`, `wheels-i18n`, `wheels-seo-suite`) found no candidates — all provide controller mixins, which require eager load to populate the mixin tables. The feature remains valid for third-party service-only packages. Added a defensive test that a package declaring `lazy: true` alongside mixins or middleware is still loaded eagerly (the loader's existing `canBeLazy` gate). (#2249)
 
 ### Deprecated
 

--- a/vendor/wheels/tests/_assets/packages/lazyignored/lazyignored.cfc
+++ b/vendor/wheels/tests/_assets/packages/lazyignored/lazyignored.cfc
@@ -1,0 +1,11 @@
+component {
+	public any function init() {
+		this.version = "1.0.0";
+		this.initialized = true;
+		return this;
+	}
+
+	public string function $lazyIgnoredHelper() {
+		return "lazyignored-eagerly-loaded";
+	}
+}

--- a/vendor/wheels/tests/_assets/packages/lazyignored/package.json
+++ b/vendor/wheels/tests/_assets/packages/lazyignored/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "wheels-lazyignored",
+	"version": "1.0.0",
+	"description": "Test fixture: lazy=true combined with mixins — lazy flag must be ignored, package must load eagerly so mixin tables are populated at boot.",
+	"lazy": true,
+	"provides": {
+		"mixins": "controller"
+	}
+}

--- a/vendor/wheels/tests/specs/packages/PackageLoaderSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/PackageLoaderSpec.cfc
@@ -446,6 +446,23 @@ component extends="wheels.WheelsTest" {
 					expect(loader.getPackages()).toHaveKey("lazypkg");
 				});
 
+				it("ignores lazy=true when the package also declares mixins", () => {
+					// Packages that contribute to mixin tables must load eagerly
+					// so the tables are complete by the time controllers/views
+					// reference the mixed-in methods. The `canBeLazy` gate in
+					// PackageLoader requires mixins=none AND no middleware.
+					var loader = new wheels.PackageLoader(
+						vendorPath = fixturesPath,
+						componentPrefix = componentPrefix
+					);
+					var pkgs = loader.getPackages();
+
+					// lazyignored declares lazy=true + mixins=controller;
+					// it should be eagerly loaded despite the lazy flag.
+					expect(pkgs).toHaveKey("lazyignored");
+					expect(pkgs.lazyignored.initialized).toBeTrue();
+				});
+
 			});
 
 			describe("Mixin collisions", () => {


### PR DESCRIPTION
Closes [#2249](https://github.com/wheels-dev/wheels/issues/2249).

## Summary

Issue 2249 asked whether to keep or remove \`\"lazy\": true\` support in \`package.json\`. **Decision: keep** (Option A in the issue). Rationale matches the issue's recommendation — the feature is small, legitimately useful for third-party service-only packages, and carries zero adoption debt since no first-party package currently qualifies.

## What was already in place

The guide and happy-path tests for lazy loading landed as part of [#2281](https://github.com/wheels-dev/wheels/pull/2281):

- Guide: a \`## Lazy loading\` section in \`web/sites/guides/.../digging-deeper/packages.mdx\` plus the \`lazy\` field entry in the manifest reference.
- Tests: \`PackageLoaderSpec.cfc\` \"Lazy loading\" describe block covers eager-skip, \`isPackageLoaded\` true-for-lazy, and on-demand \`getPackage()\` instantiation.

## What this PR adds

- **CHANGELOG entry** under \`Unreleased / Changed\` recording the decision, the first-party audit result, and a pointer to the guide.
- **Defensive spec** \`ignores lazy=true when the package also declares mixins\` — exercises the \`canBeLazy = isLazy && mixinTargets == \"none\" && !hasMiddleware\` gate in PackageLoader. A package with \`lazy: true\` but controller mixins must still be loaded eagerly, otherwise the mixin tables would be incomplete by the time controllers reference the methods.
- **New fixture** \`tests/_assets/packages/lazyignored/\` exercising that combination.

## First-party audit

All six first-party packages declare \`mixins: \"controller\"\`:

| Package | \`provides.mixins\` | Lazy candidate? |
|---|---|---|
| wheels-sentry | controller | no |
| wheels-hotwire | controller | no |
| wheels-basecoat | controller | no |
| wheels-legacy-adapter | controller | no |
| wheels-i18n | controller | no |
| wheels-seo-suite | controller | no |

Lazy loading requires \`mixins: \"none\"\` and no middleware — none of these qualify. The feature remains valid and tested for any future third-party service-only package.

## Test plan

- [ ] \`verify\` job passes (PackageLoader specs run as part of the core suite)
- [ ] The new \`ignores lazy=true when the package also declares mixins\` spec passes — it asserts the \`lazyignored\` fixture appears in \`loader.getPackages()\` despite \`lazy: true\`, and that \`.initialized\` is true (confirming the CFC was actually instantiated, not just recorded)
- [ ] No regressions in the existing \"Lazy loading\" describe block

🤖 Generated with [Claude Code](https://claude.com/claude-code)