### PR TITLE
fix(cli): reject empty-name target in wheels packages install

### DIFF
--- a/cli/lucli/services/packages/PackagesMainCli.cfc
+++ b/cli/lucli/services/packages/PackagesMainCli.cfc
@@ -252,8 +252,16 @@ component {
 	}
 
 	private struct function $parseTarget(required string target) {
-		if (Find("@", arguments.target)) {
-			local.at = Find("@", arguments.target);
+		local.at = Find("@", arguments.target);
+		if (local.at == 1) {
+			// Target starts with "@" — no name before the pin. Reject cleanly
+			// rather than crashing on Left(str, 0) (a documented Lucee 7 hazard).
+			Throw(
+				type = "Wheels.Packages.BadInput",
+				message = "Package name is required before '@'. Use: wheels packages install <name>[@<version>]"
+			);
+		}
+		if (local.at > 1) {
 			return {
 				name: Left(arguments.target, local.at - 1),
 				pin: Mid(arguments.target, local.at + 1, Len(arguments.target))

--- a/cli/lucli/tests/specs/packages/PackagesMainCliSpec.cfc
+++ b/cli/lucli/tests/specs/packages/PackagesMainCliSpec.cfc
@@ -190,6 +190,24 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				stack.cache.refresh();
 				DirectoryDelete(proj, true);
 			});
+
+			it("install throws BadInput when target starts with '@' (empty name)", () => {
+				// Regression guard: `@1.0.0` used to hit Left(str, 0), which
+				// crashes on Lucee 7 and produces a cryptic error on other
+				// engines. Must reject cleanly with BadInput.
+				var proj = $scratch();
+				var stack = $buildStack(proj);
+				var threw = false;
+				try {
+					stack.cli.install({target: "@1.0.0"});
+				} catch (any e) {
+					threw = true;
+					expect(e.type).toBe("Wheels.Packages.BadInput");
+				}
+				expect(threw).toBeTrue();
+				stack.cache.refresh();
+				DirectoryDelete(proj, true);
+			});
 		});
 
 		describe("PackagesRegistryCli", () => {


### PR DESCRIPTION
## Summary

- `PackagesMainCli.\$parseTarget` crashed on Lucee 7 (and produced a cryptic empty-name install on other engines) when invoked with a target that starts with `@`, e.g., `wheels packages install @1.0.0`.
- Root cause: `Left(target, Find(\"@\", target) - 1)` evaluates to `Left(str, 0)`, which is explicitly called out as a Lucee 7 hazard in CLAUDE.md.
- Fix: throw `Wheels.Packages.BadInput` with a clear syntax hint when the name segment is empty.

Spotted while closing out [wheels-dev/wheels#2270](https://github.com/wheels-dev/wheels/issues/2270); the scope of that issue ships via #2276 + #2287 and this is a small defensive follow-up, not a new feature.

## Test plan

- [x] `bash tools/test-cli-local.sh` — 437 pass, 0 fail, 0 error (includes new regression spec `install throws BadInput when target starts with '@' (empty name)`).
- [ ] CI compat matrix green across Lucee 5/6/7 + Adobe 2018/2021/2023/2025 + BoxLang.