### PR TITLE
fix(plugin): validate per-method mixin metadata against allowlist

### DIFF
--- a/vendor/wheels/PackageLoader.cfc
+++ b/vendor/wheels/PackageLoader.cfc
@@ -486,6 +486,24 @@ component output="false" {
 		local.methods = StructKeyList(arguments.pkg);
 		local.lifecycleHooks = "init,onPluginLoad,onPluginActivate,register,boot";
 
+		// Validation pre-pass: reject per-method mixin metadata with unknown
+		// targets BEFORE mutating variables.mixins. Without this, a typo on
+		// method N would silently produce zero injection (see #2257) and —
+		// worse — methods 1..N-1 would already be registered when we threw
+		// mid-loop, leaving the package half-loaded.
+		for (local.methodName in local.methods) {
+			if (!IsCustomFunction(arguments.pkg[local.methodName])) {
+				continue;
+			}
+			if (ListFindNoCase(local.lifecycleHooks, local.methodName)) {
+				continue;
+			}
+			local.methodMeta = GetMetadata(arguments.pkg[local.methodName]);
+			if (StructKeyExists(local.methodMeta, "mixin")) {
+				$validateMixinTargets(arguments.pkgName, local.methodMeta.mixin, local.methodName);
+			}
+		}
+
 		for (local.methodName in local.methods) {
 			if (!IsCustomFunction(arguments.pkg[local.methodName])) {
 				continue;
@@ -655,10 +673,16 @@ component output="false" {
 	 * so the package is recorded as failed instead of silently loading with zero
 	 * mixin injection.
 	 *
-	 * @pkgName  Package directory name, used in the error message
-	 * @targets  Raw mixin-target declaration from the manifest
+	 * @pkgName     Package directory name, used in the error message
+	 * @targets     Raw mixin-target declaration from the manifest or per-method metadata
+	 * @methodName  Optional method name for per-method overrides; included in the
+	 *              error message so callers can locate the offending declaration
 	 */
-	private void function $validateMixinTargets(required string pkgName, required string targets) {
+	private void function $validateMixinTargets(
+		required string pkgName,
+		required string targets,
+		string methodName = ""
+	) {
 		local.normalized = LCase(Trim(arguments.targets));
 		if (!Len(local.normalized) || local.normalized == "none" || local.normalized == "global") {
 			return;
@@ -669,9 +693,10 @@ component output="false" {
 				continue;
 			}
 			if (!ListFindNoCase(variables.mixableComponents, local.entry)) {
+				local.context = Len(arguments.methodName) ? " method '#arguments.methodName#'" : "";
 				Throw(
 					type = "Wheels.PackageInvalidMixinTarget",
-					message = "Package '#arguments.pkgName#' declares unknown mixin target '#local.entry#'. Valid targets: #variables.mixableComponents#."
+					message = "Package '#arguments.pkgName#'#local.context# declares unknown mixin target '#local.entry#'. Valid targets: #variables.mixableComponents#."
 				);
 			}
 		}

--- a/vendor/wheels/tests/_assets/packages/invalidmethodmixin/Invalidmethodmixin.cfc
+++ b/vendor/wheels/tests/_assets/packages/invalidmethodmixin/Invalidmethodmixin.cfc
@@ -1,0 +1,16 @@
+component {
+	public any function init() {
+		this.version = "1.0.0";
+		return this;
+	}
+
+	// Valid target, follows the manifest default
+	public string function $validHelper() {
+		return "valid";
+	}
+
+	// Typo in per-method metadata — must cause the package to fail to load
+	public string function $badTarget() mixin="controler" {
+		return "should-never-be-injected";
+	}
+}

--- a/vendor/wheels/tests/_assets/packages/invalidmethodmixin/package.json
+++ b/vendor/wheels/tests/_assets/packages/invalidmethodmixin/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "wheels-invalidmethodmixin",
+	"version": "1.0.0",
+	"description": "Test fixture: method-level metadata declares unknown mixin target (typo)",
+	"provides": {
+		"mixins": "controller"
+	}
+}

--- a/vendor/wheels/tests/_assets/packages/validmethodmixin/Validmethodmixin.cfc
+++ b/vendor/wheels/tests/_assets/packages/validmethodmixin/Validmethodmixin.cfc
@@ -1,0 +1,21 @@
+component {
+	public any function init() {
+		this.version = "1.0.0";
+		return this;
+	}
+
+	// Follows the manifest default (controller)
+	public string function $validmethodmixinControllerHelper() {
+		return "on-controller";
+	}
+
+	// Per-method override to model target
+	public string function $validmethodmixinModelHelper() mixin="model" {
+		return "on-model";
+	}
+
+	// Explicit opt-out of mixin injection while still callable via getPackage()
+	public string function $validmethodmixinInternal() mixin="none" {
+		return "internal";
+	}
+}

--- a/vendor/wheels/tests/_assets/packages/validmethodmixin/package.json
+++ b/vendor/wheels/tests/_assets/packages/validmethodmixin/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "wheels-validmethodmixin",
+	"version": "1.0.0",
+	"description": "Test fixture: valid per-method mixin metadata overrides",
+	"provides": {
+		"mixins": "controller"
+	}
+}

--- a/vendor/wheels/tests/specs/packages/PackageLoaderSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/PackageLoaderSpec.cfc
@@ -404,6 +404,49 @@ component extends="wheels.WheelsTest" {
 					expect(pkgs).toHaveKey("nomixin");
 				});
 
+				it("rejects packages whose per-method mixin metadata has an unknown target", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = fixturesPath,
+						componentPrefix = componentPrefix
+					);
+					var failed = loader.getFailedPackages();
+
+					// invalidmethodmixin has a method annotated mixin="controler" (typo)
+					var foundInvalid = false;
+					var errorMessage = "";
+					for (var f in failed) {
+						if (f.name == "invalidmethodmixin") {
+							foundInvalid = true;
+							errorMessage = f.error;
+						}
+					}
+					expect(foundInvalid).toBeTrue();
+					// Error must name the offending method, the unknown target, and the allowlist
+					expect(errorMessage).toInclude("$badTarget");
+					expect(errorMessage).toInclude("controler");
+					expect(errorMessage).toInclude("controller");
+				});
+
+				it("loads packages with valid per-method mixin overrides", () => {
+					var loader = new wheels.PackageLoader(
+						vendorPath = fixturesPath,
+						componentPrefix = componentPrefix
+					);
+					var pkgs = loader.getPackages();
+					var mixins = loader.getMixins();
+
+					// validmethodmixin uses mixin="model" and mixin="none" — must still load
+					expect(pkgs).toHaveKey("validmethodmixin");
+
+					// Controller default reaches controller target
+					expect(mixins.controller).toHaveKey("$validmethodmixinControllerHelper");
+					// Override to model target takes effect
+					expect(mixins.model).toHaveKey("$validmethodmixinModelHelper");
+					// Opt-out method is not registered on any target
+					expect(mixins.controller).notToHaveKey("$validmethodmixinInternal");
+					expect(mixins.model).notToHaveKey("$validmethodmixinInternal");
+				});
+
 			});
 
 			describe("Lazy loading", () => {


### PR DESCRIPTION
## Summary
- Extends the [#2256](https://github.com/wheels-dev/wheels/pull/2256) manifest-level validation to per-method mixin metadata overrides in `PackageLoader.$collectMixins`. A typo like `function foo() mixin="controler" {}` now fails the package load with a clear error instead of silently producing zero injection.
- `$validateMixinTargets` gains an optional `methodName` context parameter. Error message includes the offending method name when a per-method declaration fails validation.
- Validation runs as a pre-pass over methods before any `variables.mixins` mutation — a typo on method N cannot leave methods 1..N-1 half-registered.
- Adds two fixtures and two spec cases in the `Mixin target validation` describe block.

Closes [#2257](https://github.com/wheels-dev/wheels/issues/2257).

### Before → after behavior
| Method declaration | Before | After |
|---|---|---|
| `function foo() mixin="controler" {}` (typo) | method silently not injected; package appears loaded | package recorded in `failedPackages` with error naming package, method, unknown target, and allowlist |
| `function foo() mixin="view" {}` | silent zero-injection for that method | package recorded in `failedPackages` |
| `function foo() mixin="model" {}` | unchanged | unchanged — valid override |
| `function foo() mixin="none" {}` | unchanged | unchanged — opt-out |

## Test plan
- [x] `bash tools/test-local.sh` → 3327 pass, 0 fail, 0 error (Lucee 7 + SQLite)
- [x] New specs execute: `rejects packages whose per-method mixin metadata has an unknown target` + `loads packages with valid per-method mixin overrides` both green
- [ ] CI: full compat matrix (Lucee 5/6/7, Adobe 2018/2021/2023/2025, all DBs) green before merge

## Out of scope
- Legacy `Plugins.cfc` (sunset in v5.0 per [#2252](https://github.com/wheels-dev/wheels/issues/2252)) has the same issue but is explicitly excluded per the ticket.