### PR TITLE
fix(config): walk up two levels for monorepo box.json in $readFrameworkVersion

### DIFF
--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -2788,7 +2788,7 @@ return local.$wheels;
 			// homepage shows the upcoming version rather than a blank placeholder.
 			local.rootPath = Len(arguments.rootBoxJsonPath)
 				? arguments.rootBoxJsonPath
-				: GetDirectoryFromPath(GetCurrentTemplatePath()) & "../box.json";
+				: GetDirectoryFromPath(GetCurrentTemplatePath()) & "../../box.json";
 			try {
 				if (FileExists(local.rootPath)) {
 					local.rootBox = DeserializeJSON(FileRead(local.rootPath));

--- a/vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc
+++ b/vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc
@@ -85,6 +85,41 @@ component extends="wheels.WheelsTest" {
 				}
 			});
 
+			it("application.wheels.version resolves to <rootversion>-dev at boot in a monorepo dev checkout (regression for ##2291)", () => {
+				// Regression for ##2291. Asserts the *runtime boot* result — not a direct
+				// call — because $readFrameworkVersion is bound into the spec's scope by
+				// WheelsTest.cfc, which shifts GetCurrentTemplatePath() to this file and
+				// bypasses the code path we want to cover. application.wheels.version is
+				// populated by onapplicationstart.cfc calling $readFrameworkVersion() with
+				// no arguments, so whatever it resolved to is the answer we need to check.
+				//
+				// With the bug (one-level "../box.json"): default rootBoxJsonPath points at
+				// vendor/box.json, which does not exist, so the helper falls through to
+				// "0.0.0-dev" even in a monorepo checkout.
+				// With the fix (two-level "../../box.json"): default rootBoxJsonPath points
+				// at <repo-root>/box.json and yields "<rootversion>-dev".
+				var wheelsDir = ExpandPath("/wheels/");
+				var fwBoxPath = wheelsDir & "box.json";
+				var rootBoxPath = wheelsDir & "../../box.json";
+				if (!FileExists(fwBoxPath) || !FileExists(rootBoxPath)) {
+					return;
+				}
+				var fwBox = DeserializeJSON(FileRead(fwBoxPath));
+				var rootBox = DeserializeJSON(FileRead(rootBoxPath));
+				if (!IsStruct(fwBox) || (fwBox.version ?: "") != "@build.version@") {
+					return;
+				}
+				var isWheelsRepo = IsStruct(rootBox)
+					&& (
+						((rootBox.slug ?: "") == "wheels")
+						|| ((rootBox.name ?: "") == "Wheels.fw")
+					);
+				if (!isWheelsRepo || (rootBox.version ?: "") == "" || rootBox.version == "@build.version@") {
+					return;
+				}
+				expect(application.wheels.version).toBe(rootBox.version & "-dev");
+			});
+
 			it("$readFrameworkVersion throws Wheels.VersionReadFailed when the file is missing", () => {
 				var missing = getTempDirectory() & "wheels-version-missing-#CreateUUID()#.json";
 				var threw = false;


### PR DESCRIPTION
## Summary
- Fixes #2291: `$readFrameworkVersion()`'s default `rootBoxJsonPath` walked up only one level from `Global.cfc` (`vendor/wheels/../box.json` = `vendor/box.json`), which doesn't exist in the monorepo layout. Correct path walks up two levels to `<repo-root>/box.json`. At runtime boot via `onapplicationstart.cfc` (called with no args), this caused `application.wheels.version` to silently resolve to `"0.0.0-dev"` inside a wheels-dev/wheels checkout. One-character fix plus a regression spec.
- Adds a regression test in `frameworkVersionSpec.cfc` that asserts the **runtime boot** result (`application.wheels.version`) rather than invoking the helper directly, because `WheelsTest.cfc` binds methods into each spec's scope — which shifts `GetCurrentTemplatePath()` and bypasses the code path we need to cover. The test skips gracefully in release builds and vendored installs via environment-gated early returns.

## Why the existing tests didn't catch it
Every pre-existing spec passed explicit path arguments, so the `Len(arguments.rootBoxJsonPath) ? ... : <default>` ternary always took the left branch. The default-computation side of the ternary was completely uncovered.

## Verification
- **Runtime probe pre-fix:** `application.wheels.version` = `"0.0.0-dev"` — bug confirmed against a fresh checkout boot
- **Runtime probe post-fix:** `application.wheels.version` = `"4.0.0-dev"` — matches `<repo-root>/box.json` version + `-dev` suffix
- **Core suite (Lucee 7 + SQLite, `bash tools/test-local.sh`):** **3328 pass / 0 fail / 0 error** (was 3327; the new spec accounts for the delta)
- **Negative control:** with fix reverted, the regression test fails with `Expected [4.0.0-dev] but received [0.0.0-dev]` — confirms the test actually catches the bug rather than skipping silently

## Test plan
- [x] Full core suite green on Lucee 7 + SQLite
- [x] Manual verification that `application.wheels.version` resolves to `4.0.0-dev` at runtime after the fix
- [x] Manual verification that regression spec fails with the bug reintroduced
- [ ] CI matrix (Lucee 5/6/7, Adobe 2018/2021/2023/2025, BoxLang × MySQL/Postgres/SQL Server/H2/SQLite/CockroachDB) — relies on the same code path, no engine-specific surface touched
- [ ] Release-build smoke (branch where `@build.version@` is substituted): regression spec should skip silently via the placeholder guard

## Related
- PR #2289 (CLI-side fix for #2279): orthogonal — that one rewrites the vendored framework box.json at scaffold time. This PR fixes the framework-side fallback that runs inside the wheels-dev/wheels dev checkout itself.
- PR #2272 (original #2255 fix): introduced the default-path computation this PR corrects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)