### PR TITLE
fix(cli): substitute @build.version@ when scaffolding from dev checkout (closes #2279)

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -3534,6 +3534,10 @@ component extends="modules.BaseModule" {
 	 * Copy a resolved Wheels framework source into the new application's
 	 * vendor/wheels/ directory. The source must already exist — callers should
 	 * obtain it via resolveFrameworkSourceOrFail() before any file creation.
+	 *
+	 * After the raw directory copy, delegates to FrameworkInstaller to rewrite
+	 * any unreplaced @build.version@ placeholder in the copied box.json when
+	 * the source is a dev checkout of the wheels-dev/wheels monorepo (GH #2279).
 	 */
 	private void function copyFrameworkToVendor(
 		required string wheelsSource,
@@ -3544,6 +3548,10 @@ component extends="modules.BaseModule" {
 		var vendorDir = targetDir & "/vendor/wheels";
 		ensureDirectory(vendorDir);
 		directoryCopy(wheelsSource, vendorDir, true);
+		new services.FrameworkInstaller().rewriteVersionPlaceholder(
+			wheelsSource = wheelsSource,
+			vendorDir = vendorDir
+		);
 		printCreated(appName & "/vendor/wheels/");
 	}
 

--- a/cli/lucli/services/FrameworkInstaller.cfc
+++ b/cli/lucli/services/FrameworkInstaller.cfc
@@ -1,0 +1,76 @@
+/**
+ * Framework-installation helpers for `wheels new`.
+ *
+ * Isolated from Module.cfc so tests can exercise the behavior without
+ * instantiating the full LuCLI module (which depends on a `modules.BaseModule`
+ * mapping that only exists when LuCLI is hosting the runtime).
+ */
+component {
+
+	public function init() {
+		return this;
+	}
+
+	/**
+	 * Substitute the @build.version@ placeholder in a freshly-copied
+	 * vendor/wheels/box.json when the source is identifiable as a dev checkout
+	 * of the wheels-dev/wheels monorepo (GH ##2279).
+	 *
+	 * Released framework tarballs have the placeholder replaced at build time
+	 * by tools/build/scripts, so their box.json already carries a real version.
+	 * A dev checkout does not — the placeholder is literal. Copying that file
+	 * verbatim into a scaffolded app makes the homepage display "0.0.0-dev"
+	 * because $readFrameworkVersion()'s fallback can only identify the monorepo
+	 * when the enclosing box.json is the monorepo's own — never true inside a
+	 * generated app.
+	 *
+	 * When the source's enclosing root box.json identifies the monorepo
+	 * (slug="wheels" or name="Wheels.fw") and carries a real version, rewrite
+	 * the copy's placeholder to "<rootversion>-dev" so the new app reports a
+	 * meaningful version. Otherwise leave the placeholder alone — the
+	 * framework's runtime fallback still returns "0.0.0-dev", matching pre-fix
+	 * behavior for unusual third-party layouts.
+	 *
+	 * @wheelsSource Absolute path of the source vendor/wheels/ directory.
+	 * @vendorDir    Absolute path of the newly-written vendor/wheels/ directory
+	 *               inside the scaffolded app.
+	 * @return       True if the placeholder was rewritten, false otherwise.
+	 */
+	public boolean function rewriteVersionPlaceholder(
+		required string wheelsSource,
+		required string vendorDir
+	) {
+		var targetBox = arguments.vendorDir & "/box.json";
+		if (!fileExists(targetBox)) return false;
+
+		var content = fileRead(targetBox);
+		if (!findNoCase("@build.version@", content)) return false;
+
+		// The source is a vendor/wheels/ directory; the monorepo root lives two
+		// levels up (repo-root/vendor/wheels/ -> repo-root/box.json).
+		var File = createObject("java", "java.io.File");
+		var sourceCanonical = File.init(arguments.wheelsSource).getCanonicalPath();
+		var rootCandidate = File.init(sourceCanonical & "/../../box.json").getCanonicalPath();
+		if (!fileExists(rootCandidate)) return false;
+
+		try {
+			var rootBox = deserializeJSON(fileRead(rootCandidate));
+		} catch (any e) {
+			return false;
+		}
+
+		var isMonorepo = isStruct(rootBox)
+			&& (
+				(structKeyExists(rootBox, "slug") && rootBox.slug == "wheels")
+				|| (structKeyExists(rootBox, "name") && rootBox.name == "Wheels.fw")
+			);
+		if (!isMonorepo) return false;
+		if (!structKeyExists(rootBox, "version") || !len(rootBox.version)) return false;
+		if (rootBox.version == "@build.version@") return false;
+
+		var devVersion = rootBox.version & "-dev";
+		fileWrite(targetBox, replace(content, "@build.version@", devVersion, "all"));
+		return true;
+	}
+
+}

--- a/cli/lucli/tests/specs/services/FrameworkInstallerSpec.cfc
+++ b/cli/lucli/tests/specs/services/FrameworkInstallerSpec.cfc
@@ -1,0 +1,119 @@
+/**
+ * Regression coverage for GH #2279.
+ *
+ * `wheels new` copies vendor/wheels/ from whatever source `resolveFrameworkSource`
+ * finds. In a dev checkout of the wheels-dev/wheels monorepo that source carries
+ * an unreplaced "@build.version@" placeholder in box.json — the release build
+ * pipeline substitutes it, but a raw checkout does not. Without rewrite, the
+ * placeholder propagates into the generated app and the homepage reports
+ * "0.0.0-dev" forever.
+ *
+ * These specs exercise FrameworkInstaller.rewriteVersionPlaceholder in isolation
+ * via the filesystem: we stand up a fake monorepo layout in a temp dir, run the
+ * helper, and assert the copy's placeholder was substituted with
+ * "<rootversion>-dev". The service is isolated from Module.cfc so tests don't
+ * need a `modules.BaseModule` mapping.
+ */
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function beforeAll() {
+		variables.installer = new cli.lucli.services.FrameworkInstaller();
+	}
+
+	private struct function buildFixture(required string rootBoxContent, required string frameworkBoxContent) {
+		var fixture = {};
+		fixture.root = getTempDirectory() & "wheels-fw-fixture-#createUUID()#";
+		fixture.sourceWheels = fixture.root & "/vendor/wheels";
+		fixture.targetWheels = fixture.root & "/target/vendor/wheels";
+		directoryCreate(fixture.sourceWheels, true, true);
+		directoryCreate(fixture.targetWheels, true, true);
+		fileWrite(fixture.root & "/box.json", arguments.rootBoxContent);
+		fileWrite(fixture.sourceWheels & "/box.json", arguments.frameworkBoxContent);
+		// Simulate the directoryCopy() that copyFrameworkToVendor already did:
+		// the target starts with the same placeholder as the source.
+		fileWrite(fixture.targetWheels & "/box.json", arguments.frameworkBoxContent);
+		return fixture;
+	}
+
+	function run() {
+
+		describe("FrameworkInstaller.rewriteVersionPlaceholder (GH ##2279)", () => {
+
+			it("substitutes the placeholder with <rootversion>-dev when source is the wheels monorepo (slug match)", () => {
+				var f = buildFixture(
+					'{"name":"Wheels.fw","slug":"wheels","version":"4.0.0"}',
+					'{"version":"@build.version@"}'
+				);
+				var rewrote = installer.rewriteVersionPlaceholder(f.sourceWheels, f.targetWheels);
+				var after = deserializeJSON(fileRead(f.targetWheels & "/box.json"));
+				expect(rewrote).toBeTrue();
+				expect(after.version).toBe("4.0.0-dev");
+				directoryDelete(f.root, true);
+			});
+
+			it("substitutes even when only the name marker matches (belt-and-suspenders)", () => {
+				var f = buildFixture(
+					'{"name":"Wheels.fw","version":"4.1.0"}',
+					'{"version":"@build.version@"}'
+				);
+				var rewrote = installer.rewriteVersionPlaceholder(f.sourceWheels, f.targetWheels);
+				var after = deserializeJSON(fileRead(f.targetWheels & "/box.json"));
+				expect(rewrote).toBeTrue();
+				expect(after.version).toBe("4.1.0-dev");
+				directoryDelete(f.root, true);
+			});
+
+			it("leaves the placeholder untouched when the enclosing box.json does not identify the monorepo", () => {
+				var f = buildFixture(
+					'{"name":"SomeUserApp","slug":"user-app","version":"2.1.0"}',
+					'{"version":"@build.version@"}'
+				);
+				var rewrote = installer.rewriteVersionPlaceholder(f.sourceWheels, f.targetWheels);
+				expect(rewrote).toBeFalse();
+				expect(fileRead(f.targetWheels & "/box.json")).toInclude("@build.version@");
+				directoryDelete(f.root, true);
+			});
+
+			it("no-ops when the framework box.json already has a real version (released bundle)", () => {
+				var f = buildFixture(
+					'{"name":"Wheels.fw","slug":"wheels","version":"4.0.0"}',
+					'{"version":"4.0.0"}'
+				);
+				var rewrote = installer.rewriteVersionPlaceholder(f.sourceWheels, f.targetWheels);
+				var after = deserializeJSON(fileRead(f.targetWheels & "/box.json"));
+				expect(rewrote).toBeFalse();
+				expect(after.version).toBe("4.0.0");
+				directoryDelete(f.root, true);
+			});
+
+			it("no-ops when the monorepo root box.json is also unreplaced (pathological both-placeholder)", () => {
+				var f = buildFixture(
+					'{"name":"Wheels.fw","slug":"wheels","version":"@build.version@"}',
+					'{"version":"@build.version@"}'
+				);
+				var rewrote = installer.rewriteVersionPlaceholder(f.sourceWheels, f.targetWheels);
+				expect(rewrote).toBeFalse();
+				expect(fileRead(f.targetWheels & "/box.json")).toInclude("@build.version@");
+				directoryDelete(f.root, true);
+			});
+
+			it("no-ops when the source's enclosing directory has no box.json (unusual third-party layout)", () => {
+				var root = getTempDirectory() & "wheels-fw-noroot-#createUUID()#";
+				var sourceWheels = root & "/vendor/wheels";
+				var targetWheels = root & "/target/vendor/wheels";
+				directoryCreate(sourceWheels, true, true);
+				directoryCreate(targetWheels, true, true);
+				var placeholder = '{"version":"@build.version@"}';
+				fileWrite(sourceWheels & "/box.json", placeholder);
+				fileWrite(targetWheels & "/box.json", placeholder);
+				var rewrote = installer.rewriteVersionPlaceholder(sourceWheels, targetWheels);
+				expect(rewrote).toBeFalse();
+				expect(fileRead(targetWheels & "/box.json")).toInclude("@build.version@");
+				directoryDelete(root, true);
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary

- `wheels new` copied `vendor/wheels/box.json` verbatim from the resolved framework source. When that source was a dev checkout of the wheels-dev/wheels monorepo, the unreplaced `@build.version@` placeholder rode along into the scaffolded app. The release pipeline substitutes the placeholder at build time, but raw checkouts do not.
- `$readFrameworkVersion()`'s dev-fallback only identifies the monorepo when the enclosing `box.json` is the monorepo's own — a condition never met inside a generated app (its own `box.json` is the app's, and there's no monorepo root anywhere in its tree). The framework fell through to `"0.0.0-dev"` and the homepage reported that forever.
- `copyFrameworkToVendor` now delegates to a new `FrameworkInstaller` service that post-processes the copied `box.json`. If the placeholder is still present AND the source's enclosing root `box.json` identifies the monorepo (`slug=wheels` or `name=Wheels.fw`) AND has a real version, the copy's placeholder becomes `<rootversion>-dev` (e.g. `4.0.0-dev`). Released bundles short-circuit — their `box.json` already carries a real version.

## Why a service

Extracted into `cli/lucli/services/FrameworkInstaller.cfc` so specs can exercise the behavior without instantiating `Module.cfc`, which requires a `modules.BaseModule` mapping that only exists at LuCLI runtime. Keeps Module.cfc thin and keeps the test surface well-scoped.

## Test plan

- [x] New `FrameworkInstallerSpec` — 6 specs covering slug match, name match, non-monorepo enclosing `box.json`, released bundle (real version), both-placeholder pathological case, and missing enclosing `box.json`. All green.
- [x] Full CLI suite: `442 pass, 0 fail, 0 error` (was 436 pre-change; +6 new).
- [x] End-to-end smoke: pointed the installed LuCLI at this branch, ran `wheels new issue-2279-test` in a temp dir, inspected `vendor/wheels/box.json` → `"version":"4.0.0-dev"` (was `"@build.version@"` before the fix).
- [ ] CI: PR fast-gate across Lucee 6/7 + Adobe + BoxLang × database matrix.

## Out of scope / follow-ups

- The framework-side default `rootBoxJsonPath` in `$readFrameworkVersion()` resolves to `vendor/box.json` (one level up from `vendor/wheels/Global.cfc`), not `<repo>/box.json` two levels up. If the running Wheels dev server also shows `0.0.0-dev` at runtime on `develop`, that's a separate defect in PR #2272's default-path math and should be addressed in its own change with a smoke test on the server, not just on the synthetic-fixture unit tests.