### PR TITLE
fix(test): honor directory= URL param on core test runner

### DIFF
--- a/vendor/wheels/tests/runner.cfm
+++ b/vendor/wheels/tests/runner.cfm
@@ -97,10 +97,28 @@
         }
     }
 
+    // Resolve the TestBox scope from url.directory with a conservative allowlist.
+    // Permitted roots (plus any dotted sub-path of them):
+    //   wheels.tests.*            — core framework specs
+    //   vendor.<package>.tests.*  — first-party / installed package specs
+    // The /wheels/core/tests endpoint is unauthenticated and only safe in dev;
+    // the allowlist is defense-in-depth so stray input can't drive arbitrary
+    // CFC compilation through whatever mappings happen to be registered.
+    local.testDirectory = "wheels.tests.specs";
+    if (StructKeyExists(url, "directory") && Len(Trim(url.directory))) {
+        local.requestedDirectory = Trim(url.directory);
+        if (ReFindNoCase(
+            "^(wheels\.tests|vendor\.[a-z0-9][a-z0-9\-]*\.tests)(\.[a-zA-Z0-9_]+)*$",
+            local.requestedDirectory
+        )) {
+            local.testDirectory = local.requestedDirectory;
+        }
+    }
+
     try {
         // Try to create TestBox instance with coverage disabled
         testBox = new wheels.wheelstest.system.TestBox(
-            directory="wheels.tests.specs",
+            directory=local.testDirectory,
             options={ coverage = { enabled = false } }
         );
     } catch (any e) {

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/digging-deeper/packages.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/digging-deeper/packages.mdx
@@ -258,9 +258,13 @@ component extends="wheels.WheelsTest" output="false" {
 }
 ```
 
-<Aside type="caution">
-  The core test runner's `directory=` URL parameter (sometimes referenced as a way to scope a run to `vendor.mypackage.tests`) is documented but not currently honoured — [`wheels#2280`](https://github.com/wheels-dev/wheels/issues/2280) tracks the fix. Until that lands, run your package's specs in the package repo's own CI (most first-party packages do this) rather than through the app's HTTP test endpoint.
-</Aside>
+Scope a run to a single package with the `directory=` URL param on the core test runner:
+
+```bash
+curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&directory=vendor.mypackage.tests"
+```
+
+The runner accepts two allowlisted roots: `wheels.tests.*` (the framework core) and `vendor.<package>.tests.*` (any installed package). Any other value is silently ignored and the full core suite runs instead — the endpoint is unauthenticated and the allowlist prevents it from driving arbitrary CFC compilation.
 
 Package authors typically keep a matching set of specs in their repo and rely on the registry's `validate.yml` plus the package's own CI to catch regressions before tagging a release.
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/testing/running-tests-locally.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/testing/running-tests-locally.mdx
@@ -100,6 +100,9 @@ curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&directory=w
 
 # Skip populate when iterating on one spec and the schema is already in place
 curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&populate=false&directory=wheels.tests.specs.model.postSpec"
+
+# Scope to a single installed package's tests (e.g. wheels-sentry, wheels-i18n)
+curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&directory=vendor.wheels-sentry.tests"
 ```
 
 The `populate=false` query param is the trick that makes tight inner loops possible. Populate drops and recreates every test table — a second or two on SQLite but much slower on networked databases. Once the schema is in place for the run, skipping populate shaves the wait down to just your specs executing.
@@ -114,6 +117,7 @@ The runner accepts filters at every layer. Pick whichever matches your workflow.
 | By directory (script) | `bash tools/test-local.sh model` |
 | By directory (URL) | `&directory=wheels.tests.specs.model` |
 | By single spec file (URL) | `&directory=wheels.tests.specs.model.postSpec` |
+| By installed package (URL) | `&directory=vendor.wheels-sentry.tests` |
 | Skip in source | `xdescribe("...", ...)` / `xit("...", ...)` — built into WheelsTest |
 | Skip the whole populate | `&populate=false` on the URL (schema must already exist) |
 


### PR DESCRIPTION
## Summary
- Reads `url.directory` in `vendor/wheels/tests/runner.cfm` and passes it through to `TestBox`, guarded by an allowlist (`wheels.tests.*` or `vendor.<pkg>.tests.*`) since `/wheels/core/tests` is unauthenticated.
- Flips the "not honoured yet, tracks #2280" aside in `digging-deeper/packages.mdx` to working guidance and adds the per-package row to the filter table in `testing/running-tests-locally.mdx`.
- No changes to `tools/test-local.sh` — the issue author's concern that it "drops unmapped filters" was off; the `case` statement falls through and the filter is already appended as `&directory=$FILTER`. It's the server that was dropping the param.

Closes #2280.

## Why the allowlist
The core test runner endpoint has no auth gate — it only exists safely because it's a dev-only surface. Without validation, `url.directory` would let anyone who reaches the endpoint drive arbitrary CFC compilation through whatever mappings happen to be registered. The regex pins the input to the two legitimate roots and silently falls back to the core default on anything else.

## Verification (fresh LuCLI server in a worktree)

| Scenario | URL | Result |
|---|---|---|
| No filter (baseline) | `/wheels/core/tests?db=sqlite&format=json` | **3327 pass, 182 bundles, 24.2s** |
| Scoped to model specs | `&directory=wheels.tests.specs.model` | **803 pass, 32 bundles, 1.6s** |
| Scoped to fake package | `&directory=vendor.wheels-fake-pkg.tests` | **1 pass, 1 bundle, 6ms** — bundle named `vendor.wheels-fake-pkg.tests.FakeSpec` |
| Allowlist reject | `&directory=../../../etc` | **3327 pass** — identical to baseline, bad input silently falls back |

Regex unit-tested offline against 14 positive/negative cases (0 failures).

## Follow-up (not in this PR)
Discovered while verifying: `directory=wheels.tests.specs.model.postSpec` (documented at `running-tests-locally.mdx:99` as "filter to a single spec file") has always returned 0 bundles — TestBox's `addDirectory()` resolves the dot-path to a filesystem directory, so a trailing `.cfc` doesn't match. Pre-existing docs drift unrelated to #2280. Fix separately by either (a) removing the docs claim, or (b) adding `url.bundles` support to the core runner (the app runner at `tests/runner.cfm:98-105` already does this).

## Test plan
- [ ] CI green across the full engine × database matrix
- [ ] Spot-check `bash tools/test-local.sh model` locally — should finish in seconds, not ~25s
- [ ] Spot-check the two updated docs pages render correctly on the guides site preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)